### PR TITLE
Feature/mico 356 validate kubernetes resources

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoService.java
@@ -65,8 +65,10 @@ public class MicoService {
 
     /**
      * A brief name for the service.
+     * Pattern is the same than the one for Kubernetes Service names.
      */
     @ApiModelProperty(required = true)
+    @Pattern(regexp="^[a-z]([-a-z0-9]*[a-z0-9])?$")
     private String shortName;
 
     /**

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoService.java
@@ -65,7 +65,7 @@ public class MicoService {
 
     /**
      * A brief name for the service.
-     * Pattern is the same than the one for Kubernetes Service names.
+     * Pattern is the same as the one for Kubernetes Service names.
      */
     @ApiModelProperty(required = true)
     @Pattern(regexp="^[a-z]([-a-z0-9]*[a-z0-9])?$")

--- a/mico-core/src/main/java/io/github/ust/mico/core/web/ServiceController.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/web/ServiceController.java
@@ -32,9 +32,11 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import javax.validation.Valid;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -130,7 +132,12 @@ public class ServiceController {
     }
 
     @PostMapping
-    public ResponseEntity<Resource<MicoService>> createService(@RequestBody MicoService newService) {
+    public ResponseEntity<Resource<MicoService>> createService(@Valid @RequestBody MicoService newService,
+                                                               BindingResult bindingResult) {
+        if (bindingResult != null && bindingResult.hasErrors()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The name of the service is not valid.");
+        }
+
         Optional<MicoService> serviceOptional = serviceRepository.
             findByShortNameAndVersion(newService.getShortName(), newService.getVersion());
         if (serviceOptional.isPresent()) {
@@ -272,7 +279,7 @@ public class ServiceController {
         GitHubCrawler crawler = new GitHubCrawler(restTemplate);
         try {
             MicoService newService = crawler.crawlGitHubRepoLatestRelease(url);
-            return createService(newService);
+            return createService(newService, null);
         } catch (IOException e) {
             log.error(e.getStackTrace().toString());
             log.error("Getting exception '{}'", e.getMessage());

--- a/mico-core/src/main/java/io/github/ust/mico/core/web/ServiceInterfaceController.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/web/ServiceInterfaceController.java
@@ -35,9 +35,11 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -168,7 +170,12 @@ public class ServiceInterfaceController {
     @PostMapping(SERVICE_INTERFACE_PATH)
     public ResponseEntity<Resource<MicoServiceInterface>> createServiceInterface(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
                                                                                  @PathVariable(PATH_VARIABLE_VERSION) String version,
-                                                                                 @RequestBody MicoServiceInterface serviceInterface) {
+                                                                                 @Valid @RequestBody MicoServiceInterface serviceInterface,
+                                                                                 BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The name of the service interface is not valid.");
+        }
+
         MicoService service = getServiceFromDatabase(shortName, version);
         if (serviceInterfaceExists(serviceInterface, service)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "An interface with the name '" + serviceInterface.getServiceInterfaceName() +

--- a/mico-core/src/main/java/io/github/ust/mico/core/web/ServiceInterfaceController.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/web/ServiceInterfaceController.java
@@ -172,7 +172,7 @@ public class ServiceInterfaceController {
                                                                                  @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                                                  @Valid @RequestBody MicoServiceInterface serviceInterface,
                                                                                  BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
+        if (bindingResult != null && bindingResult.hasErrors()) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The name of the service interface is not valid.");
         }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceControllerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceControllerTests.java
@@ -24,35 +24,7 @@ import static io.github.ust.mico.core.JsonPathBuilder.LINKS;
 import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
 import static io.github.ust.mico.core.JsonPathBuilder.SELF;
 import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
-import static io.github.ust.mico.core.TestConstants.BASE_URL;
-import static io.github.ust.mico.core.TestConstants.DEPENDEES_SUBPATH;
-import static io.github.ust.mico.core.TestConstants.DEPENDERS_SUBPATH;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION_1;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION_1_MATCHER;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION_2;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION_2_MATCHER;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION_3;
-import static io.github.ust.mico.core.TestConstants.DESCRIPTION_3_MATCHER;
-import static io.github.ust.mico.core.TestConstants.ID;
-import static io.github.ust.mico.core.TestConstants.ID_1;
-import static io.github.ust.mico.core.TestConstants.SERVICES_PATH;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1_MATCHER;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2_MATCHER;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_3;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_3_MATCHER;
-import static io.github.ust.mico.core.TestConstants.SHORT_NAME_MATCHER;
-import static io.github.ust.mico.core.TestConstants.VERSION;
-import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1;
-import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1_MATCHER;
-import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2;
-import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2_MATCHER;
-import static io.github.ust.mico.core.TestConstants.VERSION_1_0_3;
-import static io.github.ust.mico.core.TestConstants.VERSION_1_0_3_MATCHER;
-import static io.github.ust.mico.core.TestConstants.VERSION_MATCHER;
+import static io.github.ust.mico.core.TestConstants.*;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
@@ -218,6 +190,23 @@ public class ServiceControllerTests {
             .andDo(print());
 
         result.andExpect(status().isCreated());
+    }
+
+    @Test
+    public void createInvalidService() throws Exception {
+        MicoService service = new MicoService()
+            .setShortName(SHORT_NAME_INVALID)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION);
+
+        given(serviceRepository.save(any(MicoService.class))).willReturn(service);
+
+        mvc.perform(post(SERVICES_PATH)
+            .content(mapper.writeValueAsBytes(service)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().reason("The name of the service is not valid."))
+            .andReturn();
     }
 
     @Test

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceControllerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceControllerTests.java
@@ -202,6 +202,7 @@ public class ServiceControllerTests {
             .andExpect(status().isUnprocessableEntity())
             .andExpect(status().reason("The name of the service is not valid."))
             .andReturn();
+    }
 
     public void createServiceWithExistingInterfaces() throws Exception {
         MicoServiceInterface serviceInterface1 = new MicoServiceInterface()

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceControllerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceControllerTests.java
@@ -81,6 +81,7 @@ public class ServiceInterfaceControllerTests {
     private static final String SELF_HREF = buildPath(JSON_PATH_LINKS_SECTION, SELF, HREF);
     private static final String INTERFACES_HREF = buildPath(JSON_PATH_LINKS_SECTION, "interfaces", HREF);
     private static final String INTERFACE_NAME = "interface-name";
+    private static final String INTERFACE_NAME_INVALID = "interface_NAME";
     private static final int INTERFACE_PORT = 1024;
     private static final MicoPortType INTERFACE_PORT_TYPE = MicoPortType.TCP;
     private static final int INTERFACE_TARGET_PORT = 1025;
@@ -143,6 +144,20 @@ public class ServiceInterfaceControllerTests {
             .content(mapper.writeValueAsBytes(serviceInterface)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isConflict())
+            .andReturn();
+    }
+
+    @Test
+    public void postInvalidServiceInterface() throws Exception {
+        MicoServiceInterface serviceInterface = getInvalidTestServiceInterface();
+        given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(
+            Optional.of(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION))
+        );
+        mvc.perform(post(INTERFACES_URL)
+            .content(mapper.writeValueAsBytes(serviceInterface)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().reason("The name of the service interface is not valid."))
             .andReturn();
     }
 
@@ -316,6 +331,17 @@ public class ServiceInterfaceControllerTests {
     private MicoServiceInterface getTestServiceInterface() {
         return new MicoServiceInterface()
             .setServiceInterfaceName(INTERFACE_NAME)
+            .setPorts(CollectionUtils.listOf(new MicoServicePort()
+                .setNumber(INTERFACE_PORT)
+                .setType(INTERFACE_PORT_TYPE)
+                .setTargetPort(INTERFACE_TARGET_PORT)))
+            .setDescription(INTERFACE_DESCRIPTION)
+            .setPublicDns(INTERFACE_PUBLIC_DNS);
+    }
+
+    private MicoServiceInterface getInvalidTestServiceInterface() {
+        return new MicoServiceInterface()
+            .setServiceInterfaceName(INTERFACE_NAME_INVALID)
             .setPorts(CollectionUtils.listOf(new MicoServicePort()
                 .setNumber(INTERFACE_PORT)
                 .setType(INTERFACE_PORT_TYPE)

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -46,6 +46,7 @@ public class TestConstants {
     public static final String SHORT_NAME_1 = "short-name-1";
     public static final String SHORT_NAME_2 = "short-name-2";
     public static final String SHORT_NAME_3 = "short-name-3";
+    public static final String SHORT_NAME_INVALID = "short_NAME";
     public static final String SHORT_NAME_ATTRIBUTE = JsonPathBuilder.buildAttributePath("shortName");
     public static final String SHORT_NAME_MATCHER = JsonPathBuilder.buildSingleMatcher(SHORT_NAME_ATTRIBUTE, SHORT_NAME);
     public static final String SHORT_NAME_1_MATCHER = JsonPathBuilder.buildSingleMatcher(SHORT_NAME_ATTRIBUTE, SHORT_NAME_1);


### PR DESCRIPTION
- [X] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Ensure to use auto format in **all** files
- [X] Tests created

---

## Short Description

The shortName of a MicoService and the name of a MicoServiceInterface are validated in the backend by the regex `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` now. If the name does not match the regex, the exception `UNPROCESSABLE ENTITY`(HTTP code 422) is returned.

@gepperho Maybe it would be meaningful to show the user a hint if the provided string does not match the regex. Such a hint seems to be more friendly instead of receiving an exception if the name is not valid. If you think this is useful, feel free to implement a solution.

## Resolving Issue/ Feature

Closes #356 
