### PR TITLE
Fix service interface loading

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceInterface.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceInterface.java
@@ -26,7 +26,7 @@ import lombok.Singular;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @NodeEntity
 @QueryResult
 public class MicoServiceInterface {

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceRepository.java
@@ -12,7 +12,7 @@ import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceInterface;
 
 public interface MicoServiceRepository extends Neo4jRepository<MicoService, Long> {
-    
+
     @Override
     List<MicoService> findAll();
 
@@ -25,9 +25,18 @@ public interface MicoServiceRepository extends Neo4jRepository<MicoService, Long
     @Depth(2)
     Optional<MicoService> findByShortNameAndVersion(String shortName, String version);
 
-    @Query("MATCH (service:MicoService)-[:PROVIDES_INTERFACES]->(interface:MicoServiceInterface)-[:PROVIDES_PORTS]->(port:MicoServicePort) WHERE service.shortName = {shortName} AND service.version = {version} return COLLECT(port) AS ports")
-    List<MicoServiceInterface> findInterfacesOfService(@Param("shortName") String shortName, @Param("version") String version);
-
+    /**
+     * Find a specific service interface.
+     *
+     * The returned interface will NOT have ports mapped by the ogm.
+     * If you want to have a interface with mapped ports use the serviceInterface
+     * list in the corresponding MicoService object returned by findByShortNameAndVersion!
+     *
+     * @param serviceInterfaceName
+     * @param shortName
+     * @param version
+     * @return
+     */
     @Query("MATCH (service:MicoService)-[:PROVIDES_INTERFACES]->(interface:MicoServiceInterface)-[:PROVIDES_PORTS]->(port:MicoServicePort) WHERE service.shortName = {shortName} AND service.version = {version} AND interface.serviceInterfaceName = {serviceInterfaceName} return COLLECT(port) AS ports")
     Optional<MicoServiceInterface> findInterfaceOfServiceByName(@Param("serviceInterfaceName") String serviceInterfaceName, @Param("shortName") String shortName, @Param("version") String version);
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceControllerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceControllerTests.java
@@ -127,8 +127,8 @@ public class ServiceInterfaceControllerTests {
     @Test
     public void getSpecificServiceInterface() throws Exception {
         MicoServiceInterface serviceInterface = getTestServiceInterface();
-        given(serviceRepository.findInterfaceOfServiceByName(serviceInterface.getServiceInterfaceName(), SHORT_NAME, VERSION)).willReturn(
-            Optional.of(serviceInterface));
+        given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(
+            Optional.of(MicoService.builder().serviceInterface(serviceInterface).build()));
 
         mvc.perform(get(INTERFACES_URL + "/" + serviceInterface.getServiceInterfaceName()).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
@@ -155,8 +155,8 @@ public class ServiceInterfaceControllerTests {
         MicoServiceInterface serviceInterface0 = MicoServiceInterface.builder().serviceInterfaceName("ServiceInterface0").build();
         MicoServiceInterface serviceInterface1 = MicoServiceInterface.builder().serviceInterfaceName("ServiceInterface1").build();
         List<MicoServiceInterface> serviceInterfaces = Arrays.asList(serviceInterface0, serviceInterface1);
-        given(serviceRepository.findInterfacesOfService(SHORT_NAME, VERSION)).willReturn(
-            serviceInterfaces);
+        given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(
+            Optional.of(MicoService.builder().serviceInterfaces(serviceInterfaces).build()));
         mvc.perform(get(INTERFACES_URL).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())


### PR DESCRIPTION
## Short Description

The neo4j ogm mapper cannot map related objects whith custom querys. Because of that the methods to get all service interfaces and specific interfaces would have incomplete serviceInterface objects.

The fix uses the parent Service object to get fully mapped service interfaces.

## Resolving Issue/ Feature

Closes #350
