### PR TITLE
Fix max size limit of shortNames

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoApplicationRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoApplicationRequestDTO.java
@@ -61,12 +61,12 @@ public class MicoApplicationRequestDTO {
             @ExtensionProperty(name = "title", value = "Short Name"),
             @ExtensionProperty(name = "pattern", value = Patterns.KUBERNETES_NAMING_REGEX),
             @ExtensionProperty(name = "minLength", value = "3"),
-            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MAX_LABLE_SIZE+""),
+            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MICO_NAME_MAX_SIZE +""),
             @ExtensionProperty(name = "x-order", value = "10"),
             @ExtensionProperty(name = "description", value = "Unique short name of the application.")
         }
     )})
-    @Size(min = 3, max = KubernetesNameNormalizer.MAX_LABLE_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MAX_LABLE_SIZE)
+    @Size(min = 3, max = KubernetesNameNormalizer.MICO_NAME_MAX_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MICO_NAME_MAX_SIZE)
     @Pattern(regexp = Patterns.KUBERNETES_NAMING_REGEX, message = Patterns.KUBERNETES_NAMING_MESSAGE)
     private String shortName;
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoApplicationRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoApplicationRequestDTO.java
@@ -22,6 +22,7 @@ package io.github.ust.mico.core.dto.request;
 import com.fasterxml.jackson.annotation.*;
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.util.KubernetesNameNormalizer;
 import io.github.ust.mico.core.util.Patterns;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.Extension;
@@ -60,12 +61,12 @@ public class MicoApplicationRequestDTO {
             @ExtensionProperty(name = "title", value = "Short Name"),
             @ExtensionProperty(name = "pattern", value = Patterns.KUBERNETES_NAMING_REGEX),
             @ExtensionProperty(name = "minLength", value = "3"),
-            @ExtensionProperty(name = "maxLength", value = "253"),
+            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MAX_LABLE_SIZE+""),
             @ExtensionProperty(name = "x-order", value = "10"),
             @ExtensionProperty(name = "description", value = "Unique short name of the application.")
         }
     )})
-    @Size(min = 3, max = 253, message = "must have a length between 3 and 253")
+    @Size(min = 3, max = KubernetesNameNormalizer.MAX_LABLE_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MAX_LABLE_SIZE)
     @Pattern(regexp = Patterns.KUBERNETES_NAMING_REGEX, message = Patterns.KUBERNETES_NAMING_MESSAGE)
     private String shortName;
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceInterfaceRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceInterfaceRequestDTO.java
@@ -66,11 +66,11 @@ public class MicoServiceInterfaceRequestDTO {
             @ExtensionProperty(name = "x-order", value = "20"),
             @ExtensionProperty(name = "description", value = "The name of this MicoServiceInterface"),
             @ExtensionProperty(name = "minLength", value = "3"),
-            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MAX_LABLE_SIZE+""),
+            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MICO_NAME_MAX_SIZE +""),
         }
     )})
     @NotNull
-    @Size(min = 3, max = KubernetesNameNormalizer.MAX_LABLE_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MAX_LABLE_SIZE)
+    @Size(min = 3, max = KubernetesNameNormalizer.MICO_NAME_MAX_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MICO_NAME_MAX_SIZE)
     @Pattern(regexp = Patterns.KUBERNETES_NAMING_REGEX, message = Patterns.KUBERNETES_NAMING_MESSAGE)
     private String serviceInterfaceName;
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceInterfaceRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceInterfaceRequestDTO.java
@@ -27,9 +27,11 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.util.KubernetesNameNormalizer;
 import io.github.ust.mico.core.util.Patterns;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.Extension;
@@ -62,10 +64,13 @@ public class MicoServiceInterfaceRequestDTO {
             @ExtensionProperty(name = "title", value = "Service Interface Name"),
             @ExtensionProperty(name = "pattern", value = Patterns.KUBERNETES_NAMING_REGEX),
             @ExtensionProperty(name = "x-order", value = "20"),
-            @ExtensionProperty(name = "description", value = "The name of this MicoServiceInterface")
+            @ExtensionProperty(name = "description", value = "The name of this MicoServiceInterface"),
+            @ExtensionProperty(name = "minLength", value = "3"),
+            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MAX_LABLE_SIZE+""),
         }
     )})
     @NotNull
+    @Size(min = 3, max = KubernetesNameNormalizer.MAX_LABLE_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MAX_LABLE_SIZE)
     @Pattern(regexp = Patterns.KUBERNETES_NAMING_REGEX, message = Patterns.KUBERNETES_NAMING_MESSAGE)
     private String serviceInterfaceName;
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceRequestDTO.java
@@ -24,6 +24,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import io.github.ust.mico.core.util.KubernetesNameNormalizer;
 import org.hibernate.validator.constraints.URL;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -69,12 +70,12 @@ public class MicoServiceRequestDTO {
             @ExtensionProperty(name = "title", value = "Short Name"),
             @ExtensionProperty(name = "pattern", value = Patterns.KUBERNETES_NAMING_REGEX),
             @ExtensionProperty(name = "minLength", value = "3"),
-            @ExtensionProperty(name = "maxLength", value = "253"),
+            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MAX_LABLE_SIZE+""),
             @ExtensionProperty(name = "x-order", value = "10"),
             @ExtensionProperty(name = "description", value = "A unique name of the MicoService.")
         }
     )})
-    @Size(min = 3, max = 253, message = "must have a length between 3 and 253")
+    @Size(min = 3, max = KubernetesNameNormalizer.MAX_LABLE_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MAX_LABLE_SIZE)
     @Pattern(regexp = Patterns.KUBERNETES_NAMING_REGEX, message = Patterns.KUBERNETES_NAMING_MESSAGE)
     private String shortName;
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceRequestDTO.java
@@ -70,12 +70,12 @@ public class MicoServiceRequestDTO {
             @ExtensionProperty(name = "title", value = "Short Name"),
             @ExtensionProperty(name = "pattern", value = Patterns.KUBERNETES_NAMING_REGEX),
             @ExtensionProperty(name = "minLength", value = "3"),
-            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MAX_LABLE_SIZE+""),
+            @ExtensionProperty(name = "maxLength", value = KubernetesNameNormalizer.MICO_NAME_MAX_SIZE +""),
             @ExtensionProperty(name = "x-order", value = "10"),
             @ExtensionProperty(name = "description", value = "A unique name of the MicoService.")
         }
     )})
-    @Size(min = 3, max = KubernetesNameNormalizer.MAX_LABLE_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MAX_LABLE_SIZE)
+    @Size(min = 3, max = KubernetesNameNormalizer.MICO_NAME_MAX_SIZE, message = "must have a length between 3 and " + KubernetesNameNormalizer.MICO_NAME_MAX_SIZE)
     @Pattern(regexp = Patterns.KUBERNETES_NAMING_REGEX, message = Patterns.KUBERNETES_NAMING_MESSAGE)
     private String shortName;
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/util/KubernetesNameNormalizer.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/KubernetesNameNormalizer.java
@@ -37,7 +37,7 @@ public class KubernetesNameNormalizer {
     private final static String REGEX_MULTIPLE_DASHES = "[-]+";
     private final static String REGEX_FIRST_OR_LAST_CHAR_IS_A_DASH = "^-|-$";
     private final static String REGEX_MATCH_VALID_FIRST_CHAR = "^[a-z]+.*";
-    public final static int MAX_LABLE_SIZE = 63;
+    public final static int MAX_LABLE_SIZE = 54;
 
     /**
      * Normalizes a name so it is a valid Kubernetes resource name.

--- a/mico-core/src/main/java/io/github/ust/mico/core/util/KubernetesNameNormalizer.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/KubernetesNameNormalizer.java
@@ -37,6 +37,7 @@ public class KubernetesNameNormalizer {
     private final static String REGEX_MULTIPLE_DASHES = "[-]+";
     private final static String REGEX_FIRST_OR_LAST_CHAR_IS_A_DASH = "^-|-$";
     private final static String REGEX_MATCH_VALID_FIRST_CHAR = "^[a-z]+.*";
+    public final static int MAX_LABLE_SIZE = 63;
 
     /**
      * Normalizes a name so it is a valid Kubernetes resource name.
@@ -69,7 +70,7 @@ public class KubernetesNameNormalizer {
             result = "short-name-" + s8;
         }
 
-        if (!result.matches(Patterns.KUBERNETES_NAMING_REGEX) || result.length() > 253) {
+        if (!result.matches(Patterns.KUBERNETES_NAMING_REGEX) || result.length() > MAX_LABLE_SIZE) {
             throw new IllegalArgumentException("Name '" + name + "' could not be normalized correctly");
         }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/util/KubernetesNameNormalizer.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/KubernetesNameNormalizer.java
@@ -22,6 +22,9 @@ package io.github.ust.mico.core.util;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceInterface;
 import org.springframework.stereotype.Component;
 
 /**
@@ -37,7 +40,13 @@ public class KubernetesNameNormalizer {
     private final static String REGEX_MULTIPLE_DASHES = "[-]+";
     private final static String REGEX_FIRST_OR_LAST_CHAR_IS_A_DASH = "^-|-$";
     private final static String REGEX_MATCH_VALID_FIRST_CHAR = "^[a-z]+.*";
-    public final static int MAX_LABLE_SIZE = 54;
+
+    /**
+     * A max limit of the MICO names ({@link MicoApplication}, {@link MicoService} and {@link MicoServiceInterface}) is
+     * required because they are used as values of Kubernetes labels that have a limit of 63. Furthermore the name is
+     * used to create a UID that adds 9 characters to it. Therefore the limit have to be set to 54.
+     */
+    public final static int MICO_NAME_MAX_SIZE = 54;
 
     /**
      * Normalizes a name so it is a valid Kubernetes resource name.
@@ -70,7 +79,7 @@ public class KubernetesNameNormalizer {
             result = "short-name-" + s8;
         }
 
-        if (!result.matches(Patterns.KUBERNETES_NAMING_REGEX) || result.length() > MAX_LABLE_SIZE) {
+        if (!result.matches(Patterns.KUBERNETES_NAMING_REGEX) || result.length() > MICO_NAME_MAX_SIZE) {
             throw new IllegalArgumentException("Name '" + name + "' could not be normalized correctly");
         }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/KubernetesNameNormalizerTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/KubernetesNameNormalizerTests.java
@@ -59,8 +59,12 @@ public class KubernetesNameNormalizerTests {
             equalTo("first-second"));
 
         collector.checkThat("Combined characters should be replaced",
-            normalizer.normalizeName("r̀r̂r̃r̈rʼŕřt̀t̂ẗţỳỹẙyʼy̎ýÿŷp̂p̈s̀s̃s̈s̊sʼs̸śŝŞşšd̂d̃d̈ďdʼḑf̈f̸g̀g̃g̈gʼģq\u200C\u200B́ĝǧḧĥj̈jʼḱk̂k̈k̸ǩl̂l̃l̈Łłẅẍc̃c̈c̊cʼc̸Çççćĉčv̂v̈vʼv̸b́b̧ǹn̂n̈n̊nʼńņňñm̀m̂m̃m̈\u200C\u200Bm̊m̌ǵß"),
-            equalTo("rrrrrrrttttyyyyyyyyppsssssssssssddddddffgggggqgghhjjkkkkklllwxcccccccccccvvvvbbnnnnnnnnnmmmmmmg"));
+            normalizer.normalizeName("r̀r̂r̃r̈rʼŕřt̀t̂ẗţỳỹẙyʼy̎ýÿŷp̂p̈s̀s̃s̈s̊sʼs̸śŝŞşšd̂d̃d̈ďdʼḑf̈f̸g̀g̃g̈gʼģq\u200C\u200B́ĝǧḧĥ"),
+            equalTo("rrrrrrrttttyyyyyyyyppsssssssssssddddddffgggggqgghh"));
+
+        collector.checkThat("Combined characters should be replaced",
+            normalizer.normalizeName("j̈jʼḱk̂k̈k̸ǩl̂l̃l̈Łłẅẍc̃c̈c̊cʼc̸Çççćĉčv̂v̈vʼv̸b́b̧ǹn̂n̈n̊nʼńņňñm̀m̂m̃m̈\u200C\u200Bm̊m̌ǵß"),
+            equalTo("jjkkkkklllwxcccccccccccvvvvbbnnnnnnnnnmmmmmmg"));
 
         collector.checkThat("Special characters '_' and '.' should be replaced by a dash",
             normalizer.normalizeName("name.js_notes"),
@@ -85,5 +89,10 @@ public class KubernetesNameNormalizerTests {
         collector.checkThat("Last character is a dash",
             normalizer.normalizeName("name-"),
             equalTo("name"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void nameToLong() {
+        normalizer.normalizeName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"); //55 chars
     }
 }


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [X] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Ensure to use auto format in **all** files
- [X] Tests created for changes or:
  - [ ] Test cases are missing - opened issue for that:
  - [ ] Reason for missing tests:
- [ ] Screenshots added (for UI changes)
- [ ] Change in CHANGELOG.md described

---

## Short Description

Sets the new max size for shortNames to ~~63~~. A limit of 54 is necessary because a UID is generated and concatenated with the shortName to form a label.

## Resolving Issue/ Feature

Closes #560
