### PR TITLE
Fix Regex for validation of Semantic Versioning

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/util/Patterns.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/Patterns.java
@@ -115,7 +115,7 @@ public class Patterns {
     /**
      * Regex for a semantic version with a prefix (optional) consisting of letters. 
      */
-    public static final String SEMANTIC_VERSION_WITH_PREFIX_REGEX = "^[a-zA-Z]*" + SEMANTIC_VERSION_REGEX + "$";
+    public static final String SEMANTIC_VERSION_WITH_PREFIX_REGEX = "^[a-zA-Z]*" + SEMANTIC_VERSION_TEMP_REGEX + "$";
 
     /**
      * Message is used if a match with the {@link Patterns#SEMANTIC_VERSION_WITH_PREFIX_REGEX} fails.


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files

---

## Short Description

<!-- Summarize the new functionalities/fixes -->

Fixes wrong regex for validation of Semantic Versioning.
Bug was introduced with #455 