### PR TITLE
Fix update of service deployment information

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -257,21 +257,22 @@ public class ApplicationResource {
                                                                                                              @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                                                                              @PathVariable(PATH_VARIABLE_SERVICE_SHORT_NAME) String serviceShortName,
                                                                                                              @Valid @RequestBody MicoServiceDeploymentInfoRequestDTO serviceDeploymentInfoRequestDto) {
-        MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDto;
+        MicoServiceDeploymentInfo updatedServiceDeploymentInfo;
         try {
-            MicoServiceDeploymentInfo updatedServiceDeploymentInfo = broker.updateMicoServiceDeploymentInformation(
+            updatedServiceDeploymentInfo = broker.updateMicoServiceDeploymentInformation(
                 shortName, version, serviceShortName, serviceDeploymentInfoRequestDto);
-            updatedServiceDeploymentInfoDto = new MicoServiceDeploymentInfoResponseDTO(updatedServiceDeploymentInfo);
         } catch (MicoApplicationNotFoundException | MicoServiceDeploymentInformationNotFoundException
-        	| KubernetesResourceException e) {
+            | KubernetesResourceException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationDoesNotIncludeMicoServiceException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
 
+        // Convert to service deployment info DTO and return it
+        MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDto = new MicoServiceDeploymentInfoResponseDTO(updatedServiceDeploymentInfo);
         return ResponseEntity.ok(new Resource<>(updatedServiceDeploymentInfoDto,
-                linkTo(methodOn(ApplicationResource.class).getServiceDeploymentInformation(shortName, version, serviceShortName))
-                        .withSelfRel()));
+            linkTo(methodOn(ApplicationResource.class).getServiceDeploymentInformation(shortName, version, serviceShortName))
+                .withSelfRel()));
     }
     
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_DEPLOYMENT_STATUS)

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -257,12 +257,11 @@ public class ApplicationResource {
                                                                                                              @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                                                                              @PathVariable(PATH_VARIABLE_SERVICE_SHORT_NAME) String serviceShortName,
                                                                                                              @Valid @RequestBody MicoServiceDeploymentInfoRequestDTO serviceDeploymentInfoRequestDto) {
-        MicoServiceDeploymentInfoResponseDTO serviceDeploymentInfoDto;
-        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo().applyValuesFrom(serviceDeploymentInfoRequestDto);
+        MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDto;
         try {
-        	
-			serviceDeploymentInfoDto = new MicoServiceDeploymentInfoResponseDTO(broker
-			    .updateMicoServiceDeploymentInformation(shortName, version, serviceShortName, serviceDeploymentInfo));
+            MicoServiceDeploymentInfo updatedServiceDeploymentInfo = broker.updateMicoServiceDeploymentInformation(
+                shortName, version, serviceShortName, serviceDeploymentInfoRequestDto);
+            updatedServiceDeploymentInfoDto = new MicoServiceDeploymentInfoResponseDTO(updatedServiceDeploymentInfo);
         } catch (MicoApplicationNotFoundException | MicoServiceDeploymentInformationNotFoundException
         	| KubernetesResourceException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
@@ -270,7 +269,7 @@ public class ApplicationResource {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
 
-        return ResponseEntity.ok(new Resource<>(serviceDeploymentInfoDto,
+        return ResponseEntity.ok(new Resource<>(updatedServiceDeploymentInfoDto,
                 linkTo(methodOn(ApplicationResource.class).getServiceDeploymentInformation(shortName, version, serviceShortName))
                         .withSelfRel()));
     }


### PR DESCRIPTION
## Short Description

<!-- Summarize the new functionalities/fixes -->

Update of a service deployment information does not remove relation to the corresponding MICO service anymore.

## Resolving Issue/ Feature

<!-- Reference to the respective issue -->

Resolves #667.