### PR TITLE
Travis should build only mico-core

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ trim_trailing_whitespace = true
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false
+
+[{package.json,.travis.yml}]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-sudo: required
 language: java
 services:
   - docker
+before_install:
+  # Build only mico-core
+  - cd mico-core
 cache:
-  npm: true
   directories:
     - $HOME/.m2


### PR DESCRIPTION
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files

---

## Short Description

Travis builds only `mico-core`.
`mico-admin` is not required at the moment, because it requires much time only for the build and there are no unit tests at the moment.

Build time is reduced from 2 min 55 sec to 1 min 51 sec.