### PR TITLE
Fix service in more than one version can be included by an application

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
@@ -54,29 +54,6 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
         @Param("applicationVersion") String applicationVersion);
     
     /**
-     * Retrieves the deployment information for a particular application and service. 
-     * 
-     * @param applicationShortName the short name of the {@link MicoApplication}.
-     * @param applicationVersion the version of the {@link MicoApplication}.
-     * @param serviceShortName the short name of the {@link MicoService}.
-     * @return an {@link Optional} of {@link MicoServiceDeploymentInfo}.
-     */
-    @Query("MATCH (a:MicoApplication)-[:PROVIDES]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
-    	+ "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
-		+ "AND s.shortName = {serviceShortName} " 
-    	+ "WITH a, sdi , s OPTIONAL MATCH (sdi)-[:HAS]->(label:MicoLabel) "
-    	+ "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
-		+ "AND s.shortName = {serviceShortName} " 
-    	+ "WITH a, sdi , s OPTIONAL MATCH (sdi)-[:HAS]->(env:MicoEnvironmentVariable) "
-        + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
-        + "AND s.shortName = {serviceShortName} "
-        + "RETURN (sdi:MicoServiceDeploymentInfo)-->()")
-    Optional<MicoServiceDeploymentInfo> findByApplicationAndService(
-        @Param("applicationShortName") String applicationShortName,
-        @Param("applicationVersion") String applicationVersion,
-        @Param("serviceShortName") String serviceShortName);
-    
-    /**
      * Retrieves the deployment information for a particular application and service.
      * 
      * @param applicationShortName the short name of the {@link MicoApplication}.

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
@@ -110,29 +110,7 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
     void deleteAllByApplication(
     	@Param("applicationShortName") String applicationShortName,
         @Param("applicationVersion") String applicationVersion);
-    
-    /**
-     * Deletes the deployment information for a particular application and service.
-     * All additional properties of a {@link MicoServiceDeploymentInfo} that
-     * are stored as a separate node entity and connected to it via a {@code [:HAS]}
-     * relationship will be deleted, too.
-     * 
-     * @param applicationShortName the short name of the {@link MicoApplication}.
-     * @param applicationVersion the version of the {@link MicoApplication}.
-     * @param serviceShortName the short name of the {@link MicoService}.
-     */
-	@Query("MATCH (a:MicoApplication)-[:PROVIDES]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
-		+ "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
-		+ "AND s.shortName = {serviceShortName} " 
-		+ "WITH a, sdi, s OPTIONAL MATCH (sdi)-[:HAS]->(additionalProperty) "
-	    + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
-	    + "AND s.shortName = {serviceShortName} " 
-	    + "DETACH DELETE sdi, additionalProperty")
-    void deleteByApplicationAndService(
-    	@Param("applicationShortName") String applicationShortName,
-        @Param("applicationVersion") String applicationVersion,
-        @Param("serviceShortName") String serviceShortName);
-	
+
     /**
      * Deletes the deployment information for a particular application and service.
      * All additional properties of a {@link MicoServiceDeploymentInfo} that

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceTests.java
@@ -743,7 +743,7 @@ public class ApplicationResourceTests {
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME))
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME, SERVICE_VERSION))
             .willReturn(Optional.of(application.getServiceDeploymentInfos().get(0)));
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
@@ -773,9 +773,10 @@ public class ApplicationResourceTests {
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 		given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(),
-		    application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+		    application.getVersion(), service.getShortName(), service.getVersion())).willReturn(Optional.of(serviceDeploymentInfo));
 
-        mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
+        mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/"
+            + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName() + "/" + service.getVersion()))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
@@ -817,10 +818,11 @@ public class ApplicationResourceTests {
 
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
         given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName(), service.getVersion())).willReturn(Optional.of(serviceDeploymentInfo));
         given(serviceDeploymentInfoRepository.save(eq(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO)))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
 
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/"
+            + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName() + "/" + service.getVersion())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -906,7 +908,8 @@ public class ApplicationResourceTests {
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion()))
             .willReturn(Optional.of(application));
 
-        final ResultActions result = mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+        final ResultActions result = mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion()
+            + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName() + "/" + service.getVersion())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print());

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceTests.java
@@ -746,7 +746,7 @@ public class ApplicationResourceTests {
         given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME, SERVICE_VERSION))
             .willReturn(Optional.of(application.getServiceDeploymentInfos().get(0)));
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
+        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isNoContent());
     }


### PR DESCRIPTION
A MicoApplication can bind multiple MicoServices with the same short name but different versions at the same time. See #390 for an example.
Therefore the same applies for the service deployment information.

Changed REST endpoints:
* getServiceDeploymentInformation: `GET /applications/{applicationShortName}/{applicationVersion}/deploymentInformation/{serviceShortName}`
  → `GET /applications/{applicationShortName}/{applicationVersion}/deploymentInformation/{serviceShortName}/{serviceVersion}`
* updateServiceDeploymentInformation: `POST /applications/{applicationShortName}/{applicationVersion}/deploymentInformation/{serviceShortName}`
  → `POST /applications/{applicationShortName}/{applicationVersion}/deploymentInformation/{serviceShortName}/{serviceVersion}`
* deleteServiceFromApplication: `DELETE /applications/{applicationShortName}/{applicationVersion}/services/{serviceShortName}`
  → `GET /applications/{applicationShortName}/{applicationVersion}/services/{serviceShortName}/{serviceVersion}`

@buehlefs / @gepperho Please adapt the UI accordingly. 