### PR TITLE
Fix naming of REST endpoint for public ip of service interface by name.

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/REST/ServiceInterfaceController.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/REST/ServiceInterfaceController.java
@@ -38,9 +38,9 @@ public class ServiceInterfaceController {
 
     private static final String PATH_VARIABLE_SERVICE_INTERFACE_NAME = "serviceInterfaceName";
     private static final String PATH_PART_INTERFACES = "interfaces";
-    private static final String PATH_PATH_PUBLIC_IP = "publicIP";
+    private static final String PATH_PART_PUBLIC_IP = "publicIP";
     private static final String SERVICE_INTERFACE_PATH = "/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_PART_INTERFACES + "/";
-    private static final String SERVICE_INTERFACE_PUBLIC_IP_PATH = SERVICE_INTERFACE_PATH + "{" + PATH_PATH_PUBLIC_IP + "}/";
+    private static final String SERVICE_INTERFACE_PUBLIC_IP_PATH = SERVICE_INTERFACE_PATH + "{" + PATH_VARIABLE_SERVICE_INTERFACE_NAME + "}/" + PATH_PART_PUBLIC_IP + "/";
 
     @Autowired
     private MicoServiceRepository serviceRepository;


### PR DESCRIPTION

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Tests created for changes or:
  - [ ] Test cases are missing - opened issue for that:
  - [ ] Reason for missing tests:
- [ ] Screenshots added (for UI changes)
- [ ] Change in CHANGELOG.md described

---

## Short Description

Fix naming of REST endpoint for public IP of service interface by name. Path now is:
/services/{shortName}/{version}/interfaces/{serviceInterfaceName}/publicIP/

## Resolving Issue/ Feature

#296 