### PR TITLE
Fix NP if no replicas are available

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -61,7 +61,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Provides functionality to retrieve status information for a {@link MicoApplication} or a particular {@link
- * MicoService}
+ * MicoService}.
  */
 @Slf4j
 @Component
@@ -87,7 +87,7 @@ public class MicoStatusService {
     }
 
     /**
-     * Get status information for a {@link MicoApplication}
+     * Get status information for a {@link MicoApplication}.
      *
      * @param micoApplication the application the status is requested for
      * @return {@link MicoApplicationStatusResponseDTO} containing a list of {@link MicoServiceStatusResponseDTO} for
@@ -120,10 +120,11 @@ public class MicoStatusService {
 
     /**
      * Get status information for a single {@link MicoService}: # available replicas, # requested replicas, pod metrics
-     * (cpu load, memory load)
+     * (CPU load, memory usage).
      *
-     * @param micoService is a {@link MicoService}
-     * @return {@link MicoServiceStatusResponseDTO} which contains status information for a specific {@link MicoService}
+     * @param micoService is a {@link MicoService}.
+     * @return {@link MicoServiceStatusResponseDTO} which contains status information for a specific {@link
+     * MicoService}.
      */
     public MicoServiceStatusResponseDTO getServiceStatus(MicoService micoService) {
         MicoServiceStatusResponseDTO serviceStatus = new MicoServiceStatusResponseDTO();
@@ -270,9 +271,9 @@ public class MicoStatusService {
     /**
      * Get information and metrics for a {@link Pod} representing an instance of a {@link MicoService}.
      *
-     * @param pod is a {@link Pod} of Kubernetes
+     * @param pod is a {@link Pod} of Kubernetes.
      * @return a {@link KubernetesPodInformationResponseDTO} which has node name, pod name, phase, host ip, memory
-     * usage, and cpu load as status information
+     * usage, and CPU load as status information.
      */
     private KubernetesPodInformationResponseDTO getUiPodInfo(Pod pod) {
         String nodeName = pod.getSpec().getNodeName();

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -133,7 +133,11 @@ public class MicoStatusService {
                 Deployment deployment = deploymentOptional.get();
                 serviceStatus.setRequestedReplicas(deployment.getSpec().getReplicas());
                 // Check if there are no replicas available of the deployment of a MicoService.
-                if ((deployment.getStatus().getUnavailableReplicas() != null) &&
+                if (deployment.getStatus().getUnavailableReplicas() == null) {
+                    log.info("The MicoService '{}' with version '{}' has '{}' available replicas.",
+                        micoService.getShortName(), micoService.getVersion(), deployment.getStatus().getAvailableReplicas());
+                    serviceStatus.setAvailableReplicas(deployment.getStatus().getAvailableReplicas());
+                } else if ((deployment.getStatus().getUnavailableReplicas() != null) &&
                     deployment.getStatus().getUnavailableReplicas() < deployment.getSpec().getReplicas()) {
                     log.info("The MicoService '{}' with version '{}' has '{}' available replicas.",
                         micoService.getShortName(), micoService.getVersion(), deployment.getStatus().getAvailableReplicas());


### PR DESCRIPTION
- [X] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Ensure to use auto format in **all** files

---

## Short Description

If no replica of a deployment is available in Kubernetes (e.g. a pod crashed and can not be restarted), MicoStatusService produced a NullPointerException when requesting the available replicas. This issue is fixed by a short check, if there are more available replicas than unavailabe ones.

## Resolving Issue/ Feature

Fixes #598 

<!-- Reference to the respective issue -->
