### PR TITLE
Fix naming of Kubernetes Build now using service version

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/service/imagebuilder/ImageBuilder.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/imagebuilder/ImageBuilder.java
@@ -33,6 +33,7 @@ import io.github.ust.mico.core.exception.NotInitializedException;
 import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.service.imagebuilder.buildtypes.*;
 import io.github.ust.mico.core.util.CollectionUtils;
+import io.github.ust.mico.core.util.KubernetesNameNormalizer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -55,19 +56,24 @@ public class ImageBuilder {
 
     private final MicoKubernetesBuildBotConfig buildBotConfig;
     private final KubernetesClient kubernetesClient;
+    private final KubernetesNameNormalizer kubernetesNameNormalizer;
 
     private NonNamespaceOperation<Build, BuildList, DoneableBuild, Resource<Build, DoneableBuild>> buildClient;
     private ScheduledExecutorService scheduledBuildStatusCheckService;
 
 
     /**
-     * @param kubernetesClient The Kubernetes client object
-     * @param buildBotConfig   The build bot configuration for the image builder
+     * Create a {@code ImageBuilder} to be able to build Docker images in the cluster.
+     *
+     * @param kubernetesClient         the {@link KubernetesClient}
+     * @param buildBotConfig           the build bot configuration for the image builder
+     * @param kubernetesNameNormalizer the {@link KubernetesNameNormalizer}
      */
     @Autowired
-    public ImageBuilder(KubernetesClient kubernetesClient, MicoKubernetesBuildBotConfig buildBotConfig) {
+    public ImageBuilder(KubernetesClient kubernetesClient, MicoKubernetesBuildBotConfig buildBotConfig, KubernetesNameNormalizer kubernetesNameNormalizer) {
         this.kubernetesClient = kubernetesClient;
         this.buildBotConfig = buildBotConfig;
+        this.kubernetesNameNormalizer = kubernetesNameNormalizer;
     }
 
     /**
@@ -156,13 +162,12 @@ public class ImageBuilder {
 
         String namespace = buildBotConfig.getNamespaceBuildExecution();
 
-        String buildName = createBuildName(micoService.getShortName());
+        String buildName = createBuildName(micoService.getShortName(), micoService.getVersion());
         String destination = createImageName(micoService.getShortName(), micoService.getVersion());
         String dockerfilePath;
         if (!StringUtils.isEmpty(micoService.getDockerfilePath())) {
             dockerfilePath = "/workspace/" + micoService.getDockerfilePath();
         } else {
-            // TODO check if a Dockerfile is placed in the root directory of the Git repository
             log.warn("Path to Dockerfile of MicoService '{}' is unknown. Try to use 'Dockerfile' in the root directory.", micoService.getShortName());
             dockerfilePath = "/workspace/Dockerfile";
         }
@@ -277,11 +282,12 @@ public class ImageBuilder {
     /**
      * Creates a build name based on the service name.
      *
-     * @param serviceName the name of the MICO service
-     * @return the build name
+     * @param serviceName    the name of the MICO service
+     * @param serviceVersion the name of the MICO service
+     * @return the name of the build
      */
-    private String createBuildName(String serviceName) {
-        return "build-" + serviceName;
+    private String createBuildName(String serviceName, String serviceVersion) {
+        return kubernetesNameNormalizer.normalizeName("build-" + serviceName + "-" + serviceVersion);
     }
 
     /**

--- a/mico-core/src/test/java/io/github/ust/mico/core/ImageBuilderTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ImageBuilderTests.java
@@ -19,8 +19,13 @@
 
 package io.github.ust.mico.core;
 
-import static io.github.ust.mico.core.TestConstants.*;
-
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.github.ust.mico.core.TestConstants.*;
+import io.github.ust.mico.core.configuration.MicoKubernetesBuildBotConfig;
+import io.github.ust.mico.core.exception.NotInitializedException;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.service.imagebuilder.ImageBuilder;
+import io.github.ust.mico.core.util.KubernetesNameNormalizer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,12 +34,7 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import io.github.ust.mico.core.TestConstants.IntegrationTest;
-import io.github.ust.mico.core.configuration.MicoKubernetesBuildBotConfig;
-import io.github.ust.mico.core.exception.NotInitializedException;
-import io.github.ust.mico.core.model.MicoService;
-import io.github.ust.mico.core.service.imagebuilder.ImageBuilder;
+import static io.github.ust.mico.core.TestConstants.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -53,7 +53,8 @@ public class ImageBuilderTests {
         buildBotConfig.setDockerRegistryServiceAccountName("service-account-name");
         buildBotConfig.setDockerImageRepositoryUrl("image-repository-url");
 
-        imageBuilder = new ImageBuilder(mockServer.getClient(), buildBotConfig);
+        KubernetesNameNormalizer kubernetesNameNormalizer = new KubernetesNameNormalizer();
+        imageBuilder = new ImageBuilder(mockServer.getClient(), buildBotConfig, kubernetesNameNormalizer);
     }
 
     @After


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Tests created for changes

---

## Short Description

<!-- Summarize the new functionalities/fixes -->

Fixes naming of Kubernetes Builds using also the version of a *MicoService*.

## Resolving Issue/ Feature

<!-- Reference to the respective issue -->

Resolves #586