### PR TITLE
Fix redundant creation of Kubernetes objects

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/mapping/MicoKubernetesClient.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/mapping/MicoKubernetesClient.java
@@ -11,6 +11,7 @@ import io.github.ust.mico.core.model.MicoServiceInterface;
 import io.github.ust.mico.core.model.MicoServicePort;
 import io.github.ust.mico.core.util.CollectionUtils;
 import io.github.ust.mico.core.util.UIDUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,7 @@ import java.util.Map;
 /**
  * Provides accessor methods for creating deployment and services in Kubernetes.
  */
+@Slf4j
 @Component
 public class MicoKubernetesClient {
 
@@ -29,6 +31,7 @@ public class MicoKubernetesClient {
      * Labels are used as selectors for Kubernetes deployments, services and pods.
      * The `app` label references to the shortName of the {@link MicoService}.
      * The `version` label references to the version of the {@link MicoService}.
+     * The `interface` label references to the name of the {@link MicoServiceInterface}.
      * The `run` label references to the UID that is created for each {@link MicoService}.
      */
     public static final String LABEL_APP_KEY = "app";
@@ -48,21 +51,40 @@ public class MicoKubernetesClient {
     /**
      * Create a Kubernetes deployment based on a MICO service.
      *
-     * @param service        the {@link MicoService}
+     * @param micoService    the {@link MicoService}
      * @param deploymentInfo the {@link MicoServiceDeploymentInfo}
      * @return the Kubernetes {@link Deployment} resource object
      */
-    public Deployment createMicoService(MicoService service, MicoServiceDeploymentInfo deploymentInfo) {
+    public Deployment createMicoService(MicoService micoService, MicoServiceDeploymentInfo deploymentInfo) throws KubernetesResourceException {
         String namespace = micoKubernetesConfig.getNamespaceMicoWorkspace();
+        String deploymentUid;
 
-        String deploymentUid = UIDUtils.uidFor(service);
+        // Check if there are already Kubernetes deployments for the requested MicoService
+        List<Deployment> alreadyExistingDeployments = getDeployedMicoServices(micoService);
+        if (alreadyExistingDeployments.isEmpty()) {
+            // Create new Kubernetes Deployment -> create new name for it
+            deploymentUid = UIDUtils.uidFor(micoService);
+        } else if (alreadyExistingDeployments.size() == 1) {
+            // Kubernetes Deployment already exists -> use existing name and update the Deployment
+            String existingDeploymentName = alreadyExistingDeployments.get(0).getMetadata().getName();
+            log.info("MicoService '{}' in version '{}' is already deployed. Kubernetes Deployment '{}' will be updated.",
+                micoService.getShortName(), micoService.getVersion(), existingDeploymentName);
+
+            deploymentUid = existingDeploymentName;
+        } else {
+            // There is more than one deployment for the MicoService!
+            log.warn("MicoService '{}' in version '{}' is already deployed multiple times. Don't know which to replace.",
+                micoService.getShortName(), micoService.getVersion());
+            throw new KubernetesResourceException("There are multiple Kubernetes Deployments for MicoService '"
+                + micoService.getShortName() + "' in version '" + micoService.getVersion() + "'.");
+        }
 
         Deployment deployment = new DeploymentBuilder()
             .withNewMetadata()
             .withName(deploymentUid)
             .withNamespace(micoKubernetesConfig.getNamespaceMicoWorkspace())
-            .addToLabels(LABEL_APP_KEY, service.getShortName())
-            .addToLabels(LABEL_VERSION_KEY, service.getVersion())
+            .addToLabels(LABEL_APP_KEY, micoService.getShortName())
+            .addToLabels(LABEL_VERSION_KEY, micoService.getVersion())
             .addToLabels(LABEL_RUN_KEY, deploymentUid)
             .endMetadata()
             .withNewSpec()
@@ -72,17 +94,17 @@ public class MicoKubernetesClient {
             .endSelector()
             .withNewTemplate()
             .withNewMetadata()
-            .addToLabels(LABEL_APP_KEY, service.getShortName())
-            .addToLabels(LABEL_VERSION_KEY, service.getVersion())
+            .addToLabels(LABEL_APP_KEY, micoService.getShortName())
+            .addToLabels(LABEL_VERSION_KEY, micoService.getVersion())
             .addToLabels(LABEL_RUN_KEY, deploymentUid)
             .endMetadata()
             .withNewSpec()
             .withContainers(
                 new ContainerBuilder()
                     // TODO: Use containers from mico service deployment info
-                    .withName(service.getShortName())
-                    .withImage(service.getDockerImageUri())
-                    .withPorts(createContainerPorts(service))
+                    .withName(micoService.getShortName())
+                    .withImage(micoService.getDockerImageUri())
+                    .withPorts(createContainerPorts(micoService))
                     .build())
             .endSpec()
             .endTemplate()
@@ -101,9 +123,27 @@ public class MicoKubernetesClient {
      */
     public Service createMicoServiceInterface(MicoServiceInterface micoServiceInterface, MicoService micoService) throws KubernetesResourceException {
         String namespace = micoKubernetesConfig.getNamespaceMicoWorkspace();
+        String serviceInterfaceUid;
 
-        // Unique identifier for the service interface used as its name tag
-        String serviceInterfaceUid = UIDUtils.uidFor(micoServiceInterface);
+        // Check if there are already Kubernetes services for the requested MicoServiceInterface
+        List<Service> alreadyExistingServices = getDeployedMicoServiceInterfaces(micoService, micoServiceInterface);
+        if (alreadyExistingServices.isEmpty()) {
+            // Create new Kubernetes Service -> create enew name for it
+            serviceInterfaceUid = UIDUtils.uidFor(micoServiceInterface);
+        } else if (alreadyExistingServices.size() == 1) {
+            // Kubernetes Service already exists -> use existing name and update the Service
+            String existingServiceName = alreadyExistingServices.get(0).getMetadata().getName();
+            log.info("MicoServiceInterface '{}' in version '{}' already exists. Kubernetes Service '{}' will be updated.",
+                micoService.getShortName(), micoService.getVersion(), existingServiceName);
+
+            serviceInterfaceUid = existingServiceName;
+        } else {
+            // There is more than one deployment for the MicoService!
+            log.warn("MicoServiceInterface '{}' in version '{}' already exists multiple times. Don't know which to replace.",
+                micoService.getShortName(), micoService.getVersion());
+            throw new KubernetesResourceException("There are multiple Kubernetes Services for MicoServiceInterface '"
+                + micoServiceInterface.getServiceInterfaceName() + "' of MicoService '" + micoService.getShortName() + "' in version '" + micoService.getVersion() + "'.");
+        }
 
         // Retrieve deployment corresponding to given MicoService to retrieve
         // the unique run label which will be used for the Kubernetes Service, too.
@@ -143,6 +183,42 @@ public class MicoKubernetesClient {
         return cluster.createService(service, namespace);
     }
 
+    /**
+     * Looks up deployed MICO services by checking the labels of the existing Kubernetes deployments.
+     *
+     * @param micoService the MICO service
+     * @return the list of Kubernetes deployments
+     */
+    private List<Deployment> getDeployedMicoServices(MicoService micoService) {
+        Map<String, String> labels = CollectionUtils.mapOf(
+            LABEL_APP_KEY, micoService.getShortName(),
+            LABEL_VERSION_KEY, micoService.getVersion()
+        );
+        String namespace = micoKubernetesConfig.getNamespaceMicoWorkspace();
+
+        List<Deployment> deploymentList = cluster.getDeploymentsByLabels(labels, namespace).getItems();
+        log.debug("Found {} Kubernetes deployment(s) that match the labels '{}': '{}'", deploymentList.size(), labels.toString(), deploymentList);
+        return deploymentList;
+    }
+
+    /**
+     * Looks up deployed MICO service interfaces by checking the labels of the existing Kubernetes services.
+     *
+     * @param micoService          the MICO service
+     * @param micoServiceInterface the MICO service interface
+     * @return the list of Kubernetes services
+     */
+    private List<Service> getDeployedMicoServiceInterfaces(MicoService micoService, MicoServiceInterface micoServiceInterface) {
+        Map<String, String> labels = CollectionUtils.mapOf(
+            LABEL_APP_KEY, micoService.getShortName(),
+            LABEL_VERSION_KEY, micoService.getVersion(),
+            LABEL_INTERFACE_KEY, micoServiceInterface.getServiceInterfaceName()
+        );
+        String namespace = micoKubernetesConfig.getNamespaceMicoWorkspace();
+        List<Service> serviceList = cluster.getServicesByLabels(labels, namespace).getItems();
+        log.debug("Found {} Kubernetes service(s) that match the labels '{}': '{}'", serviceList.size(), labels.toString(), serviceList);
+        return serviceList;
+    }
 
     /**
      * Creates a list of ports based on a MICO service. This list of ports

--- a/mico-core/src/main/java/io/github/ust/mico/core/util/CollectionUtils.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/CollectionUtils.java
@@ -43,4 +43,14 @@ public class CollectionUtils {
         
     }
 
+    public final <K, V> Map<K, V> mapOf(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+        Map<K, V> map = new HashMap<K, V>();
+        map.put(k1, v1);
+        map.put(k2, v2);
+        map.put(k3, v3);
+        map.put(k4, v4);
+        return map;
+
+    }
+
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/DeploymentControllerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DeploymentControllerTests.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.github.ust.mico.core.REST.DeploymentController;
 import io.github.ust.mico.core.concurrency.MicoCoreBackgroundTaskFactory;
 import io.github.ust.mico.core.imagebuilder.ImageBuilder;
+import io.github.ust.mico.core.mapping.KubernetesResourceException;
 import io.github.ust.mico.core.mapping.MicoKubernetesClient;
 import io.github.ust.mico.core.model.*;
 import io.github.ust.mico.core.persistence.MicoApplicationRepository;
@@ -74,7 +75,7 @@ public class DeploymentControllerTests {
     private MicoKubernetesClient micoKubernetesClient;
 
     @Before
-    public void setUp() {
+    public void setUp() throws KubernetesResourceException {
         given(imageBuilder.createImageName(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).willReturn(DOCKER_IMAGE_URI);
 
         Deployment deployment = new Deployment();

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -1,0 +1,253 @@
+package io.github.ust.mico.core;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.github.ust.mico.core.mapping.KubernetesResourceException;
+import io.github.ust.mico.core.mapping.MicoKubernetesClient;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.model.MicoServicePort;
+import io.github.ust.mico.core.util.CollectionUtils;
+import io.github.ust.mico.core.util.UIDUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.mapping.MicoKubernetesClient.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class MicoKubernetesClientTests {
+
+    @MockBean
+    MicoKubernetesConfig micoKubernetesConfig;
+
+    @MockBean
+    private ClusterAwarenessFabric8 cluster;
+
+    @Autowired
+    MicoKubernetesClient micoKubernetesClient;
+
+    private static String testNamespace = "test-namespace";
+
+    @Before
+    public void setUp() {
+        given(micoKubernetesConfig.getNamespaceMicoWorkspace()).willReturn(testNamespace);
+    }
+
+    @Test
+    public void creationOfMicoServiceWorks() throws KubernetesResourceException {
+
+        DeploymentList emptyDeploymentList = new DeploymentList(); // at the beginning there are no existing deployments
+        given(cluster.getDeploymentsByLabels(anyMap(), anyString())).willReturn(emptyDeploymentList);
+
+        MicoService micoServiceWithoutInterface = getMicoServiceWithoutInterface();
+        MicoServiceDeploymentInfo deploymentInfo = new MicoServiceDeploymentInfo();
+        micoKubernetesClient.createMicoService(micoServiceWithoutInterface, deploymentInfo);
+
+        ArgumentCaptor<Deployment> deploymentArgumentCaptor = ArgumentCaptor.forClass(Deployment.class);
+        ArgumentCaptor<String> namespaceArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(cluster, times(1)).createDeployment(deploymentArgumentCaptor.capture(), namespaceArgumentCaptor.capture());
+        assertEquals(testNamespace, namespaceArgumentCaptor.getValue());
+
+        Deployment actualDeployment = deploymentArgumentCaptor.getValue();
+        assertNotNull(actualDeployment);
+        assertTrue("Name of Kubernetes Deployment does not start with short name of MicoService",
+            actualDeployment.getMetadata().getName().startsWith(micoServiceWithoutInterface.getShortName()));
+        assertEquals(testNamespace, actualDeployment.getMetadata().getNamespace());
+
+        verify(cluster, never()).createService(any(), any());
+    }
+
+    @Test
+    public void creationOfMicoServiceInterfaceWorks() throws KubernetesResourceException {
+
+        ServiceList existingServices = new ServiceList(); // at the beginning there are no existing services
+        given(cluster.getServicesByLabels(anyMap(), anyString())).willReturn(existingServices);
+
+        MicoService micoService = getMicoServiceWithInterface();
+        MicoServiceInterface micoServiceInterface = getMicoServiceInterface();
+        String deploymentUid = UIDUtils.uidFor(micoService);
+
+        Deployment existingDeployment = getDeploymentObject(micoService, deploymentUid);
+
+        Map<String, String> labels = CollectionUtils.mapOf(
+            LABEL_APP_KEY, micoService.getShortName(),
+            LABEL_VERSION_KEY, micoService.getVersion());
+        DeploymentList deploymentList = new DeploymentList();
+        deploymentList.setItems(CollectionUtils.listOf(existingDeployment));
+        given(cluster.getDeploymentsByLabels(labels, testNamespace)).willReturn(deploymentList);
+
+        micoKubernetesClient.createMicoServiceInterface(micoServiceInterface, micoService);
+
+        ArgumentCaptor<Service> serviceArgumentCaptor = ArgumentCaptor.forClass(Service.class);
+        ArgumentCaptor<String> namespaceArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(cluster, times(1)).createService(serviceArgumentCaptor.capture(), namespaceArgumentCaptor.capture());
+        assertEquals(testNamespace, namespaceArgumentCaptor.getValue());
+
+        Service actualService = serviceArgumentCaptor.getValue();
+        assertNotNull(actualService);
+        assertTrue("Name of Kubernetes Service does not start with name of MicoServiceInterface",
+            actualService.getMetadata().getName().startsWith(micoServiceInterface.getServiceInterfaceName()));
+
+        String expectedRunLabelValue = existingDeployment.getMetadata().getLabels().getOrDefault(LABEL_RUN_KEY, "UNKNOWN RUN LABEL KEY");
+        assertEquals("Expected RUN label value in metadata is same than associated deployment",
+            expectedRunLabelValue, actualService.getMetadata().getLabels().getOrDefault(LABEL_RUN_KEY, "UNKNOWN RUN LABEL KEY"));
+        assertEquals("Expected RUN label value in spec used as selector is same than associated deployment",
+            expectedRunLabelValue, actualService.getSpec().getSelector().getOrDefault(LABEL_RUN_KEY, "UNKNOWN RUN LABEL KEY"));
+        assertEquals(testNamespace, actualService.getMetadata().getNamespace());
+
+        verify(cluster, never()).createDeployment(any(), any());
+    }
+
+    @Test
+    public void creationOfMicoServiceThatAlreadyExistsDoesReplaceTheSameObject() throws KubernetesResourceException {
+
+        // Arrange existing deployments
+        DeploymentList existingDeployments = new DeploymentList(); // at the beginning there are no existing deployments
+        given(cluster.getDeploymentsByLabels(anyMap(), anyString())).willReturn(existingDeployments);
+
+        MicoService micoServiceWithoutInterface = getMicoServiceWithoutInterface();
+        MicoServiceDeploymentInfo deploymentInfo = new MicoServiceDeploymentInfo();
+
+        ArgumentCaptor<Deployment> deploymentArgumentCaptor = ArgumentCaptor.forClass(Deployment.class);
+        ArgumentCaptor<String> namespaceArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        // First creation
+        micoKubernetesClient.createMicoService(micoServiceWithoutInterface, deploymentInfo);
+
+        verify(cluster, times(1)).createDeployment(deploymentArgumentCaptor.capture(), namespaceArgumentCaptor.capture());
+        Deployment firstDeployment = deploymentArgumentCaptor.getValue();
+        assertNotNull(firstDeployment);
+        String firstDeploymentName = firstDeployment.getMetadata().getName();
+        Deployment deployment = getDeploymentObject(micoServiceWithoutInterface, firstDeploymentName);
+        existingDeployments.setItems(CollectionUtils.listOf(deployment));  // after the first deployment there is one deployment
+        given(cluster.getDeploymentsByLabels(anyMap(), anyString())).willReturn(existingDeployments);
+
+        // Second creation
+        micoKubernetesClient.createMicoService(micoServiceWithoutInterface, deploymentInfo);
+
+        verify(cluster, times(2)).createDeployment(deploymentArgumentCaptor.capture(), namespaceArgumentCaptor.capture());
+        Deployment secondDeployment = deploymentArgumentCaptor.getValue();
+        assertNotNull(secondDeployment);
+        assertEquals("Expected both deployments have the same name", firstDeployment.getMetadata().getName(), secondDeployment.getMetadata().getName());
+        assertEquals("Expected both deployments are the same", firstDeployment, secondDeployment);
+    }
+
+    @Test
+    public void creationOfMicoServiceInterfaceThatAlreadyExistsDoesNotReplaceTheSameObject() throws KubernetesResourceException {
+
+        MicoService micoService = getMicoServiceWithInterface();
+        MicoServiceInterface micoServiceInterface = getMicoServiceInterface();
+        String deploymentUid = UIDUtils.uidFor(micoService);
+
+        // Arrange existing deployments
+        Deployment existingDeployment = getDeploymentObject(micoService, deploymentUid);
+        Map<String, String> labels = CollectionUtils.mapOf(LABEL_APP_KEY, micoService.getShortName(), LABEL_VERSION_KEY, micoService.getVersion());
+        DeploymentList deploymentList = new DeploymentList();
+        deploymentList.setItems(CollectionUtils.listOf(existingDeployment));
+        given(cluster.getDeploymentsByLabels(labels, testNamespace)).willReturn(deploymentList);
+
+        // Arrange existing services
+        ServiceList existingServices = new ServiceList(); // at the beginning there are no existing services
+        given(cluster.getServicesByLabels(anyMap(), anyString())).willReturn(existingServices);
+
+        ArgumentCaptor<Service> serviceArgumentCaptor = ArgumentCaptor.forClass(Service.class);
+        ArgumentCaptor<String> namespaceArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        // First creation
+        micoKubernetesClient.createMicoServiceInterface(micoServiceInterface, micoService);
+
+        verify(cluster, times(1)).createService(serviceArgumentCaptor.capture(), namespaceArgumentCaptor.capture());
+        Service firstService = serviceArgumentCaptor.getValue();
+        assertNotNull(firstService);
+        String firstServiceName = firstService.getMetadata().getName();
+        Service service = getServiceObject(micoServiceInterface, micoService, firstServiceName);
+        existingServices.setItems(CollectionUtils.listOf(service)); // after the first creation there is one service
+        given(cluster.getServicesByLabels(anyMap(), anyString())).willReturn(existingServices);
+
+        // Second creation
+        micoKubernetesClient.createMicoServiceInterface(micoServiceInterface, micoService);
+
+        verify(cluster, times(2)).createService(serviceArgumentCaptor.capture(), namespaceArgumentCaptor.capture());
+        Service secondService = serviceArgumentCaptor.getValue();
+        assertNotNull(secondService);
+        assertEquals("Expected both services have the same name", firstService.getMetadata().getName(), secondService.getMetadata().getName());
+        assertEquals("Expected both services are the same", firstService, secondService);
+    }
+
+    private Deployment getDeploymentObject(MicoService micoService, String deploymentUid) {
+        Map<String, String> labels = CollectionUtils.mapOf(
+            LABEL_APP_KEY, micoService.getShortName(),
+            LABEL_VERSION_KEY, micoService.getVersion(),
+            LABEL_RUN_KEY, deploymentUid);
+        return new DeploymentBuilder()
+            .withNewMetadata()
+            .withName(deploymentUid)
+            .withNamespace(testNamespace)
+            .withLabels(labels)
+            .endMetadata()
+            .build();
+    }
+
+    private Service getServiceObject(MicoServiceInterface micoServiceInterface, MicoService micoService, String serviceInterfaceUid) {
+        Map<String, String> labels = CollectionUtils.mapOf(
+            LABEL_APP_KEY, micoService.getShortName(),
+            LABEL_VERSION_KEY, micoService.getVersion(),
+            LABEL_INTERFACE_KEY, micoServiceInterface.getServiceInterfaceName(),
+            LABEL_RUN_KEY, serviceInterfaceUid);
+        return new ServiceBuilder()
+            .withNewMetadata()
+            .withName(serviceInterfaceUid)
+            .withNamespace(testNamespace)
+            .withLabels(labels)
+            .endMetadata()
+            .build();
+    }
+
+    private MicoService getMicoServiceWithInterface() {
+        MicoService micoService = getMicoServiceWithoutInterface();
+        MicoServiceInterface micoServiceInterface = getMicoServiceInterface();
+        micoService.setServiceInterfaces(CollectionUtils.listOf(micoServiceInterface));
+        return micoService;
+    }
+
+    private MicoService getMicoServiceWithoutInterface() {
+        return new MicoService()
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(RELEASE)
+            .setGitCloneUrl(GIT_TEST_REPO_URL)
+            .setDockerfilePath(DOCKERFILE);
+    }
+
+    private MicoServiceInterface getMicoServiceInterface() {
+        return new MicoServiceInterface()
+            .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
+            .setPorts(CollectionUtils.listOf(
+                new MicoServicePort()
+                    .setNumber(80)
+                    .setTargetPort(80)
+                )
+            );
+    }
+}

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -23,10 +23,10 @@ public class TestConstants {
     public static final String VERSION_1_0_2_MATCHER = JsonPathBuilder.buildVersionMatcher(VERSION_1_0_2);
     public static final String VERSION_1_0_3_MATCHER = JsonPathBuilder.buildVersionMatcher(VERSION_1_0_3);
 
-    public static final String SHORT_NAME = "ShortName";
-    public static final String SHORT_NAME_1 = "ShortName1";
-    public static final String SHORT_NAME_2 = "ShortName2";
-    public static final String SHORT_NAME_3 = "ShortName3";
+    public static final String SHORT_NAME = "short-name";
+    public static final String SHORT_NAME_1 = "short-name-1";
+    public static final String SHORT_NAME_2 = "short-name-2";
+    public static final String SHORT_NAME_3 = "short-name-3";
     public static final String SHORT_NAME_ATTRIBUTE = JsonPathBuilder.buildAttributePath("shortName");
     public static final String SHORT_NAME_MATCHER = JsonPathBuilder.buildSingleMatcher(SHORT_NAME_ATTRIBUTE, SHORT_NAME);
     public static final String SHORT_NAME_1_MATCHER = JsonPathBuilder.buildSingleMatcher(SHORT_NAME_ATTRIBUTE, SHORT_NAME_1);


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Tests created for changes

---

## Short Description

<!-- Summarize the new functionalities/fixes -->

Fixes creation of redundant creation of Kubernetes objects for same MicoServices (Kubernetes Deployments) and MicoServiceInterfaces (Kubernetes Services).

## Resolving Issue/ Feature

<!-- Reference to the respective issue -->

Resolves #405 