### PR TITLE
Refactor MicoServiceStatusDTO to use KubernetesNodeMetricsDTO

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/KubernetesNodeMetricsDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/KubernetesNodeMetricsDTO.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
+import io.github.ust.mico.core.model.MicoService;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+/**
+ * DTO for the average CPU load and the average memory usage of all {@link Pod Pods} running on a Kubernetes {@link
+ * Node}.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KubernetesNodeMetricsDTO {
+
+    /**
+     * Name of the Kubernetes {@link Node}.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Node Name"),
+            @ExtensionProperty(name = "x-order", value = "10"),
+            @ExtensionProperty(name = "description", value = "Name of the Kubernetes Node.")
+        }
+    )})
+    private String nodeName;
+
+    /**
+     * The average CPU load of all pods of one {@link MicoService} running on this {@link Node}.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Average CPU Load"),
+            @ExtensionProperty(name = "x-order", value = "20"),
+            @ExtensionProperty(name = "description", value = "The average CPU load of all pods of one MicoService running on this Node.")
+        }
+    )})
+    private int averageCpuLoad;
+
+    /**
+     * The average memory usage of all pods of one {@link MicoService} running on this {@link Node}.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Average Memory Usage"),
+            @ExtensionProperty(name = "x-order", value = "30"),
+            @ExtensionProperty(name = "description", value = "The average memory usage of all pods of one MicoService running on this Node.")
+        }
+    )})
+    private int averageMemoryUsage;
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/MicoServiceStatusDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/MicoServiceStatusDTO.java
@@ -21,7 +21,6 @@ package io.github.ust.mico.core.dto;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -128,7 +127,8 @@ public class MicoServiceStatusDTO {
     private List<MicoServiceInterfaceStatusDTO> interfacesInformation = new ArrayList<>();
 
     /**
-     * List of {@link MicoApplicationDTO MicoApplicationDTOs}, representing all applications that are using one service together.
+     * List of {@link MicoApplicationDTO MicoApplicationDTOs}, representing all applications that are using one service
+     * together.
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
@@ -139,7 +139,7 @@ public class MicoServiceStatusDTO {
                 "representing all applications that are using one service together.")
         }
     )})
-    private List<MicoApplicationDTO> applicationsUsingThisService  = new ArrayList<>();
+    private List<MicoApplicationDTO> applicationsUsingThisService = new ArrayList<>();
 
     /**
      * List of all {@link Pod Pods} of all replicas of a deployment of a {@link MicoService}.
@@ -156,38 +156,18 @@ public class MicoServiceStatusDTO {
     private List<KubernetesPodInformationDTO> podsInformation = new ArrayList<>();
 
     /**
-     * Each entry in this map represents a node with its average CPU load. The average CPU load is computed from all
-     * pods of the deployment of a {@link MicoService}, which are running on this node.
+     * List of {@link KubernetesNodeMetricsDTO KubernetesNodeMetricsDTOs} with metrics for each node used by the {@link
+     * MicoService}.
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "Average CPU Load Per Node"),
-            @ExtensionProperty(name = "x-order", value = "92"),
-            @ExtensionProperty(name = "description", value = "Each entry in this map represents " +
-                "a node with its average CPU load. \n" +
-                "The average CPU load is computed from all pods of the deployment " +
-                "of a MicoService running on this node.")
+            @ExtensionProperty(name = "title", value = "Node Metrics"),
+            @ExtensionProperty(name = "x-order", value = "90"),
+            @ExtensionProperty(name = "description", value = "List of KubernetesNodeMetricsDTO with metrics for each node used by this MicoService.")
         }
     )})
-    private Map<String, Integer> averageCpuLoadPerNode;
-
-    /**
-     * Each entry in this map represents a node with its average memory usage. The average memory usage is computed from
-     * all pods of the deployment of a {@link MicoService}, which are running on this node.
-     */
-    @ApiModelProperty(extensions = {@Extension(
-        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
-        properties = {
-            @ExtensionProperty(name = "title", value = "Average Memory Usage Per Node"),
-            @ExtensionProperty(name = "x-order", value = "93"),
-            @ExtensionProperty(name = "description", value = "Each entry in this map represents a " +
-                "node with its average memory usage.\n " +
-                "The average memory usage is computed from all pods of the deployment" +
-                "of a MicoService, which are running on this node.")
-        }
-    )})
-    private Map<String, Integer> averageMemoryUsagePerNode;
+    private List<KubernetesNodeMetricsDTO> nodeMetrics;
 
     /**
      * Contains error messages for services that are not deployed or not available due to other reasons.

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationControllerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationControllerTests.java
@@ -19,12 +19,31 @@
 
 package io.github.ust.mico.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.github.ust.mico.core.configuration.CorsConfig;
-import io.github.ust.mico.core.dto.*;
-import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.dto.KubernetesNodeMetricsDTO;
+import io.github.ust.mico.core.dto.KubernetesPodInformationDTO;
+import io.github.ust.mico.core.dto.KubernetesPodMetricsDTO;
+import io.github.ust.mico.core.dto.MicoApplicationDTO;
+import io.github.ust.mico.core.dto.MicoApplicationStatusDTO;
+import io.github.ust.mico.core.dto.MicoApplicationWithServicesDTO;
+import io.github.ust.mico.core.dto.MicoServiceDeploymentInfoDTO;
+import io.github.ust.mico.core.dto.MicoServiceInterfaceStatusDTO;
+import io.github.ust.mico.core.dto.MicoServiceStatusDTO;
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoLabel;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo.ImagePullPolicy;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfoQueryResult;
+import io.github.ust.mico.core.model.MicoServiceInterface;
 import io.github.ust.mico.core.persistence.MicoApplicationRepository;
 import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
@@ -50,13 +69,57 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.JsonPathBuilder.EMBEDDED;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
+import static io.github.ust.mico.core.JsonPathBuilder.SELF_HREF;
+import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
+import static io.github.ust.mico.core.TestConstants.AVAILABLE_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION;
+import static io.github.ust.mico.core.TestConstants.ERROR_MESSAGES;
+import static io.github.ust.mico.core.TestConstants.GIT_TEST_REPO_URL;
+import static io.github.ust.mico.core.TestConstants.ID;
+import static io.github.ust.mico.core.TestConstants.ID_1;
+import static io.github.ust.mico.core.TestConstants.ID_2;
+import static io.github.ust.mico.core.TestConstants.ID_3;
+import static io.github.ust.mico.core.TestConstants.INTERFACES_INFORMATION;
+import static io.github.ust.mico.core.TestConstants.INTERFACES_INFORMATION_NAME;
+import static io.github.ust.mico.core.TestConstants.NAME;
+import static io.github.ust.mico.core.TestConstants.NODE_METRICS_AVERAGE_CPU_LOAD;
+import static io.github.ust.mico.core.TestConstants.NODE_METRICS_AVERAGE_MEMORY_USAGE;
+import static io.github.ust.mico.core.TestConstants.NODE_METRICS_NAME;
+import static io.github.ust.mico.core.TestConstants.OWNER;
+import static io.github.ust.mico.core.TestConstants.POD_INFO;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_AVAILABLE_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_AVAILABLE_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_CPU_LOAD_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_CPU_LOAD_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_MEMORY_USAGE_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_MEMORY_USAGE_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_NODE_NAME_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_NODE_NAME_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_PHASE_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_PHASE_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_POD_NAME_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_POD_NAME_2;
+import static io.github.ust.mico.core.TestConstants.REQUESTED_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.SDI_IMAGE_PULLPOLICY_PATH;
+import static io.github.ust.mico.core.TestConstants.SDI_LABELS_PATH;
+import static io.github.ust.mico.core.TestConstants.SDI_REPLICAS_PATH;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INFORMATION_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_VERSION;
 import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_OTHER;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_AVAILABLE_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_MICO_SERVICES;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_PODS;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_REQUESTED_REPLICAS;
 import static io.github.ust.mico.core.TestConstants.VERSION;
-import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -64,10 +127,17 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ApplicationController.class)
@@ -75,8 +145,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @EnableAutoConfiguration
 @EnableConfigurationProperties(value = {CorsConfig.class})
 public class ApplicationControllerTests {
-
-    private static final String JSON_PATH_LINKS_SECTION = "$._links.";
 
     public static final String APPLICATION_DTO_LIST_PATH = buildPath(EMBEDDED, "micoApplicationDTOList");
     public static final String APPLICATION_WITH_SERVICES_DTO_LIST_PATH = buildPath(EMBEDDED, "micoApplicationWithServicesDTOList");
@@ -89,6 +157,7 @@ public class ApplicationControllerTests {
     public static final String SERVICE_LIST_PATH = buildPath(ROOT, "services");
     public static final String INTERFACES_LIST_PATH = buildPath(ROOT, "serviceInterfaces");
     public static final String ID_PATH = buildPath(ROOT, "id");
+    private static final String JSON_PATH_LINKS_SECTION = "$._links.";
     private static final String BASE_PATH = "/applications";
     private static final String PATH_SERVICES = "services";
     private static final String PATH_DEPLOYMENT_INFORMATION = "deploymentInformation";
@@ -698,8 +767,12 @@ public class ApplicationControllerTests {
                 .setDescription(otherMicoApplication.getDescription())))
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusDTO().setName(SERVICE_INTERFACE_NAME)))
             .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2))
-            .setAverageCpuLoadPerNode(ImmutableMap.of(nodeName, 25))
-            .setAverageMemoryUsagePerNode(ImmutableMap.of(nodeName, 60));
+            .setNodeMetrics(CollectionUtils.listOf(
+                new KubernetesNodeMetricsDTO()
+                    .setNodeName(nodeName)
+                    .setAverageCpuLoad(25)
+                    .setAverageMemoryUsage(60)
+            ));
         micoApplicationStatus.getServiceStatuses().add(micoServiceStatus);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
@@ -717,8 +790,9 @@ public class ApplicationControllerTests {
             .andExpect(jsonPath(TOTAL_NUMBER_OF_REQUESTED_REPLICAS, is(replicas)))
             .andExpect(jsonPath(TOTAL_NUMBER_OF_PODS, is(2)))
             .andExpect(jsonPath(TOTAL_NUMBER_OF_MICO_SERVICES, is(1)))
-            .andExpect(jsonPath(AVERAGE_CPU_LOAD_PER_NODE_PATH, is(ImmutableMap.of(nodeName, 25))))
-            .andExpect(jsonPath(AVERAGE_MEMORY_USAGE_PER_NODE_PATH, is(ImmutableMap.of(nodeName, 60))))
+            .andExpect(jsonPath(NODE_METRICS_NAME, is(nodeName)))
+            .andExpect(jsonPath(NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
+            .andExpect(jsonPath(NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
             .andExpect(jsonPath(REQUESTED_REPLICAS, is(replicas)))
             .andExpect(jsonPath(AVAILABLE_REPLICAS, is(availableReplicas)))
             .andExpect(jsonPath(INTERFACES_INFORMATION, hasSize(1)))

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -19,7 +19,13 @@
 
 package io.github.ust.mico.core;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -27,7 +33,14 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.github.ust.mico.core.configuration.PrometheusConfig;
-import io.github.ust.mico.core.dto.*;
+import io.github.ust.mico.core.dto.KubernetesNodeMetricsDTO;
+import io.github.ust.mico.core.dto.KubernetesPodInformationDTO;
+import io.github.ust.mico.core.dto.KubernetesPodMetricsDTO;
+import io.github.ust.mico.core.dto.MicoApplicationDTO;
+import io.github.ust.mico.core.dto.MicoApplicationStatusDTO;
+import io.github.ust.mico.core.dto.MicoServiceInterfaceStatusDTO;
+import io.github.ust.mico.core.dto.MicoServiceStatusDTO;
+import io.github.ust.mico.core.dto.PrometheusResponse;
 import io.github.ust.mico.core.exception.KubernetesResourceException;
 import io.github.ust.mico.core.model.MicoApplication;
 import io.github.ust.mico.core.model.MicoService;
@@ -49,12 +62,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.*;
-
-import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.TestConstants.NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_OTHER;
+import static io.github.ust.mico.core.TestConstants.VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -230,7 +247,7 @@ public class MicoStatusServiceTest {
     }
 
     @Test
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void getApplicationStatus() {
         MicoApplicationStatusDTO micoApplicationStatus = new MicoApplicationStatusDTO();
         micoApplicationStatus
@@ -249,8 +266,16 @@ public class MicoStatusServiceTest {
                     .setShortName(otherMicoApplication.getShortName())
                     .setVersion(otherMicoApplication.getVersion())
                     .setDescription(otherMicoApplication.getDescription())))
-                .setAverageMemoryUsagePerNode(ImmutableMap.of(nodeName1, 60, nodeName2, 57))
-                .setAverageCpuLoadPerNode(ImmutableMap.of(nodeName1, 20, nodeName2, 7))
+                .setNodeMetrics(CollectionUtils.listOf(
+                    new KubernetesNodeMetricsDTO()
+                        .setNodeName(nodeName1)
+                        .setAverageCpuLoad(20)
+                        .setAverageMemoryUsage(60),
+                    new KubernetesNodeMetricsDTO()
+                        .setNodeName(nodeName2)
+                        .setAverageCpuLoad(7)
+                        .setAverageMemoryUsage(57)
+                ))
                 // Add four pods (on two different nodes)
                 .setPodsInformation(Arrays.asList(
                     new KubernetesPodInformationDTO()
@@ -353,8 +378,12 @@ public class MicoStatusServiceTest {
                     .setShortName(otherMicoApplication.getShortName())
                     .setVersion(otherMicoApplication.getVersion())
                     .setDescription(otherMicoApplication.getDescription())))
-                .setAverageMemoryUsagePerNode(ImmutableMap.of(nodeName1, 70))
-                .setAverageCpuLoadPerNode(ImmutableMap.of(nodeName1, 30))
+                .setNodeMetrics(CollectionUtils.listOf(
+                    new KubernetesNodeMetricsDTO()
+                        .setNodeName(nodeName1)
+                        .setAverageCpuLoad(30)
+                        .setAverageMemoryUsage(70)
+                ))
                 // Add four pods (on two different nodes)
                 .setPodsInformation(CollectionUtils.listOf(
                     new KubernetesPodInformationDTO()
@@ -429,7 +458,7 @@ public class MicoStatusServiceTest {
     }
 
     @Test
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void getServiceStatus() {
         MicoServiceStatusDTO micoServiceStatus = new MicoServiceStatusDTO();
         micoServiceStatus
@@ -443,8 +472,16 @@ public class MicoStatusServiceTest {
                 .setShortName(otherMicoApplication.getShortName())
                 .setVersion(otherMicoApplication.getVersion())
                 .setDescription(otherMicoApplication.getDescription())))
-            .setAverageMemoryUsagePerNode(ImmutableMap.of(nodeName1, 60, nodeName2, 57))
-            .setAverageCpuLoadPerNode(ImmutableMap.of(nodeName1, 20, nodeName2, 7))
+            .setNodeMetrics(CollectionUtils.listOf(
+                new KubernetesNodeMetricsDTO()
+                    .setNodeName(nodeName1)
+                    .setAverageCpuLoad(20)
+                    .setAverageMemoryUsage(60),
+                new KubernetesNodeMetricsDTO()
+                    .setNodeName(nodeName2)
+                    .setAverageCpuLoad(7)
+                    .setAverageMemoryUsage(57)
+            ))
             // Add four pods (on two different nodes)
             .setPodsInformation(Arrays.asList(
                 new KubernetesPodInformationDTO()

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -23,7 +23,9 @@ import io.github.ust.mico.core.dto.MicoApplicationStatusDTO;
 import io.github.ust.mico.core.dto.MicoServiceStatusDTO;
 import io.github.ust.mico.core.model.MicoVersion;
 
-import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
+import static io.github.ust.mico.core.JsonPathBuilder.buildAttributePath;
+import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
 
 public class TestConstants {
 
@@ -93,14 +95,17 @@ public class TestConstants {
      * All paths are build on the path for the status of this service.
      */
     /**
-     * Path of a single {@link MicoServiceStatusDTO} in a {@link MicoApplicationStatusDTO}. Contains status information for this service.
+     * Path of a single {@link MicoServiceStatusDTO} in a {@link MicoApplicationStatusDTO}. Contains status information
+     * for this service.
      */
     public static final String SERVICE_STATUS_PATH = buildPath(ROOT, "serviceStatuses[0]");
     public static final String SERVICE_INFORMATION_NAME = buildPath(SERVICE_STATUS_PATH, "name");
     public static final String REQUESTED_REPLICAS = buildPath(SERVICE_STATUS_PATH, "requestedReplicas");
     public static final String AVAILABLE_REPLICAS = buildPath(SERVICE_STATUS_PATH, "availableReplicas");
-    public static final String AVERAGE_CPU_LOAD_PER_NODE_PATH = buildPath(SERVICE_STATUS_PATH, "averageCpuLoadPerNode");
-    public static final String AVERAGE_MEMORY_USAGE_PER_NODE_PATH = buildPath(SERVICE_STATUS_PATH, "averageMemoryUsagePerNode");
+    public static final String NODE_METRICS_PATH_FIRST_ELEMENT = buildPath(SERVICE_STATUS_PATH, "nodeMetrics[0]");
+    public static final String NODE_METRICS_NAME = buildPath(NODE_METRICS_PATH_FIRST_ELEMENT, "nodeName");
+    public static final String NODE_METRICS_AVERAGE_CPU_LOAD = buildPath(NODE_METRICS_PATH_FIRST_ELEMENT, "averageCpuLoad");
+    public static final String NODE_METRICS_AVERAGE_MEMORY_USAGE = buildPath(NODE_METRICS_PATH_FIRST_ELEMENT, "averageMemoryUsage");
     public static final String ERROR_MESSAGES = buildPath(SERVICE_STATUS_PATH, "errorMessages");
     public static final String INTERFACES_INFORMATION = buildPath(SERVICE_STATUS_PATH, "interfacesInformation");
     public static final String INTERFACES_INFORMATION_NAME = buildPath(SERVICE_STATUS_PATH, "interfacesInformation[0].name");
@@ -130,8 +135,10 @@ public class TestConstants {
     public static final String SERVICE_DTO_SERVICE_NAME = buildAttributePath("name");
     public static final String SERVICE_DTO_REQUESTED_REPLICAS = buildPath(ROOT, "requestedReplicas");
     public static final String SERVICE_DTO_AVAILABLE_REPLICAS = buildPath(ROOT, "availableReplicas");
-    public static final String SERVICE_DTO_AVERAGE_CPU_LOAD_PER_NODE = buildPath(ROOT, "averageCpuLoadPerNode");
-    public static final String SERVICE_DTO_AVERAGE_MEMORY_USAGE_PER_NODE = buildPath(ROOT, "averageMemoryUsagePerNode");
+    public static final String SERVICE_DTO_NODE_METRICS = buildPath(ROOT, "nodeMetrics[0]");
+    public static final String SERVICE_DTO_NODE_NAME = buildPath(SERVICE_DTO_NODE_METRICS, "nodeName");
+    public static final String SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD = buildPath(SERVICE_DTO_NODE_METRICS, "averageCpuLoad");
+    public static final String SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE = buildPath(SERVICE_DTO_NODE_METRICS, "averageMemoryUsage");
     public static final String SERVICE_DTO_ERROR_MESSAGES = buildPath(ROOT, "errorMessages");
     public static final String SERVICE_DTO_INTERFACES_INFORMATION = buildPath(ROOT, "interfacesInformation");
     public static final String SERVICE_DTO_INTERFACES_INFORMATION_NAME = buildPath(ROOT, "interfacesInformation[0].name");


### PR DESCRIPTION
- [X] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Ensure to use auto format in **all** files
- [X] Tests created for changes

---

## Short Description

For an improved handling in the frontend, the separated maps for average CPU and memory values per node in a MicoServiceStatusDTO are replaced with a list of KubernetesNodeMetricsDTOs.

## Resolving Issue/ Feature

Resolves #523 

<!-- Reference to the respective issue -->
