### PR TITLE
Bump fabric8 Kubernetes to version 4.1.3

### DIFF
--- a/mico-core/pom.xml
+++ b/mico-core/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
-            <version>1.0.0.RELEASE</version>
+            <version>1.0.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
@@ -83,12 +83,12 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>4.1.2</version>
+            <version>4.1.3</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
-            <version>4.1.2</version>
+            <version>4.1.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## Short Description

<!-- Summarize the new functionalities/fixes -->

Updates two dependencies:
* fabric8 Kuberentes: 4.1.2 → 4.1.3
* Spring Cloud Starter Kubernetes Config: 1.0.0 → 1.0.1