### PR TITLE
Add multi template support based on node.type

### DIFF
--- a/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph.component.ts
+++ b/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph.component.ts
@@ -16,7 +16,7 @@ const STYLE_TEMPLATE = {
 };
 
 const NODE_TEMPLATE = {
-    id: 'node',
+    id: 'default',
     innerHTML: `<rect width="100" height="60" x="-50" y="-30"></rect>
         <text class="title text" data-content="title" data-click="title" x="-40" y="-10"></text>
         <text class="text" data-content="type" x="-40" y="10"></text>`

--- a/mico-grapheditor/src/object-cache.ts
+++ b/mico-grapheditor/src/object-cache.ts
@@ -1,17 +1,27 @@
 import { Node } from "./node";
 import { Edge, edgeId } from "./edge";
+import { DEFAULT_NODE_TEMPLATE } from "./templates";
 
 export class GraphObjectCache {
+
+    private nodeTemplates: Map<string, string>;
     private nodes: Map<number|string, Node>;
     private edges: Map<number|string, Edge>;
     private edgesBySource: Map<number|string, Set<Edge>>;
     private edgesByTarget: Map<number|string, Set<Edge>>;
 
     constructor() {
+        this.nodeTemplates = new Map();
         this.nodes = new Map();
         this.edges = new Map();
         this.edgesBySource = new Map();
         this.edgesByTarget = new Map();
+    }
+
+    updateNodeTemplateCache(templates: {id: string, innerHTML: string, [prop: string]: any}[]) {
+        const templateMap = new Map();
+        templates.forEach((template) => templateMap.set(template.id, template.innerHTML));
+        this.nodeTemplates = templateMap;
     }
 
     updateNodeCache(nodes: Node[]) {
@@ -24,6 +34,28 @@ export class GraphObjectCache {
         const edgeMap = new Map();
         edges.forEach((edge) => edgeMap.set(edgeId(edge), edge));
         this.edges = edgeMap;
+    }
+
+    getNodeTemplateId(nodeType: string) {
+        if (nodeType == null || !this.nodeTemplates.has(nodeType)) {
+            return 'default';
+        } else {
+            return nodeType;
+        }
+    }
+
+    getNodeTemplate(nodeType: string) {
+        if (nodeType == null) {
+            nodeType = 'default';
+        }
+        let template = this.nodeTemplates.get(nodeType);
+        if (template == null) {
+            template = this.nodeTemplates.get('default');
+        }
+        if (template == null) {
+            template = DEFAULT_NODE_TEMPLATE;
+        }
+        return template;
     }
 
     getNode(id: number|string) {

--- a/mico-grapheditor/src/templates.ts
+++ b/mico-grapheditor/src/templates.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_NODE_TEMPLATE = `<circle cx="0" cy="0" r="10"></circle>`

--- a/mico-grapheditor/test.html
+++ b/mico-grapheditor/test.html
@@ -26,11 +26,17 @@
                     .edge.highlight-incoming {stroke: green;}
                 </style>
             </template>
-            <template id="node" template-type="node">
+            <template id="REST" template-type="node">
                 <rect width="100" height="60" x="-50" y="-30">
                 </rect>
                 <text class="title text" data-content="title" data-click="title" x="-40" y="-10"></text>
                 <text class="text" data-content="type" x="-40" y="10"></text>
+            </template>
+            <template id="gRPC" template-type="node">
+                <rect width="100" height="40" x="-50" y="-20">
+                </rect>
+                <text class="title text" data-content="title" data-click="title" x="-40" y="-5"></text>
+                <text class="text" data-content="type" x="-40" y="15"></text>
             </template>
         </network-graph>
 


### PR DESCRIPTION
Node-Templates are now only stored in object cache. The `type` attribute in node datum is used to determine which template to use. The id 'default' can overwrite the standard default template.