### PR TITLE
Fix Kubernetes unit tests when complete project is executed

### DIFF
--- a/mico-core/src/test/java/io/github/ust/mico/core/ClusterAwarenessFabric8Test.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ClusterAwarenessFabric8Test.java
@@ -2,7 +2,6 @@ package io.github.ust.mico.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.api.model.*;
-import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
@@ -11,8 +10,8 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 
 import static org.junit.Assert.*;
@@ -264,17 +263,17 @@ public class ClusterAwarenessFabric8Test {
 
     @Test
     public void createFromYaml() throws IOException {
-        cluster.createFromYaml(new FileInputStream("src/test/resources/hello-kubernetes-w-namespace.yaml"));
+        cluster.createFromYaml(new ClassPathResource("hello-kubernetes-w-namespace.yaml").getInputStream());
     }
 
     @Test
     public void createFromYaml1() throws IOException {
-        cluster.createFromYaml(new FileInputStream("src/test/resources/hello-kubernetes-deployment.yaml"), namespaceName);
+        cluster.createFromYaml(new ClassPathResource("hello-kubernetes-deployment.yaml").getInputStream(), namespaceName);
     }
 
     @Test
     public void deleteFromYaml() throws IOException {
-        cluster.deleteFromYaml(new FileInputStream("src/test/resources/hello-kubernetes-deployment.yaml"), namespaceName);
+        cluster.deleteFromYaml(new ClassPathResource("hello-kubernetes-deployment.yaml").getInputStream(), namespaceName);
     }
 
     @Test


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Tests created for changes or:
  - [ ] Test cases are missing - opened issue for that:
  - [ ] Reason for missing tests:
- [ ] Screenshots added (for UI changes)
- [ ] Change in CHANGELOG.md described

---

## Short Description

<!-- Summarize the new functionalities/fixes -->

When all unit tests were executed for the complete project at once, 3 tests failed.
Reason for that was the path to the resource directory.

## Resolving Issue/ Feature

<!-- Reference to the respective issue -->

Now every unit test works regardless of the path to the resource directory.