### PR TITLE
Fix/status service npe

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/KubernetesPodMetricsResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/KubernetesPodMetricsResponseDTO.java
@@ -63,17 +63,4 @@ public class KubernetesPodMetricsResponseDTO {
         }
     )})
     private int cpuLoad;
-
-    /**
-     * Indicates if a pod is available or not.
-     */
-    @ApiModelProperty(extensions = {@Extension(
-        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
-        properties = {
-            @ExtensionProperty(name = "title", value = "Available"),
-            @ExtensionProperty(name = "x-order", value = "30"),
-            @ExtensionProperty(name = "description", value = "Indicates if a pod is available.")
-        }
-    )})
-    private boolean available;
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -342,14 +342,15 @@ public class MicoStatusService {
             podMetrics.setMemoryUsage(memoryUsage);
             podMetrics.setCpuLoad(cpuLoad);
             return new KubernetesPodInformationResponseDTO(podName, phase, hostIp, nodeName, restarts, age, podMetrics);
+        } else {
+            return new KubernetesPodInformationResponseDTO()
+                .setNodeName(nodeName)
+                .setPodName(podName)
+                .setPhase(phase)
+                .setHostIp(hostIp)
+                .setRestarts(restarts)
+                .setStartTime(age);
         }
-        return new KubernetesPodInformationResponseDTO()
-            .setNodeName(nodeName)
-            .setPodName(podName)
-            .setPhase(phase)
-            .setHostIp(hostIp)
-            .setRestarts(restarts)
-            .setStartTime(age);
     }
 
     private int getMemoryUsageForPod(String podName) throws PrometheusRequestFailedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -20,25 +20,30 @@
 package io.github.ust.mico.core.service;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.constraints.NotNull;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.LoadBalancerIngress;
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.github.ust.mico.core.configuration.PrometheusConfig;
 import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
 import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
-import io.github.ust.mico.core.dto.response.status.*;
+import io.github.ust.mico.core.dto.response.status.KubernetesNodeMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodInformationResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoApplicationStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoMessageResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceStatusResponseDTO;
 import io.github.ust.mico.core.exception.KubernetesResourceException;
 import io.github.ust.mico.core.exception.PrometheusRequestFailedException;
 import io.github.ust.mico.core.model.MicoApplication;
@@ -50,6 +55,14 @@ import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.util.CollectionUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Provides functionality to retrieve status information for a {@link MicoApplication} or a particular {@link
@@ -198,7 +211,7 @@ public class MicoStatusService {
             int sumCpuLoadOnNode = 0;
             int sumMemoryUsageOnNode = 0;
             for (Pod pod : podsPerNode.get(nodeName)) {
-                KubernetesPodInformationResponseDTO podInformation = getUiPodInfo(pod);
+                KubernetesPodInformationResponseDTO podInformation = getPodInformation(pod);
                 sumCpuLoadOnNode += podInformation.getMetrics().getCpuLoad();
                 sumMemoryUsageOnNode += podInformation.getMetrics().getMemoryUsage();
                 podInfos.add(podInformation);
@@ -238,7 +251,7 @@ public class MicoStatusService {
         }
         return interfacesInformation;
     }
-    
+
     /**
      * Get the public IP of a {@link MicoServiceInterface} by providing the corresponding Kubernetes {@link Service}.
      *
@@ -300,7 +313,7 @@ public class MicoStatusService {
      * @return a {@link KubernetesPodInformationResponseDTO} which has node name, pod name, phase, host ip, memory
      * usage, and CPU load as status information.
      */
-    private KubernetesPodInformationResponseDTO getUiPodInfo(Pod pod) {
+    private KubernetesPodInformationResponseDTO getPodInformation(Pod pod) {
         String nodeName = pod.getSpec().getNodeName();
         String podName = pod.getMetadata().getName();
         String phase = pod.getStatus().getPhase();
@@ -310,20 +323,28 @@ public class MicoStatusService {
             restarts += containerStatus.getRestartCount();
         }
         String age = pod.getStatus().getStartTime();
-        int memoryUsage = -1;
-        int cpuLoad = -1;
+        int memoryUsage = 0;
+        int cpuLoad = 0;
         KubernetesPodMetricsResponseDTO podMetrics = new KubernetesPodMetricsResponseDTO();
-        try {
-            memoryUsage = getMemoryUsageForPod(podName);
-            cpuLoad = getCpuLoadForPod(podName);
-            podMetrics.setAvailable(true);
-        } catch (PrometheusRequestFailedException | ResourceAccessException e) {
-            podMetrics.setAvailable(false);
-            log.error(e.getMessage(), e);
+        // Request values from Prometheus only if the pod phase is "Running"
+        if (phase.equals("Running")) {
+            try {
+                memoryUsage = getMemoryUsageForPod(podName);
+                cpuLoad = getCpuLoadForPod(podName);
+            } catch (PrometheusRequestFailedException | ResourceAccessException e) {
+                log.error(e.getMessage(), e);
+            }
+            podMetrics.setMemoryUsage(memoryUsage);
+            podMetrics.setCpuLoad(cpuLoad);
+            return new KubernetesPodInformationResponseDTO(podName, phase, hostIp, nodeName, restarts, age, podMetrics);
         }
-        podMetrics.setMemoryUsage(memoryUsage);
-        podMetrics.setCpuLoad(cpuLoad);
-        return new KubernetesPodInformationResponseDTO(podName, phase, hostIp, nodeName, restarts, age, podMetrics);
+        return new KubernetesPodInformationResponseDTO()
+            .setNodeName(nodeName)
+            .setPodName(podName)
+            .setPhase(phase)
+            .setHostIp(hostIp)
+            .setRestarts(restarts)
+            .setStartTime(age);
     }
 
     private int getMemoryUsageForPod(String podName) throws PrometheusRequestFailedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/util/PrometheusValueDeserializer.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/PrometheusValueDeserializer.java
@@ -22,19 +22,20 @@ package io.github.ust.mico.core.util;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Custom deserializer for a response, which is received from Prometheus for CPU load / memory usage requests.
  */
+@Slf4j
 public class PrometheusValueDeserializer extends StdDeserializer<Integer> {
 
-	private static final long serialVersionUID = 8170187864990259257L;
+    private static final long serialVersionUID = 8170187864990259257L;
 
-	public PrometheusValueDeserializer() {
+    public PrometheusValueDeserializer() {
         this(null);
     }
 
@@ -43,11 +44,16 @@ public class PrometheusValueDeserializer extends StdDeserializer<Integer> {
     }
 
     @Override
-    public Integer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        JsonNode dataJson = p.getCodec().readTree(p);
-        JsonNode resultJsonArray = dataJson.get("result");
-        JsonNode resultJsonArrayFirstElement = resultJsonArray.get(0);
-        JsonNode valueNode = resultJsonArrayFirstElement.get("value");
-        return valueNode.get(1).asInt();
+    public Integer deserialize(JsonParser parser, DeserializationContext context) {
+        try {
+            JsonNode dataJson = parser.getCodec().readTree(parser);
+            JsonNode resultJsonArray = dataJson.get("result");
+            JsonNode resultJsonArrayFirstElement = resultJsonArray.get(0);
+            JsonNode valueNode = resultJsonArrayFirstElement.get("value");
+            return valueNode.get(1).asInt();
+        } catch (IOException | NullPointerException e) {
+            log.error(e.getMessage(), e);
+            return 0;
+        }
     }
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -19,6 +19,13 @@
 
 package io.github.ust.mico.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ust.mico.core.dto.request.MicoApplicationRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoLabelRequestDTO;
@@ -27,10 +34,29 @@ import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
 import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
 import io.github.ust.mico.core.dto.response.MicoLabelResponseDTO;
 import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
-import io.github.ust.mico.core.dto.response.status.*;
-import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.dto.response.status.KubernetesNodeMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodInformationResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoApplicationStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceStatusResponseDTO;
+import io.github.ust.mico.core.model.KubernetesDeploymentInfo;
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoApplicationDeploymentStatus;
+import io.github.ust.mico.core.model.MicoEnvironmentVariable;
+import io.github.ust.mico.core.model.MicoLabel;
+import io.github.ust.mico.core.model.MicoMessage;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo.ImagePullPolicy;
-import io.github.ust.mico.core.persistence.*;
+import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.persistence.KubernetesDeploymentInfoRepository;
+import io.github.ust.mico.core.persistence.MicoApplicationRepository;
+import io.github.ust.mico.core.persistence.MicoEnvironmentVariableRepository;
+import io.github.ust.mico.core.persistence.MicoInterfaceConnectionRepository;
+import io.github.ust.mico.core.persistence.MicoLabelRepository;
+import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
+import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
 import io.github.ust.mico.core.service.MicoStatusService;
 import io.github.ust.mico.core.util.CollectionUtils;
@@ -50,23 +76,73 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.JsonPathBuilder.EMBEDDED;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
+import static io.github.ust.mico.core.JsonPathBuilder.SELF_HREF;
+import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
+import static io.github.ust.mico.core.TestConstants.AVAILABLE_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION;
+import static io.github.ust.mico.core.TestConstants.ERROR_MESSAGES;
+import static io.github.ust.mico.core.TestConstants.ID;
+import static io.github.ust.mico.core.TestConstants.ID_1;
+import static io.github.ust.mico.core.TestConstants.ID_2;
+import static io.github.ust.mico.core.TestConstants.ID_3;
+import static io.github.ust.mico.core.TestConstants.INTERFACES_INFORMATION;
+import static io.github.ust.mico.core.TestConstants.INTERFACES_INFORMATION_NAME;
+import static io.github.ust.mico.core.TestConstants.NAME;
+import static io.github.ust.mico.core.TestConstants.NODE_METRICS_AVERAGE_CPU_LOAD;
+import static io.github.ust.mico.core.TestConstants.NODE_METRICS_AVERAGE_MEMORY_USAGE;
+import static io.github.ust.mico.core.TestConstants.NODE_METRICS_NAME;
+import static io.github.ust.mico.core.TestConstants.OWNER;
+import static io.github.ust.mico.core.TestConstants.POD_INFO;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_CPU_LOAD_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_CPU_LOAD_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_MEMORY_USAGE_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_METRICS_MEMORY_USAGE_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_NODE_NAME_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_NODE_NAME_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_PHASE_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_PHASE_2;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_POD_NAME_1;
+import static io.github.ust.mico.core.TestConstants.POD_INFO_POD_NAME_2;
+import static io.github.ust.mico.core.TestConstants.REQUESTED_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.SDI_IMAGE_PULLPOLICY_PATH;
+import static io.github.ust.mico.core.TestConstants.SDI_LABELS_PATH;
+import static io.github.ust.mico.core.TestConstants.SDI_REPLICAS_PATH;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INFORMATION_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_VERSION;
 import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_OTHER;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_AVAILABLE_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_MICO_SERVICES;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_PODS;
+import static io.github.ust.mico.core.TestConstants.TOTAL_NUMBER_OF_REQUESTED_REPLICAS;
 import static io.github.ust.mico.core.TestConstants.VERSION;
-import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @EnableAutoConfiguration
@@ -132,67 +208,67 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void getAllApplications() throws Exception {
         given(applicationRepository.findAll(3)).willReturn(
-                CollectionUtils.listOf(
-                        new MicoApplication().setId(ID_1).setShortName(SHORT_NAME).setVersion(VERSION_1_0_1),
-                        new MicoApplication().setId(ID_2).setShortName(SHORT_NAME).setVersion(VERSION),
-                        new MicoApplication().setId(ID_3).setShortName(SHORT_NAME_1).setVersion(VERSION)));
+            CollectionUtils.listOf(
+                new MicoApplication().setId(ID_1).setShortName(SHORT_NAME).setVersion(VERSION_1_0_1),
+                new MicoApplication().setId(ID_2).setShortName(SHORT_NAME).setVersion(VERSION),
+                new MicoApplication().setId(ID_3).setShortName(SHORT_NAME_1).setVersion(VERSION)));
         mvc.perform(get(BASE_PATH).accept(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[*]", hasSize(3)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].shortName", is(SHORT_NAME)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].version", is(VERSION_1_0_1)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[1].shortName", is(SHORT_NAME)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[1].version", is(VERSION)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].shortName", is(SHORT_NAME_1)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].version", is(VERSION)))
-                .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "self.href", is("http://localhost/applications")))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[*]", hasSize(3)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].shortName", is(SHORT_NAME)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].version", is(VERSION_1_0_1)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[1].shortName", is(SHORT_NAME)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[1].version", is(VERSION)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].shortName", is(SHORT_NAME_1)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].version", is(VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "self.href", is("http://localhost/applications")))
+            .andReturn();
     }
 
     @Test
     public void getApplicationByShortName() throws Exception {
         given(applicationRepository.findByShortName(SHORT_NAME)).willReturn(
-                CollectionUtils.listOf(new MicoApplication().setId(ID).setShortName(SHORT_NAME).setVersion(VERSION)));
+            CollectionUtils.listOf(new MicoApplication().setId(ID).setShortName(SHORT_NAME).setVersion(VERSION)));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].shortName", is(SHORT_NAME)))
-                .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].version", is(VERSION)))
-                .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].shortName", is(SHORT_NAME)))
+            .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].version", is(VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME)))
+            .andReturn();
     }
 
     @Test
     public void getApplicationByShortNameAndVersion() throws Exception {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(
-                Optional.of(new MicoApplication().setId(ID).setShortName(SHORT_NAME).setVersion(VERSION)));
+            Optional.of(new MicoApplication().setId(ID).setShortName(SHORT_NAME).setVersion(VERSION)));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
-                .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
-                .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME + "/" + VERSION)))
-                .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/applications")))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/applications")))
+            .andReturn();
     }
 
     @Test
     public void getApplicationByShortNameAndVersionWithServices() throws Exception {
         MicoService service = new MicoService()
-                .setId(ID_1)
-                .setShortName(SERVICE_SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID_1)
+            .setShortName(SERVICE_SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION).setOwner(OWNER);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION).setOwner(OWNER);
 
         MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo().setService(service);
 
@@ -202,57 +278,57 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
-                .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
-                .andExpect(jsonPath(OWNER_PATH, is(OWNER)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].shortName", is(SERVICE_SHORT_NAME)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].version", is(VERSION)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].name", is(NAME)))
-                .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME + "/" + VERSION)))
-                .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/applications")))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
+            .andExpect(jsonPath(OWNER_PATH, is(OWNER)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].shortName", is(SERVICE_SHORT_NAME)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].version", is(VERSION)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].name", is(NAME)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/applications")))
+            .andReturn();
     }
 
     @Test
     public void getApplicationByShortNameWithTrailingSlash() throws Exception {
         given(applicationRepository.findByShortName(SHORT_NAME)).willReturn(
-                CollectionUtils.listOf(new MicoApplication().setId(ID).setShortName(SHORT_NAME).setVersion(VERSION)));
+            CollectionUtils.listOf(new MicoApplication().setId(ID).setShortName(SHORT_NAME).setVersion(VERSION)));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn();
     }
 
     @Test
     public void createApplication() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(application);
 
         mvc.perform(post(BASE_PATH)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(application.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(application.getVersion())))
-                .andExpect(jsonPath(DEPLOYMENT_STATUS_PATH + ".value", is(MicoApplicationDeploymentStatus.Value.UNDEPLOYED.toString())));
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(application.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(application.getVersion())))
+            .andExpect(jsonPath(DEPLOYMENT_STATUS_PATH + ".value", is(MicoApplicationDeploymentStatus.Value.UNDEPLOYED.toString())));
     }
 
     @Test
     public void createApplicationWithExistingServices() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         MicoService service1 = new MicoService().setShortName(SHORT_NAME).setVersion(VERSION);
         MicoService service2 = new MicoService().setShortName(SHORT_NAME_1).setVersion(VERSION);
@@ -264,84 +340,84 @@ public class ApplicationResourceIntegrationTests {
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(application);
         given(serviceRepository.findByShortNameAndVersion(eq(service1.getShortName()), eq(service1.getVersion())))
-                .willReturn(Optional.of(service1));
+            .willReturn(Optional.of(service1));
         given(serviceRepository.findByShortNameAndVersion(eq(service2.getShortName()), eq(service2.getVersion())))
-                .willReturn(Optional.of(service2));
+            .willReturn(Optional.of(service2));
 
         MicoApplicationResponseDTO newApplicationDto = (MicoApplicationResponseDTO) new MicoApplicationResponseDTO()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         mvc.perform(post(BASE_PATH)
-                .content(mapper.writeValueAsBytes(newApplicationDto))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(application.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(application.getVersion())))
-                .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(2)))
-                .andExpect(status().isCreated())
-                .andReturn();
+            .content(mapper.writeValueAsBytes(newApplicationDto))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(application.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(application.getVersion())))
+            .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(2)))
+            .andExpect(status().isCreated())
+            .andReturn();
     }
 
     @Test
     public void createApplicationWithInconsistentServiceData() throws Exception {
         MicoService invalidMicoService = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION)
-                .setGitCloneUrl("http://example.com/INVALID");
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION)
+            .setGitCloneUrl("http://example.com/INVALID");
 
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         application.getServices().add(invalidMicoService);
         application.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo().setService(invalidMicoService));
 
         // MicoService exists with different data
         given(applicationRepository.findByShortNameAndVersion(eq(application.getShortName()),
-                eq(application.getVersion()))).willReturn(Optional.of(application));
+            eq(application.getVersion()))).willReturn(Optional.of(application));
 
         mvc.perform(post(BASE_PATH)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isConflict());
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isConflict());
     }
 
     @Test
     public void createApplicationWithoutRequiredName() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(null).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(null).setDescription(DESCRIPTION);
 
         mvc.perform(post(BASE_PATH)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void createApplicationWithDescriptionSetToNull() throws Exception {
         MicoApplication newApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(null);
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(null);
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME).setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME).setDescription("");
 
         ArgumentCaptor<MicoApplication> applicationArgumentCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(expectedApplication);
 
         mvc.perform(post(BASE_PATH)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(newApplication)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated());
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(newApplication)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated());
 
         verify(applicationRepository, times(1)).save(applicationArgumentCaptor.capture());
         MicoApplication savedApplication = applicationArgumentCaptor.getValue();
@@ -352,22 +428,22 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void createApplicationWithEmptyDescription() throws Exception {
         MicoApplication newApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription("");
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription("");
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription("");
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription("");
 
         ArgumentCaptor<MicoApplication> applicationArgumentCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(expectedApplication);
 
         mvc.perform(post(BASE_PATH)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(newApplication)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated());
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(newApplication)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated());
 
         verify(applicationRepository, times(1)).save(applicationArgumentCaptor.capture());
         MicoApplication savedApplication = applicationArgumentCaptor.getValue();
@@ -378,52 +454,52 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void updateApplication() throws Exception {
         MicoApplication existingApplication = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         MicoApplication updatedApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription("newDesc");
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription("newDesc");
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setId(existingApplication.getId())
-                .setShortName(updatedApplication.getShortName()).setVersion(updatedApplication.getVersion())
-                .setName(updatedApplication.getName()).setDescription(updatedApplication.getDescription());
+            .setId(existingApplication.getId())
+            .setShortName(updatedApplication.getShortName()).setVersion(updatedApplication.getVersion())
+            .setName(updatedApplication.getName()).setDescription(updatedApplication.getDescription());
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(existingApplication));
         given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
 
         mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedApplication.getDescription())))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(updatedApplication.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(updatedApplication.getVersion())))
-                .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(0)));
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedApplication.getDescription())))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(updatedApplication.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(updatedApplication.getVersion())))
+            .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(0)));
     }
 
     @Test
     public void updateApplicationUsesExistingServices() throws Exception {
         MicoService existingService = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION)
-                .setName(NAME);
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION)
+            .setName(NAME);
 
         MicoApplication existingApplication = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         MicoApplication updatedApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription("newDesc");
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription("newDesc");
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setId(existingApplication.getId())
-                .setShortName(updatedApplication.getShortName()).setVersion(updatedApplication.getVersion())
-                .setName(updatedApplication.getName()).setDescription(updatedApplication.getDescription());
+            .setId(existingApplication.getId())
+            .setShortName(updatedApplication.getShortName()).setVersion(updatedApplication.getVersion())
+            .setName(updatedApplication.getName()).setDescription(updatedApplication.getDescription());
 
         expectedApplication.getServices().add(existingService);
         expectedApplication.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo().setService(existingService));
@@ -432,44 +508,44 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.save(eq(updatedApplication.setId(ID)))).willReturn(expectedApplication);
 
         mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedApplication.getDescription())))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(updatedApplication.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(updatedApplication.getVersion())))
-                .andExpect(jsonPath(NAME_PATH, is(updatedApplication.getName())))
-                .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].shortName", is(SERVICE_SHORT_NAME)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].version", is(SERVICE_VERSION)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].name", is(NAME)));
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedApplication.getDescription())))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(updatedApplication.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(updatedApplication.getVersion())))
+            .andExpect(jsonPath(NAME_PATH, is(updatedApplication.getName())))
+            .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].shortName", is(SERVICE_SHORT_NAME)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].version", is(SERVICE_VERSION)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].name", is(NAME)));
     }
 
     @Test
     public void promoteApplication() throws Exception {
         MicoService service = new MicoService()
-                .setId(ID_1)
-                .setShortName(SERVICE_SHORT_NAME)
-                .setVersion(SERVICE_VERSION)
-                .setName(NAME);
+            .setId(ID_1)
+            .setShortName(SERVICE_SHORT_NAME)
+            .setVersion(SERVICE_VERSION)
+            .setName(NAME);
         MicoServiceDeploymentInfo deploymentInfo = new MicoServiceDeploymentInfo()
-                .setId(2000L)
-                .setService(service)
-                .setReplicas(5)
-                .setLabels(CollectionUtils.listOf(new MicoLabel(3000L, "key", "value")))
-                .setEnvironmentVariables(CollectionUtils.listOf(new MicoEnvironmentVariable(4000L, "name", "key")))
-                .setKubernetesDeploymentInfo(new KubernetesDeploymentInfo()
-                        .setId(5000L)
-                        .setNamespace("namespace")
-                        .setDeploymentName("deployment")
-                        .setServiceNames(CollectionUtils.listOf("service")));
+            .setId(2000L)
+            .setService(service)
+            .setReplicas(5)
+            .setLabels(CollectionUtils.listOf(new MicoLabel(3000L, "key", "value")))
+            .setEnvironmentVariables(CollectionUtils.listOf(new MicoEnvironmentVariable(4000L, "name", "key")))
+            .setKubernetesDeploymentInfo(new KubernetesDeploymentInfo()
+                .setId(5000L)
+                .setNamespace("namespace")
+                .setDeploymentName("deployment")
+                .setServiceNames(CollectionUtils.listOf("service")));
 
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         application.getServices().add(service);
         application.getServiceDeploymentInfos().add(deploymentInfo);
 
@@ -477,24 +553,24 @@ public class ApplicationResourceIntegrationTests {
         Long newId = ID + 1;
 
         MicoApplication updatedApplication = new MicoApplication()
-                .setId(null)
-                .setShortName(SHORT_NAME)
-                .setVersion(newVersion)
-                .setName(NAME);
+            .setId(null)
+            .setShortName(SHORT_NAME)
+            .setVersion(newVersion)
+            .setName(NAME);
         updatedApplication.getServices().add(service);
         // Service deployment information is copied without the actual Kubernetes deployment information.
         MicoServiceDeploymentInfo updatedDeploymentInfo = new MicoServiceDeploymentInfo()
-                .setId(null).setService(service).setReplicas(5).setKubernetesDeploymentInfo(null);
+            .setId(null).setService(service).setReplicas(5).setKubernetesDeploymentInfo(null);
         updatedApplication.getServiceDeploymentInfos().add(updatedDeploymentInfo);
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setId(newId)
-                .setShortName(SHORT_NAME)
-                .setVersion(newVersion)
-                .setName(NAME);
+            .setId(newId)
+            .setShortName(SHORT_NAME)
+            .setVersion(newVersion)
+            .setName(NAME);
         expectedApplication.getServices().add(service);
         MicoServiceDeploymentInfo expectedDeploymentInfo = new MicoServiceDeploymentInfo()
-                .setId(ID_2).setService(service).setReplicas(5).setKubernetesDeploymentInfo(null);
+            .setId(ID_2).setService(service).setReplicas(5).setKubernetesDeploymentInfo(null);
         expectedApplication.getServiceDeploymentInfos().add(expectedDeploymentInfo);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
@@ -503,17 +579,17 @@ public class ApplicationResourceIntegrationTests {
         ArgumentCaptor<MicoApplication> applicationArgumentCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
         mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_PROMOTE)
-                .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(NAME_PATH, is(updatedApplication.getName())))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(updatedApplication.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(newVersion)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].shortName", is(SERVICE_SHORT_NAME)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].version", is(SERVICE_VERSION)))
-                .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].name", is(NAME)));
+            .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(NAME_PATH, is(updatedApplication.getName())))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(updatedApplication.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(newVersion)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH, hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].shortName", is(SERVICE_SHORT_NAME)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].version", is(SERVICE_VERSION)))
+            .andExpect(jsonPath(SERVICE_LIST_PATH + "[0].name", is(NAME)));
 
         verify(applicationRepository, times(1)).save(applicationArgumentCaptor.capture());
         MicoApplication savedMicoApplication = applicationArgumentCaptor.getValue();
@@ -531,38 +607,38 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void updateApplicationWithoutRequiredName() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         MicoApplication updatedApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(null).setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(null).setDescription(DESCRIPTION);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 
         mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void updateApplicationWithDescriptionSetToNull() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         MicoApplication updatedApplication = new MicoApplication()
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(null);
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(null);
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setId(application.getId())
-                .setShortName(application.getShortName()).setVersion(application.getVersion())
-                .setName(updatedApplication.getName()).setDescription("");
+            .setId(application.getId())
+            .setShortName(application.getShortName()).setVersion(application.getVersion())
+            .setName(updatedApplication.getName()).setDescription("");
 
         ArgumentCaptor<MicoApplication> applicationArgumentCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
@@ -570,10 +646,10 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(expectedApplication);
 
         mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk());
+            .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk());
 
         verify(applicationRepository, times(1)).save(applicationArgumentCaptor.capture());
         MicoApplication savedMicoApplication = applicationArgumentCaptor.getValue();
@@ -584,18 +660,18 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void deleteApplication() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME).setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME).setDescription(DESCRIPTION);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 
         ArgumentCaptor<MicoApplication> appCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isNoContent())
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isNoContent())
+            .andReturn();
 
         verify(applicationRepository).delete(appCaptor.capture());
         assertEquals("Wrong short name.", application.getShortName(), appCaptor.getValue().getShortName());
@@ -695,20 +771,20 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void getStatusOfApplication() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION)
+            .setName(NAME);
 
         MicoApplication otherMicoApplication = new MicoApplication()
-                .setId(ID_1)
-                .setShortName(SHORT_NAME_OTHER).setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID_1)
+            .setShortName(SHORT_NAME_OTHER).setVersion(VERSION)
+            .setName(NAME);
 
         MicoServiceInterface serviceInterface = new MicoServiceInterface().setServiceInterfaceName(SERVICE_INTERFACE_NAME);
 
         MicoService service = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION)
-                .setServiceInterfaces(CollectionUtils.listOf(serviceInterface));
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION)
+            .setServiceInterfaces(CollectionUtils.listOf(serviceInterface));
 
         String nodeName = "testNode";
         String podPhase = "Running";
@@ -731,56 +807,54 @@ public class ApplicationResourceIntegrationTests {
         int cpuLoad2 = 40;
 
         MicoApplicationStatusResponseDTO micoApplicationStatus = new MicoApplicationStatusResponseDTO()
-                .setTotalNumberOfMicoServices(1)
-                .setTotalNumberOfAvailableReplicas(availableReplicas)
-                .setTotalNumberOfRequestedReplicas(replicas)
-                .setTotalNumberOfPods(2);
+            .setTotalNumberOfMicoServices(1)
+            .setTotalNumberOfAvailableReplicas(availableReplicas)
+            .setTotalNumberOfRequestedReplicas(replicas)
+            .setTotalNumberOfPods(2);
         MicoServiceStatusResponseDTO micoServiceStatus = new MicoServiceStatusResponseDTO();
 
         // Set information for first pod of a MicoService
         KubernetesPodInformationResponseDTO kubernetesPodInfo1 = new KubernetesPodInformationResponseDTO();
         kubernetesPodInfo1
-                .setHostIp(hostIp)
-                .setNodeName(nodeName)
-                .setPhase(podPhase)
-                .setPodName(podName1)
-                .setStartTime(startTimePod1)
-                .setRestarts(restartsPod1)
-                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setAvailable(false)
-                        .setCpuLoad(cpuLoad1)
-                        .setMemoryUsage(memoryUsage1));
+            .setHostIp(hostIp)
+            .setNodeName(nodeName)
+            .setPhase(podPhase)
+            .setPodName(podName1)
+            .setStartTime(startTimePod1)
+            .setRestarts(restartsPod1)
+            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                .setCpuLoad(cpuLoad1)
+                .setMemoryUsage(memoryUsage1));
 
         // Set information for second pod of a MicoService
         KubernetesPodInformationResponseDTO kubernetesPodInfo2 = new KubernetesPodInformationResponseDTO();
         kubernetesPodInfo2
-                .setHostIp(hostIp)
-                .setNodeName(nodeName)
-                .setPhase(podPhase)
-                .setPodName(podName2)
-                .setStartTime(startTimePod2)
-                .setRestarts(restartsPod2)
-                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setAvailable(true)
-                        .setCpuLoad(cpuLoad2)
-                        .setMemoryUsage(memoryUsage2));
+            .setHostIp(hostIp)
+            .setNodeName(nodeName)
+            .setPhase(podPhase)
+            .setPodName(podName2)
+            .setStartTime(startTimePod2)
+            .setRestarts(restartsPod2)
+            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                .setCpuLoad(cpuLoad2)
+                .setMemoryUsage(memoryUsage2));
 
         // Set deployment information for MicoService
         micoServiceStatus
-                .setName(NAME)
-                .setShortName(SERVICE_SHORT_NAME)
-                .setVersion(SERVICE_VERSION)
-                .setAvailableReplicas(availableReplicas)
-                .setRequestedReplicas(replicas)
-                .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
-                .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
-                .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2))
-                .setNodeMetrics(CollectionUtils.listOf(
-                        new KubernetesNodeMetricsResponseDTO()
-                                .setNodeName(nodeName)
-                                .setAverageCpuLoad(25)
-                                .setAverageMemoryUsage(60)
-                ));
+            .setName(NAME)
+            .setShortName(SERVICE_SHORT_NAME)
+            .setVersion(SERVICE_VERSION)
+            .setAvailableReplicas(availableReplicas)
+            .setRequestedReplicas(replicas)
+            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+            .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
+            .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2))
+            .setNodeMetrics(CollectionUtils.listOf(
+                new KubernetesNodeMetricsResponseDTO()
+                    .setNodeName(nodeName)
+                    .setAverageCpuLoad(25)
+                    .setAverageMemoryUsage(60)
+            ));
         micoApplicationStatus.getServiceStatuses().add(micoServiceStatus);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
@@ -791,44 +865,42 @@ public class ApplicationResourceIntegrationTests {
         given(micoStatusService.getApplicationStatus(any(MicoApplication.class))).willReturn(micoApplicationStatus);
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_STATUS))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SERVICE_INFORMATION_NAME, is(NAME)))
-                .andExpect(jsonPath(TOTAL_NUMBER_OF_AVAILABLE_REPLICAS, is(availableReplicas)))
-                .andExpect(jsonPath(TOTAL_NUMBER_OF_REQUESTED_REPLICAS, is(replicas)))
-                .andExpect(jsonPath(TOTAL_NUMBER_OF_PODS, is(2)))
-                .andExpect(jsonPath(TOTAL_NUMBER_OF_MICO_SERVICES, is(1)))
-                .andExpect(jsonPath(NODE_METRICS_NAME, is(nodeName)))
-                .andExpect(jsonPath(NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
-                .andExpect(jsonPath(NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
-                .andExpect(jsonPath(REQUESTED_REPLICAS, is(replicas)))
-                .andExpect(jsonPath(AVAILABLE_REPLICAS, is(availableReplicas)))
-                .andExpect(jsonPath(INTERFACES_INFORMATION, hasSize(1)))
-                .andExpect(jsonPath(INTERFACES_INFORMATION_NAME, is(SERVICE_INTERFACE_NAME)))
-                .andExpect(jsonPath(POD_INFO, hasSize(2)))
-                .andExpect(jsonPath(POD_INFO_POD_NAME_1, is(podName1)))
-                .andExpect(jsonPath(POD_INFO_PHASE_1, is(podPhase)))
-                .andExpect(jsonPath(POD_INFO_NODE_NAME_1, is(nodeName)))
-                .andExpect(jsonPath(POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsage1)))
-                .andExpect(jsonPath(POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoad1)))
-                .andExpect(jsonPath(POD_INFO_METRICS_AVAILABLE_1, is(false)))
-                .andExpect(jsonPath(POD_INFO_POD_NAME_2, is(podName2)))
-                .andExpect(jsonPath(POD_INFO_PHASE_2, is(podPhase)))
-                .andExpect(jsonPath(POD_INFO_NODE_NAME_2, is(nodeName)))
-                .andExpect(jsonPath(POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsage2)))
-                .andExpect(jsonPath(POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoad2)))
-                .andExpect(jsonPath(POD_INFO_METRICS_AVAILABLE_2, is(true)))
-                .andExpect(jsonPath(ERROR_MESSAGES, is(CollectionUtils.listOf())));
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SERVICE_INFORMATION_NAME, is(NAME)))
+            .andExpect(jsonPath(TOTAL_NUMBER_OF_AVAILABLE_REPLICAS, is(availableReplicas)))
+            .andExpect(jsonPath(TOTAL_NUMBER_OF_REQUESTED_REPLICAS, is(replicas)))
+            .andExpect(jsonPath(TOTAL_NUMBER_OF_PODS, is(2)))
+            .andExpect(jsonPath(TOTAL_NUMBER_OF_MICO_SERVICES, is(1)))
+            .andExpect(jsonPath(NODE_METRICS_NAME, is(nodeName)))
+            .andExpect(jsonPath(NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
+            .andExpect(jsonPath(NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
+            .andExpect(jsonPath(REQUESTED_REPLICAS, is(replicas)))
+            .andExpect(jsonPath(AVAILABLE_REPLICAS, is(availableReplicas)))
+            .andExpect(jsonPath(INTERFACES_INFORMATION, hasSize(1)))
+            .andExpect(jsonPath(INTERFACES_INFORMATION_NAME, is(SERVICE_INTERFACE_NAME)))
+            .andExpect(jsonPath(POD_INFO, hasSize(2)))
+            .andExpect(jsonPath(POD_INFO_POD_NAME_1, is(podName1)))
+            .andExpect(jsonPath(POD_INFO_PHASE_1, is(podPhase)))
+            .andExpect(jsonPath(POD_INFO_NODE_NAME_1, is(nodeName)))
+            .andExpect(jsonPath(POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsage1)))
+            .andExpect(jsonPath(POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoad1)))
+            .andExpect(jsonPath(POD_INFO_POD_NAME_2, is(podName2)))
+            .andExpect(jsonPath(POD_INFO_PHASE_2, is(podPhase)))
+            .andExpect(jsonPath(POD_INFO_NODE_NAME_2, is(nodeName)))
+            .andExpect(jsonPath(POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsage2)))
+            .andExpect(jsonPath(POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoad2)))
+            .andExpect(jsonPath(ERROR_MESSAGES, is(CollectionUtils.listOf())));
     }
 
     @Test
     public void addServiceToApplication() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoService service = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
@@ -837,8 +909,8 @@ public class ApplicationResourceIntegrationTests {
         ArgumentCaptor<MicoApplication> micoApplicationCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
         mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
-                .andDo(print())
-                .andExpect(status().isNoContent());
+            .andDo(print())
+            .andExpect(status().isNoContent());
 
         verify(applicationRepository, times(1)).save(micoApplicationCaptor.capture());
         MicoApplication savedMicoApplication = micoApplicationCaptor.getValue();
@@ -849,11 +921,11 @@ public class ApplicationResourceIntegrationTests {
     @Test
     public void deleteServiceFromApplication() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoService service = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
 
         application.getServices().add(service);
         application.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo().setService(service));
@@ -861,71 +933,71 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME))
-                .willReturn(Optional.of(application.getServiceDeploymentInfos().get(0)));
+            .willReturn(Optional.of(application.getServiceDeploymentInfos().get(0)));
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
-                .andDo(print())
-                .andExpect(status().isNoContent());
+            .andDo(print())
+            .andExpect(status().isNoContent());
     }
 
     @Test
     public void getServiceDeploymentInformation() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoService service = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
 
         List<MicoLabel> labels = CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value"));
         ImagePullPolicy imagePullPolicy = ImagePullPolicy.IF_NOT_PRESENT;
         MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
-                .setService(service)
-                .setReplicas(3)
-                .setLabels(labels)
-                .setImagePullPolicy(imagePullPolicy);
+            .setService(service)
+            .setReplicas(3)
+            .setLabels(labels)
+            .setImagePullPolicy(imagePullPolicy);
 
         application.getServices().add(service);
         application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(),
-                application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+            application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
 
         mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
-                .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(labels.get(0).getKey())))
-                .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(labels.get(0).getValue())))
-                .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(imagePullPolicy.toString())))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(labels.get(0).getKey())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(labels.get(0).getValue())))
+            .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(imagePullPolicy.toString())))
+            .andReturn();
     }
 
     @Test
     public void updateServiceDeploymentInformation() throws Exception {
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoService service = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
 
         MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
-                .setId(ID_1)
-                .setService(service)
-                .setReplicas(3)
-                .setLabels(CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value")))
-                .setImagePullPolicy(ImagePullPolicy.IF_NOT_PRESENT);
+            .setId(ID_1)
+            .setService(service)
+            .setReplicas(3)
+            .setLabels(CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value")))
+            .setImagePullPolicy(ImagePullPolicy.IF_NOT_PRESENT);
 
         MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
-                .setReplicas(5)
-                .setLabels(CollectionUtils.listOf(new MicoLabelRequestDTO().setKey("key-updated").setValue("value-updated")))
-                .setImagePullPolicy(ImagePullPolicy.NEVER);
+            .setReplicas(5)
+            .setLabels(CollectionUtils.listOf(new MicoLabelRequestDTO().setKey("key-updated").setValue("value-updated")))
+            .setImagePullPolicy(ImagePullPolicy.NEVER);
 
         application.getServices().add(service);
         application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
@@ -938,15 +1010,15 @@ public class ApplicationResourceIntegrationTests {
         given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
 
         mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
-                .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
-                .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getKey())))
-                .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getValue())))
-                .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(updatedServiceDeploymentInfoDTO.getImagePullPolicy().toString())))
-                .andReturn();
+            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getKey())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getValue())))
+            .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(updatedServiceDeploymentInfoDTO.getImagePullPolicy().toString())))
+            .andReturn();
     }
 
     @Test
@@ -961,15 +1033,15 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.isApplicationDeployed(any(MicoApplication.class))).willReturn(false);
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME))
-                .andDo(print())
-                .andExpect(status().isNoContent())
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isNoContent())
+            .andReturn();
 
         verify(applicationRepository, times(1)).deleteAll(micoApplicationListCaptor.capture());
         List<MicoApplication> actualDeletedApplications = micoApplicationListCaptor.getValue();
         assertEquals("Expected 3 applications were deleted", 3, actualDeletedApplications.size());
         List<MicoApplication> otherApplications = actualDeletedApplications.stream()
-                .filter(app -> !app.getShortName().equals(SHORT_NAME)).collect(Collectors.toList());
+            .filter(app -> !app.getShortName().equals(SHORT_NAME)).collect(Collectors.toList());
         assertEquals("Excepted no other application was deleted", 0, otherApplications.size());
     }
 
@@ -985,10 +1057,10 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.isApplicationDeployed(micoApplicationV3)).willReturn(false);
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME))
-                .andDo(print())
-                .andExpect(status().isConflict())
-                .andExpect(status().reason("Application 'short-name' '1.0.1' is currently deployed!"))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isConflict())
+            .andExpect(status().reason("Application 'short-name' '1.0.1' is currently deployed!"))
+            .andReturn();
 
         verify(applicationRepository, never()).deleteAll(micoApplicationListCaptor.capture());
     }
@@ -999,21 +1071,21 @@ public class ApplicationResourceIntegrationTests {
         List<MicoLabel> labels = CollectionUtils.listOf(new MicoLabel().setKey("invalid-key!").setValue("value"));
 
         MicoApplication application = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoApplication expectedApplication = new MicoApplication()
-                .setId(ID)
-                .setShortName(SHORT_NAME).setVersion(VERSION);
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
 
         MicoService service = new MicoService()
-                .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
 
         MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo().setService(service);
 
         MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDTO =
-                (MicoServiceDeploymentInfoResponseDTO) new MicoServiceDeploymentInfoResponseDTO()
-                        .setLabels(labels.stream().map(MicoLabelResponseDTO::new).collect(Collectors.toList()));
+            (MicoServiceDeploymentInfoResponseDTO) new MicoServiceDeploymentInfoResponseDTO()
+                .setLabels(labels.stream().map(MicoLabelResponseDTO::new).collect(Collectors.toList()));
 
         application.getServices().add(service);
         application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
@@ -1021,12 +1093,12 @@ public class ApplicationResourceIntegrationTests {
         expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
 
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion()))
-                .willReturn(Optional.of(application));
+            .willReturn(Optional.of(application));
 
         final ResultActions result = mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
-                .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         result.andExpect(status().isUnprocessableEntity());
     }
@@ -1042,14 +1114,14 @@ public class ApplicationResourceIntegrationTests {
         application.getServiceDeploymentInfos().add(serviceDeploymentInfoOld);
 
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion()))
-                .willReturn(Optional.of(application));
+            .willReturn(Optional.of(application));
         given(serviceRepository.findByShortNameAndVersion(serviceNew.getShortName(), serviceNew.getVersion()))
-                .willReturn(Optional.of(serviceNew));
+            .willReturn(Optional.of(serviceNew));
 
         mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_2)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isNoContent());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isNoContent());
 
         ArgumentCaptor<MicoApplication> applicationCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
@@ -1070,15 +1142,15 @@ public class ApplicationResourceIntegrationTests {
         micoApplication.getServices().add(service2);
 
         given(applicationRepository.findByShortNameAndVersion(micoApplication.getShortName(), micoApplication.getVersion()))
-                .willReturn(Optional.of(micoApplication));
+            .willReturn(Optional.of(micoApplication));
         given(serviceRepository.findByShortNameAndVersion(service1.getShortName(), service1.getVersion()))
-                .willReturn(Optional.of(service1));
+            .willReturn(Optional.of(service1));
         given(serviceRepository.findAllByApplicationAndShortName(SHORT_NAME, VERSION, SERVICE_SHORT_NAME))
-                .willReturn(CollectionUtils.listOf(service1, service2));
+            .willReturn(CollectionUtils.listOf(service1, service2));
 
         mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isConflict());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isConflict());
     }
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -86,24 +86,20 @@ import static org.mockito.Mockito.mock;
 @ActiveProfiles("local")
 public class MicoStatusServiceTest {
 
+    private static final String POD_PHASE_RUNNING = "Running";
+    private static final String POD_PHASE_PENDING = "Pending";
     @MockBean
     private MicoKubernetesClient micoKubernetesClient;
-
     @MockBean
     private PrometheusConfig prometheusConfig;
-
     @MockBean
     private RestTemplate restTemplate;
-
     @MockBean
     private MicoApplicationRepository applicationRepository;
-
     @MockBean
     private MicoServiceRepository serviceRepository;
-
     @MockBean
     private MicoServiceInterfaceRepository serviceInterfaceRepository;
-
     @Autowired
     private MicoStatusService micoStatusService;
 
@@ -115,20 +111,16 @@ public class MicoStatusServiceTest {
     private Optional<Service> kubernetesService;
     private PodList podList;
     private PodList podListWithOnePod;
-
     private String nodeName1 = "testNode";
     private String nodeName2 = "testNode2";
-    private String podPhase = "Running";
     private String hostIp = "192.168.0.0";
     private String deploymentName = "deployment1";
-
     // Metrics for pod 1
     private String podName1 = "pod1";
     private int memoryUsagePod1 = 70;
     private int cpuLoadPod1 = 30;
     private String startTimePod1 = new Date().toString();
     private int restartsPod1 = 0;
-    private boolean podAvailablePod1 = true;
 
     // Metrics for pod 2
     private String podName2 = "pod2";
@@ -136,7 +128,6 @@ public class MicoStatusServiceTest {
     private int cpuLoadPod2 = 10;
     private String startTimePod2 = new Date().toString();
     private int restartsPod2 = 0;
-    private boolean podAvailablePod2 = true;
 
     // Metrics for pod 3
     private String podName3 = "pod3";
@@ -144,7 +135,6 @@ public class MicoStatusServiceTest {
     private int cpuLoadPod3 = 10;
     private String startTimePod3 = new Date().toString();
     private int restartsPod3 = 0;
-    private boolean podAvailablePod3 = true;
 
     // Metrics for pod 4
     private String podName4 = "pod4";
@@ -152,7 +142,6 @@ public class MicoStatusServiceTest {
     private int cpuLoadPod4 = 5;
     private String startTimePod4 = new Date().toString();
     private int restartsPod4 = 0;
-    private boolean podAvailablePod4 = true;
 
 
     @Before
@@ -211,10 +200,10 @@ public class MicoStatusServiceTest {
             .addNewItem()
             .withNewMetadata().withName(podName1).endMetadata()
             .withNewSpec().withNodeName(nodeName1).endSpec()
-            .withNewStatus().withStartTime(startTimePod1).
-                addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().
-                withPhase(podPhase).
-                withHostIP(hostIp)
+            .withNewStatus().withStartTime(startTimePod1)
+            .addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus()
+            .withPhase(POD_PHASE_RUNNING)
+            .withHostIP(hostIp)
             .endStatus()
             .endItem()
             .addNewItem()
@@ -222,7 +211,7 @@ public class MicoStatusServiceTest {
             .withNewSpec().withNodeName(nodeName1).endSpec()
             .withNewStatus().withStartTime(startTimePod2)
             .addNewContainerStatus().withRestartCount(restartsPod2).endContainerStatus()
-            .withPhase(podPhase)
+            .withPhase(POD_PHASE_RUNNING)
             .withHostIP(hostIp)
             .endStatus()
             .endItem()
@@ -231,7 +220,7 @@ public class MicoStatusServiceTest {
             .withNewSpec().withNodeName(nodeName2).endSpec()
             .withNewStatus().withStartTime(startTimePod3)
             .addNewContainerStatus().withRestartCount(restartsPod3).endContainerStatus()
-            .withPhase(podPhase)
+            .withPhase(POD_PHASE_RUNNING)
             .withHostIP(hostIp)
             .endStatus()
             .endItem()
@@ -240,7 +229,7 @@ public class MicoStatusServiceTest {
             .withNewSpec().withNodeName(nodeName2).endSpec()
             .withNewStatus().withStartTime(startTimePod4)
             .addNewContainerStatus().withRestartCount(restartsPod4).endContainerStatus()
-            .withPhase(podPhase)
+            .withPhase(POD_PHASE_PENDING)
             .withHostIP(hostIp)
             .endStatus()
             .endItem()
@@ -250,7 +239,7 @@ public class MicoStatusServiceTest {
             .addNewItem()
             .withNewMetadata().withName(podName1).endMetadata()
             .withNewSpec().withNodeName(nodeName1).endSpec()
-            .withNewStatus().withStartTime(startTimePod1).addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().withPhase(podPhase).withHostIP(hostIp).endStatus()
+            .withNewStatus().withStartTime(startTimePod1).addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().withPhase(POD_PHASE_RUNNING).withHostIP(hostIp).endStatus()
             .endItem()
             .build();
     }
@@ -278,8 +267,8 @@ public class MicoStatusServiceTest {
                         .setAverageMemoryUsage(60),
                     new KubernetesNodeMetricsResponseDTO()
                         .setNodeName(nodeName2)
-                        .setAverageCpuLoad(7)
-                        .setAverageMemoryUsage(57)
+                        .setAverageCpuLoad(10)
+                        .setAverageMemoryUsage(50)
                 ))
                 // Add four pods (on two different nodes)
                 .setPodsInformation(Arrays.asList(
@@ -287,7 +276,7 @@ public class MicoStatusServiceTest {
                         .setPodName(podName1)
                         .setHostIp(hostIp)
                         .setNodeName(nodeName1)
-                        .setPhase(podPhase)
+                        .setPhase(POD_PHASE_RUNNING)
                         .setStartTime(startTimePod1)
                         .setRestarts(restartsPod1)
                         .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -297,7 +286,7 @@ public class MicoStatusServiceTest {
                         .setPodName(podName2)
                         .setHostIp(hostIp)
                         .setNodeName(nodeName1)
-                        .setPhase(podPhase)
+                        .setPhase(POD_PHASE_RUNNING)
                         .setStartTime(startTimePod2)
                         .setRestarts(restartsPod2)
                         .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -307,7 +296,7 @@ public class MicoStatusServiceTest {
                         .setPodName(podName3)
                         .setHostIp(hostIp)
                         .setNodeName(nodeName2)
-                        .setPhase(podPhase)
+                        .setPhase(POD_PHASE_RUNNING)
                         .setStartTime(startTimePod3)
                         .setRestarts(restartsPod3)
                         .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -317,18 +306,14 @@ public class MicoStatusServiceTest {
                         .setPodName(podName4)
                         .setHostIp(hostIp)
                         .setNodeName(nodeName2)
-                        .setPhase(podPhase)
+                        .setPhase(POD_PHASE_PENDING)
                         .setStartTime(startTimePod4)
-                        .setRestarts(restartsPod4)
-                        .setMetrics(new KubernetesPodMetricsResponseDTO()
-                            .setMemoryUsage(memoryUsagePod4)
-                            .setCpuLoad(cpuLoadPod4))))
+                        .setRestarts(restartsPod4)))
                 .setErrorMessages(CollectionUtils.listOf())
                 .setInterfacesInformation(CollectionUtils.listOf(
                     new MicoServiceInterfaceStatusResponseDTO()
                         .setName(SERVICE_INTERFACE_NAME)
-                        .setExternalIp("192.168.2.112")))))
-        ;
+                        .setExternalIp("192.168.2.112")))));
         try {
             given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(deployment);
             given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(kubernetesService);
@@ -390,7 +375,7 @@ public class MicoStatusServiceTest {
                         .setPodName(podName1)
                         .setHostIp(hostIp)
                         .setNodeName(nodeName1)
-                        .setPhase(podPhase)
+                        .setPhase(POD_PHASE_RUNNING)
                         .setStartTime(startTimePod1)
                         .setRestarts(restartsPod1)
                         .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -477,8 +462,8 @@ public class MicoStatusServiceTest {
                     .setAverageMemoryUsage(60),
                 new KubernetesNodeMetricsResponseDTO()
                     .setNodeName(nodeName2)
-                    .setAverageCpuLoad(7)
-                    .setAverageMemoryUsage(57)
+                    .setAverageCpuLoad(10)
+                    .setAverageMemoryUsage(50)
             ))
             // Add four pods (on two different nodes)
             .setPodsInformation(Arrays.asList(
@@ -486,7 +471,7 @@ public class MicoStatusServiceTest {
                     .setPodName(podName1)
                     .setHostIp(hostIp)
                     .setNodeName(nodeName1)
-                    .setPhase(podPhase)
+                    .setPhase(POD_PHASE_RUNNING)
                     .setStartTime(startTimePod1)
                     .setRestarts(restartsPod1)
                     .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -496,7 +481,7 @@ public class MicoStatusServiceTest {
                     .setPodName(podName2)
                     .setHostIp(hostIp)
                     .setNodeName(nodeName1)
-                    .setPhase(podPhase)
+                    .setPhase(POD_PHASE_RUNNING)
                     .setStartTime(startTimePod2)
                     .setRestarts(restartsPod2)
                     .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -506,7 +491,7 @@ public class MicoStatusServiceTest {
                     .setPodName(podName3)
                     .setHostIp(hostIp)
                     .setNodeName(nodeName2)
-                    .setPhase(podPhase)
+                    .setPhase(POD_PHASE_RUNNING)
                     .setStartTime(startTimePod3)
                     .setRestarts(restartsPod3)
                     .setMetrics(new KubernetesPodMetricsResponseDTO()
@@ -516,12 +501,9 @@ public class MicoStatusServiceTest {
                     .setPodName(podName4)
                     .setHostIp(hostIp)
                     .setNodeName(nodeName2)
-                    .setPhase(podPhase)
+                    .setPhase(POD_PHASE_PENDING)
                     .setStartTime(startTimePod4)
-                    .setRestarts(restartsPod4)
-                    .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setMemoryUsage(memoryUsagePod4)
-                        .setCpuLoad(cpuLoadPod4))))
+                    .setRestarts(restartsPod4)))
             .setErrorMessages(CollectionUtils.listOf())
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO()
                 .setName(SERVICE_INTERFACE_NAME)

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -19,15 +19,43 @@
 
 package io.github.ust.mico.core;
 
-import static io.github.ust.mico.core.TestConstants.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
-import java.util.*;
-
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.github.ust.mico.core.configuration.PrometheusConfig;
+import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
+import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesNodeMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodInformationResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoApplicationStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoMessageResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceStatusResponseDTO;
+import io.github.ust.mico.core.exception.KubernetesResourceException;
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoMessage.Type;
+import io.github.ust.mico.core.model.MicoPortType;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.model.MicoServicePort;
+import io.github.ust.mico.core.persistence.MicoApplicationRepository;
+import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
+import io.github.ust.mico.core.persistence.MicoServiceRepository;
+import io.github.ust.mico.core.service.MicoKubernetesClient;
+import io.github.ust.mico.core.service.MicoStatusService;
+import io.github.ust.mico.core.util.CollectionUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,25 +68,18 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.api.model.PodListBuilder;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.github.ust.mico.core.configuration.PrometheusConfig;
-import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
-import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
-import io.github.ust.mico.core.dto.response.status.*;
-import io.github.ust.mico.core.exception.KubernetesResourceException;
-import io.github.ust.mico.core.model.*;
-import io.github.ust.mico.core.model.MicoMessage.Type;
-import io.github.ust.mico.core.persistence.MicoApplicationRepository;
-import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
-import io.github.ust.mico.core.persistence.MicoServiceRepository;
-import io.github.ust.mico.core.service.MicoKubernetesClient;
-import io.github.ust.mico.core.service.MicoStatusService;
-import io.github.ust.mico.core.util.CollectionUtils;
+import static io.github.ust.mico.core.TestConstants.NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_OTHER;
+import static io.github.ust.mico.core.TestConstants.VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -137,29 +158,29 @@ public class MicoStatusServiceTest {
     @Before
     public void setupMicoApplication() {
         micoApplication = new MicoApplication()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION);
 
         otherMicoApplication = new MicoApplication()
-                .setName(NAME)
-                .setShortName(SHORT_NAME_OTHER)
-                .setVersion(VERSION);
+            .setName(NAME)
+            .setShortName(SHORT_NAME_OTHER)
+            .setVersion(VERSION);
 
         micoService = new MicoService()
-                .setName(NAME)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setServiceInterfaces(CollectionUtils.listOf(
-                        new MicoServiceInterface()
-                                .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
-                ));
+            .setName(NAME)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setServiceInterfaces(CollectionUtils.listOf(
+                new MicoServiceInterface()
+                    .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
+            ));
 
         micoServiceInterface = new MicoServiceInterface()
-                .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
-                .setPorts(CollectionUtils.listOf(new MicoServicePort()
-                        .setPort(80)
-                        .setTargetPort(80)
-                        .setType(MicoPortType.TCP)));
+            .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
+            .setPorts(CollectionUtils.listOf(new MicoServicePort()
+                .setPort(80)
+                .setTargetPort(80)
+                .setType(MicoPortType.TCP)));
 
         micoApplication.getServices().add(micoService);
         micoApplication.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo().setService(micoService));
@@ -171,67 +192,67 @@ public class MicoStatusServiceTest {
         int replicas = 1;
 
         deployment = Optional.of(new DeploymentBuilder()
-                .withNewMetadata().withName(deploymentName).endMetadata()
-                .withNewSpec().withReplicas(replicas).endSpec().withNewStatus().withAvailableReplicas(availableReplicas).endStatus()
-                .build());
+            .withNewMetadata().withName(deploymentName).endMetadata()
+            .withNewSpec().withReplicas(replicas).endSpec().withNewStatus().withAvailableReplicas(availableReplicas).endStatus()
+            .build());
 
         kubernetesService = Optional.of(new ServiceBuilder()
-                .withNewMetadata().withName(SERVICE_INTERFACE_NAME).endMetadata()
-                .withNewSpec().endSpec()
-                .withNewStatus()
-                .withNewLoadBalancer()
-                .addNewIngress().withIp("192.168.2.112").endIngress()
-                .addNewIngress().withIp("192.168.2.113").endIngress()
-                .endLoadBalancer()
-                .endStatus()
-                .build());
+            .withNewMetadata().withName(SERVICE_INTERFACE_NAME).endMetadata()
+            .withNewSpec().endSpec()
+            .withNewStatus()
+            .withNewLoadBalancer()
+            .addNewIngress().withIp("192.168.2.112").endIngress()
+            .addNewIngress().withIp("192.168.2.113").endIngress()
+            .endLoadBalancer()
+            .endStatus()
+            .build());
 
         podList = new PodListBuilder()
-                .addNewItem()
-                .withNewMetadata().withName(podName1).endMetadata()
-                .withNewSpec().withNodeName(nodeName1).endSpec()
-                .withNewStatus().withStartTime(startTimePod1).
-                        addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().
-                        withPhase(podPhase).
-                        withHostIP(hostIp)
-                .endStatus()
-                .endItem()
-                .addNewItem()
-                .withNewMetadata().withName(podName2).endMetadata()
-                .withNewSpec().withNodeName(nodeName1).endSpec()
-                .withNewStatus().withStartTime(startTimePod2)
-                .addNewContainerStatus().withRestartCount(restartsPod2).endContainerStatus()
-                .withPhase(podPhase)
-                .withHostIP(hostIp)
-                .endStatus()
-                .endItem()
-                .addNewItem()
-                .withNewMetadata().withName(podName3).endMetadata()
-                .withNewSpec().withNodeName(nodeName2).endSpec()
-                .withNewStatus().withStartTime(startTimePod3)
-                .addNewContainerStatus().withRestartCount(restartsPod3).endContainerStatus()
-                .withPhase(podPhase)
-                .withHostIP(hostIp)
-                .endStatus()
-                .endItem()
-                .addNewItem()
-                .withNewMetadata().withName(podName4).endMetadata()
-                .withNewSpec().withNodeName(nodeName2).endSpec()
-                .withNewStatus().withStartTime(startTimePod4)
-                .addNewContainerStatus().withRestartCount(restartsPod4).endContainerStatus()
-                .withPhase(podPhase)
-                .withHostIP(hostIp)
-                .endStatus()
-                .endItem()
-                .build();
+            .addNewItem()
+            .withNewMetadata().withName(podName1).endMetadata()
+            .withNewSpec().withNodeName(nodeName1).endSpec()
+            .withNewStatus().withStartTime(startTimePod1).
+                addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().
+                withPhase(podPhase).
+                withHostIP(hostIp)
+            .endStatus()
+            .endItem()
+            .addNewItem()
+            .withNewMetadata().withName(podName2).endMetadata()
+            .withNewSpec().withNodeName(nodeName1).endSpec()
+            .withNewStatus().withStartTime(startTimePod2)
+            .addNewContainerStatus().withRestartCount(restartsPod2).endContainerStatus()
+            .withPhase(podPhase)
+            .withHostIP(hostIp)
+            .endStatus()
+            .endItem()
+            .addNewItem()
+            .withNewMetadata().withName(podName3).endMetadata()
+            .withNewSpec().withNodeName(nodeName2).endSpec()
+            .withNewStatus().withStartTime(startTimePod3)
+            .addNewContainerStatus().withRestartCount(restartsPod3).endContainerStatus()
+            .withPhase(podPhase)
+            .withHostIP(hostIp)
+            .endStatus()
+            .endItem()
+            .addNewItem()
+            .withNewMetadata().withName(podName4).endMetadata()
+            .withNewSpec().withNodeName(nodeName2).endSpec()
+            .withNewStatus().withStartTime(startTimePod4)
+            .addNewContainerStatus().withRestartCount(restartsPod4).endContainerStatus()
+            .withPhase(podPhase)
+            .withHostIP(hostIp)
+            .endStatus()
+            .endItem()
+            .build();
 
         podListWithOnePod = new PodListBuilder()
-                .addNewItem()
-                .withNewMetadata().withName(podName1).endMetadata()
-                .withNewSpec().withNodeName(nodeName1).endSpec()
-                .withNewStatus().withStartTime(startTimePod1).addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().withPhase(podPhase).withHostIP(hostIp).endStatus()
-                .endItem()
-                .build();
+            .addNewItem()
+            .withNewMetadata().withName(podName1).endMetadata()
+            .withNewSpec().withNodeName(nodeName1).endSpec()
+            .withNewStatus().withStartTime(startTimePod1).addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().withPhase(podPhase).withHostIP(hostIp).endStatus()
+            .endItem()
+            .build();
     }
 
     @Test
@@ -239,78 +260,74 @@ public class MicoStatusServiceTest {
     public void getApplicationStatus() {
         MicoApplicationStatusResponseDTO micoApplicationStatus = new MicoApplicationStatusResponseDTO();
         micoApplicationStatus
-                .setTotalNumberOfRequestedReplicas(1)
-                .setTotalNumberOfAvailableReplicas(1)
-                .setTotalNumberOfPods(4)
-                .setTotalNumberOfMicoServices(1)
-                .setServiceStatuses(CollectionUtils.listOf(new MicoServiceStatusResponseDTO()
-                        .setName(NAME)
-                        .setShortName(SHORT_NAME)
-                        .setVersion(VERSION)
-                        .setAvailableReplicas(1)
-                        .setRequestedReplicas(1)
-                        .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
-                        .setNodeMetrics(CollectionUtils.listOf(
-                                new KubernetesNodeMetricsResponseDTO()
-                                        .setNodeName(nodeName1)
-                                        .setAverageCpuLoad(20)
-                                        .setAverageMemoryUsage(60),
-                                new KubernetesNodeMetricsResponseDTO()
-                                        .setNodeName(nodeName2)
-                                        .setAverageCpuLoad(7)
-                                        .setAverageMemoryUsage(57)
-                        ))
-                        // Add four pods (on two different nodes)
-                        .setPodsInformation(Arrays.asList(
-                                new KubernetesPodInformationResponseDTO()
-                                        .setPodName(podName1)
-                                        .setHostIp(hostIp)
-                                        .setNodeName(nodeName1)
-                                        .setPhase(podPhase)
-                                        .setStartTime(startTimePod1)
-                                        .setRestarts(restartsPod1)
-                                        .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                                .setMemoryUsage(memoryUsagePod1)
-                                                .setCpuLoad(cpuLoadPod1)
-                                                .setAvailable(podAvailablePod1)),
-                                new KubernetesPodInformationResponseDTO()
-                                        .setPodName(podName2)
-                                        .setHostIp(hostIp)
-                                        .setNodeName(nodeName1)
-                                        .setPhase(podPhase)
-                                        .setStartTime(startTimePod2)
-                                        .setRestarts(restartsPod2)
-                                        .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                                .setMemoryUsage(memoryUsagePod2)
-                                                .setCpuLoad(cpuLoadPod2)
-                                                .setAvailable(podAvailablePod2)),
-                                new KubernetesPodInformationResponseDTO()
-                                        .setPodName(podName3)
-                                        .setHostIp(hostIp)
-                                        .setNodeName(nodeName2)
-                                        .setPhase(podPhase)
-                                        .setStartTime(startTimePod3)
-                                        .setRestarts(restartsPod3)
-                                        .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                                .setMemoryUsage(memoryUsagePod3)
-                                                .setCpuLoad(cpuLoadPod3)
-                                                .setAvailable(podAvailablePod3)),
-                                new KubernetesPodInformationResponseDTO()
-                                        .setPodName(podName4)
-                                        .setHostIp(hostIp)
-                                        .setNodeName(nodeName2)
-                                        .setPhase(podPhase)
-                                        .setStartTime(startTimePod4)
-                                        .setRestarts(restartsPod4)
-                                        .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                                .setMemoryUsage(memoryUsagePod4)
-                                                .setCpuLoad(cpuLoadPod4)
-                                                .setAvailable(podAvailablePod4))))
-                        .setErrorMessages(CollectionUtils.listOf())
-                        .setInterfacesInformation(CollectionUtils.listOf(
-                                new MicoServiceInterfaceStatusResponseDTO()
-                                        .setName(SERVICE_INTERFACE_NAME)
-                                        .setExternalIp("192.168.2.112")))))
+            .setTotalNumberOfRequestedReplicas(1)
+            .setTotalNumberOfAvailableReplicas(1)
+            .setTotalNumberOfPods(4)
+            .setTotalNumberOfMicoServices(1)
+            .setServiceStatuses(CollectionUtils.listOf(new MicoServiceStatusResponseDTO()
+                .setName(NAME)
+                .setShortName(SHORT_NAME)
+                .setVersion(VERSION)
+                .setAvailableReplicas(1)
+                .setRequestedReplicas(1)
+                .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+                .setNodeMetrics(CollectionUtils.listOf(
+                    new KubernetesNodeMetricsResponseDTO()
+                        .setNodeName(nodeName1)
+                        .setAverageCpuLoad(20)
+                        .setAverageMemoryUsage(60),
+                    new KubernetesNodeMetricsResponseDTO()
+                        .setNodeName(nodeName2)
+                        .setAverageCpuLoad(7)
+                        .setAverageMemoryUsage(57)
+                ))
+                // Add four pods (on two different nodes)
+                .setPodsInformation(Arrays.asList(
+                    new KubernetesPodInformationResponseDTO()
+                        .setPodName(podName1)
+                        .setHostIp(hostIp)
+                        .setNodeName(nodeName1)
+                        .setPhase(podPhase)
+                        .setStartTime(startTimePod1)
+                        .setRestarts(restartsPod1)
+                        .setMetrics(new KubernetesPodMetricsResponseDTO()
+                            .setMemoryUsage(memoryUsagePod1)
+                            .setCpuLoad(cpuLoadPod1)),
+                    new KubernetesPodInformationResponseDTO()
+                        .setPodName(podName2)
+                        .setHostIp(hostIp)
+                        .setNodeName(nodeName1)
+                        .setPhase(podPhase)
+                        .setStartTime(startTimePod2)
+                        .setRestarts(restartsPod2)
+                        .setMetrics(new KubernetesPodMetricsResponseDTO()
+                            .setMemoryUsage(memoryUsagePod2)
+                            .setCpuLoad(cpuLoadPod2)),
+                    new KubernetesPodInformationResponseDTO()
+                        .setPodName(podName3)
+                        .setHostIp(hostIp)
+                        .setNodeName(nodeName2)
+                        .setPhase(podPhase)
+                        .setStartTime(startTimePod3)
+                        .setRestarts(restartsPod3)
+                        .setMetrics(new KubernetesPodMetricsResponseDTO()
+                            .setMemoryUsage(memoryUsagePod3)
+                            .setCpuLoad(cpuLoadPod3)),
+                    new KubernetesPodInformationResponseDTO()
+                        .setPodName(podName4)
+                        .setHostIp(hostIp)
+                        .setNodeName(nodeName2)
+                        .setPhase(podPhase)
+                        .setStartTime(startTimePod4)
+                        .setRestarts(restartsPod4)
+                        .setMetrics(new KubernetesPodMetricsResponseDTO()
+                            .setMemoryUsage(memoryUsagePod4)
+                            .setCpuLoad(cpuLoadPod4))))
+                .setErrorMessages(CollectionUtils.listOf())
+                .setInterfacesInformation(CollectionUtils.listOf(
+                    new MicoServiceInterfaceStatusResponseDTO()
+                        .setName(SERVICE_INTERFACE_NAME)
+                        .setExternalIp("192.168.2.112")))))
         ;
         try {
             given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(deployment);
@@ -334,14 +351,14 @@ public class MicoStatusServiceTest {
         ResponseEntity responseEntityMemoryUsagePod4 = getPrometheusResponseEntity(memoryUsagePod4);
         ResponseEntity responseEntityCpuLoadPod4 = getPrometheusResponseEntity(cpuLoadPod4);
         given(restTemplate.getForEntity(any(), eq(PrometheusResponseDTO.class))).
-                willReturn(responseEntityMemoryUsagePod1)
-                .willReturn(responseEntityCpuLoadPod1)
-                .willReturn(responseEntityMemoryUsagePod2)
-                .willReturn(responseEntityCpuLoadPod2)
-                .willReturn(responseEntityMemoryUsagePod3)
-                .willReturn(responseEntityCpuLoadPod3)
-                .willReturn(responseEntityMemoryUsagePod4)
-                .willReturn(responseEntityCpuLoadPod4);
+            willReturn(responseEntityMemoryUsagePod1)
+            .willReturn(responseEntityCpuLoadPod1)
+            .willReturn(responseEntityMemoryUsagePod2)
+            .willReturn(responseEntityCpuLoadPod2)
+            .willReturn(responseEntityMemoryUsagePod3)
+            .willReturn(responseEntityCpuLoadPod3)
+            .willReturn(responseEntityMemoryUsagePod4)
+            .willReturn(responseEntityCpuLoadPod4);
         assertEquals(micoApplicationStatus, micoStatusService.getApplicationStatus(micoApplication));
     }
 
@@ -350,41 +367,40 @@ public class MicoStatusServiceTest {
     public void getApplicationStatusWithMissingKubernetesService() {
         MicoApplicationStatusResponseDTO micoApplicationStatus = new MicoApplicationStatusResponseDTO();
         micoApplicationStatus
-                .setTotalNumberOfRequestedReplicas(1)
-                .setTotalNumberOfAvailableReplicas(1)
-                .setTotalNumberOfPods(1)
-                .setTotalNumberOfMicoServices(1)
-                .setServiceStatuses(CollectionUtils.listOf(new MicoServiceStatusResponseDTO()
-                        .setName(NAME)
-                        .setShortName(SHORT_NAME)
-                        .setVersion(VERSION)
-                        .setAvailableReplicas(1)
-                        .setRequestedReplicas(1)
-                        .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
-                        .setNodeMetrics(CollectionUtils.listOf(
-                                new KubernetesNodeMetricsResponseDTO()
-                                        .setNodeName(nodeName1)
-                                        .setAverageCpuLoad(30)
-                                        .setAverageMemoryUsage(70)
-                        ))
-                        // Add four pods (on two different nodes)
-                        .setPodsInformation(CollectionUtils.listOf(
-                                new KubernetesPodInformationResponseDTO()
-                                        .setPodName(podName1)
-                                        .setHostIp(hostIp)
-                                        .setNodeName(nodeName1)
-                                        .setPhase(podPhase)
-                                        .setStartTime(startTimePod1)
-                                        .setRestarts(restartsPod1)
-                                        .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                                .setMemoryUsage(memoryUsagePod1)
-                                                .setCpuLoad(cpuLoadPod1)
-                                                .setAvailable(podAvailablePod1))))
-                        .setErrorMessages(CollectionUtils.listOf(
-                          new MicoMessageResponseDTO().setContent("404 NOT_FOUND \"No deployed service interface 'service-interface-name' of MicoService 'short-name' '1.0.0' was found!\"").setType(Type.ERROR)))
-                        .setInterfacesInformation(CollectionUtils.listOf(
-                                new MicoServiceInterfaceStatusResponseDTO()
-                                        .setName(SERVICE_INTERFACE_NAME))))); // No IPs
+            .setTotalNumberOfRequestedReplicas(1)
+            .setTotalNumberOfAvailableReplicas(1)
+            .setTotalNumberOfPods(1)
+            .setTotalNumberOfMicoServices(1)
+            .setServiceStatuses(CollectionUtils.listOf(new MicoServiceStatusResponseDTO()
+                .setName(NAME)
+                .setShortName(SHORT_NAME)
+                .setVersion(VERSION)
+                .setAvailableReplicas(1)
+                .setRequestedReplicas(1)
+                .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+                .setNodeMetrics(CollectionUtils.listOf(
+                    new KubernetesNodeMetricsResponseDTO()
+                        .setNodeName(nodeName1)
+                        .setAverageCpuLoad(30)
+                        .setAverageMemoryUsage(70)
+                ))
+                // Add four pods (on two different nodes)
+                .setPodsInformation(CollectionUtils.listOf(
+                    new KubernetesPodInformationResponseDTO()
+                        .setPodName(podName1)
+                        .setHostIp(hostIp)
+                        .setNodeName(nodeName1)
+                        .setPhase(podPhase)
+                        .setStartTime(startTimePod1)
+                        .setRestarts(restartsPod1)
+                        .setMetrics(new KubernetesPodMetricsResponseDTO()
+                            .setMemoryUsage(memoryUsagePod1)
+                            .setCpuLoad(cpuLoadPod1))))
+                .setErrorMessages(CollectionUtils.listOf(
+                    new MicoMessageResponseDTO().setContent("404 NOT_FOUND \"No deployed service interface 'service-interface-name' of MicoService 'short-name' '1.0.0' was found!\"").setType(Type.ERROR)))
+                .setInterfacesInformation(CollectionUtils.listOf(
+                    new MicoServiceInterfaceStatusResponseDTO()
+                        .setName(SERVICE_INTERFACE_NAME))))); // No IPs
         try {
             given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(deployment);
             given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.of(micoServiceInterface));
@@ -401,11 +417,11 @@ public class MicoStatusServiceTest {
         ResponseEntity responseEntityMemoryUsagePod1 = getPrometheusResponseEntity(memoryUsagePod1);
         ResponseEntity responseEntityCpuLoadPod1 = getPrometheusResponseEntity(cpuLoadPod1);
         given(restTemplate.getForEntity(any(), eq(PrometheusResponseDTO.class))).
-                willReturn(responseEntityMemoryUsagePod1)
-                .willReturn(responseEntityCpuLoadPod1);
+            willReturn(responseEntityMemoryUsagePod1)
+            .willReturn(responseEntityCpuLoadPod1);
         assertEquals(micoApplicationStatus, micoStatusService.getApplicationStatus(micoApplication));
     }
-        
+
     @Test
     public void getApplicationStatusWithMissingDeployment() {
         MicoApplicationStatusResponseDTO micoApplicationStatus = new MicoApplicationStatusResponseDTO();
@@ -415,9 +431,9 @@ public class MicoStatusServiceTest {
             .setTotalNumberOfPods(0)
             .setTotalNumberOfMicoServices(1)
             .setServiceStatuses(CollectionUtils.listOf(new MicoServiceStatusResponseDTO()
-		        .setErrorMessages(CollectionUtils
-		            .listOf(new MicoMessageResponseDTO().setContent("No deployment of MicoService '" + micoService.getShortName()
-		                + "' '" + micoService.getVersion() + "' is available.").setType(Type.ERROR)))));
+                .setErrorMessages(CollectionUtils
+                    .listOf(new MicoMessageResponseDTO().setContent("No deployment of MicoService '" + micoService.getShortName()
+                        + "' '" + micoService.getVersion() + "' is available.").setType(Type.ERROR)))));
         try {
             given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(Optional.empty());
             given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(kubernetesService);
@@ -425,7 +441,7 @@ public class MicoStatusServiceTest {
         } catch (KubernetesResourceException e) {
             e.printStackTrace();
         }
-        
+
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
         given(serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion())).willReturn(CollectionUtils.listOf(micoService));
         assertEquals(micoApplicationStatus, micoStatusService.getApplicationStatus(micoApplication));
@@ -448,72 +464,68 @@ public class MicoStatusServiceTest {
     public void getServiceStatus() {
         MicoServiceStatusResponseDTO micoServiceStatus = new MicoServiceStatusResponseDTO();
         micoServiceStatus
-                .setName(NAME)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setAvailableReplicas(1)
-                .setRequestedReplicas(1)
-                .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
-                .setNodeMetrics(CollectionUtils.listOf(
-                        new KubernetesNodeMetricsResponseDTO()
-                                .setNodeName(nodeName1)
-                                .setAverageCpuLoad(20)
-                                .setAverageMemoryUsage(60),
-                        new KubernetesNodeMetricsResponseDTO()
-                                .setNodeName(nodeName2)
-                                .setAverageCpuLoad(7)
-                                .setAverageMemoryUsage(57)
-                ))
-                // Add four pods (on two different nodes)
-                .setPodsInformation(Arrays.asList(
-                        new KubernetesPodInformationResponseDTO()
-                                .setPodName(podName1)
-                                .setHostIp(hostIp)
-                                .setNodeName(nodeName1)
-                                .setPhase(podPhase)
-                                .setStartTime(startTimePod1)
-                                .setRestarts(restartsPod1)
-                                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                        .setMemoryUsage(memoryUsagePod1)
-                                        .setCpuLoad(cpuLoadPod1)
-                                        .setAvailable(podAvailablePod1)),
-                        new KubernetesPodInformationResponseDTO()
-                                .setPodName(podName2)
-                                .setHostIp(hostIp)
-                                .setNodeName(nodeName1)
-                                .setPhase(podPhase)
-                                .setStartTime(startTimePod2)
-                                .setRestarts(restartsPod2)
-                                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                        .setMemoryUsage(memoryUsagePod2)
-                                        .setCpuLoad(cpuLoadPod2)
-                                        .setAvailable(podAvailablePod2)),
-                        new KubernetesPodInformationResponseDTO()
-                                .setPodName(podName3)
-                                .setHostIp(hostIp)
-                                .setNodeName(nodeName2)
-                                .setPhase(podPhase)
-                                .setStartTime(startTimePod3)
-                                .setRestarts(restartsPod3)
-                                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                        .setMemoryUsage(memoryUsagePod3)
-                                        .setCpuLoad(cpuLoadPod3)
-                                        .setAvailable(podAvailablePod3)),
-                        new KubernetesPodInformationResponseDTO()
-                                .setPodName(podName4)
-                                .setHostIp(hostIp)
-                                .setNodeName(nodeName2)
-                                .setPhase(podPhase)
-                                .setStartTime(startTimePod4)
-                                .setRestarts(restartsPod4)
-                                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                                        .setMemoryUsage(memoryUsagePod4)
-                                        .setCpuLoad(cpuLoadPod4)
-                                        .setAvailable(podAvailablePod4))))
-                .setErrorMessages(CollectionUtils.listOf())
-                .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO()
-                        .setName(SERVICE_INTERFACE_NAME)
-                        .setExternalIp("192.168.2.112")));
+            .setName(NAME)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setAvailableReplicas(1)
+            .setRequestedReplicas(1)
+            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+            .setNodeMetrics(CollectionUtils.listOf(
+                new KubernetesNodeMetricsResponseDTO()
+                    .setNodeName(nodeName1)
+                    .setAverageCpuLoad(20)
+                    .setAverageMemoryUsage(60),
+                new KubernetesNodeMetricsResponseDTO()
+                    .setNodeName(nodeName2)
+                    .setAverageCpuLoad(7)
+                    .setAverageMemoryUsage(57)
+            ))
+            // Add four pods (on two different nodes)
+            .setPodsInformation(Arrays.asList(
+                new KubernetesPodInformationResponseDTO()
+                    .setPodName(podName1)
+                    .setHostIp(hostIp)
+                    .setNodeName(nodeName1)
+                    .setPhase(podPhase)
+                    .setStartTime(startTimePod1)
+                    .setRestarts(restartsPod1)
+                    .setMetrics(new KubernetesPodMetricsResponseDTO()
+                        .setMemoryUsage(memoryUsagePod1)
+                        .setCpuLoad(cpuLoadPod1)),
+                new KubernetesPodInformationResponseDTO()
+                    .setPodName(podName2)
+                    .setHostIp(hostIp)
+                    .setNodeName(nodeName1)
+                    .setPhase(podPhase)
+                    .setStartTime(startTimePod2)
+                    .setRestarts(restartsPod2)
+                    .setMetrics(new KubernetesPodMetricsResponseDTO()
+                        .setMemoryUsage(memoryUsagePod2)
+                        .setCpuLoad(cpuLoadPod2)),
+                new KubernetesPodInformationResponseDTO()
+                    .setPodName(podName3)
+                    .setHostIp(hostIp)
+                    .setNodeName(nodeName2)
+                    .setPhase(podPhase)
+                    .setStartTime(startTimePod3)
+                    .setRestarts(restartsPod3)
+                    .setMetrics(new KubernetesPodMetricsResponseDTO()
+                        .setMemoryUsage(memoryUsagePod3)
+                        .setCpuLoad(cpuLoadPod3)),
+                new KubernetesPodInformationResponseDTO()
+                    .setPodName(podName4)
+                    .setHostIp(hostIp)
+                    .setNodeName(nodeName2)
+                    .setPhase(podPhase)
+                    .setStartTime(startTimePod4)
+                    .setRestarts(restartsPod4)
+                    .setMetrics(new KubernetesPodMetricsResponseDTO()
+                        .setMemoryUsage(memoryUsagePod4)
+                        .setCpuLoad(cpuLoadPod4))))
+            .setErrorMessages(CollectionUtils.listOf())
+            .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO()
+                .setName(SERVICE_INTERFACE_NAME)
+                .setExternalIp("192.168.2.112")));
         try {
             given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(deployment);
             given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(kubernetesService);
@@ -535,14 +547,14 @@ public class MicoStatusServiceTest {
         ResponseEntity responseEntityMemoryUsagePod4 = getPrometheusResponseEntity(memoryUsagePod4);
         ResponseEntity responseEntityCpuLoadPod4 = getPrometheusResponseEntity(cpuLoadPod4);
         given(restTemplate.getForEntity(any(), eq(PrometheusResponseDTO.class))).
-                willReturn(responseEntityMemoryUsagePod1)
-                .willReturn(responseEntityCpuLoadPod1)
-                .willReturn(responseEntityMemoryUsagePod2)
-                .willReturn(responseEntityCpuLoadPod2)
-                .willReturn(responseEntityMemoryUsagePod3)
-                .willReturn(responseEntityCpuLoadPod3)
-                .willReturn(responseEntityMemoryUsagePod4)
-                .willReturn(responseEntityCpuLoadPod4);
+            willReturn(responseEntityMemoryUsagePod1)
+            .willReturn(responseEntityCpuLoadPod1)
+            .willReturn(responseEntityMemoryUsagePod2)
+            .willReturn(responseEntityCpuLoadPod2)
+            .willReturn(responseEntityMemoryUsagePod3)
+            .willReturn(responseEntityCpuLoadPod3)
+            .willReturn(responseEntityMemoryUsagePod4)
+            .willReturn(responseEntityCpuLoadPod4);
         assertEquals(micoServiceStatus, micoStatusService.getServiceStatus(micoService));
     }
 
@@ -550,12 +562,12 @@ public class MicoStatusServiceTest {
     public void getServiceInterfaceStatus() throws KubernetesResourceException {
 
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(micoService, SERVICE_INTERFACE_NAME))
-                .willReturn(kubernetesService);
+            .willReturn(kubernetesService);
         given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.of(micoServiceInterface));
 
         MicoServiceInterfaceStatusResponseDTO expectedServiceInterface = new MicoServiceInterfaceStatusResponseDTO()
-                .setName(SERVICE_INTERFACE_NAME)
-                .setExternalIp("192.168.2.112");
+            .setName(SERVICE_INTERFACE_NAME)
+            .setExternalIp("192.168.2.112");
         List<MicoServiceInterfaceStatusResponseDTO> expectedInterfaceStatusDTO = new LinkedList<>();
         expectedInterfaceStatusDTO.add(expectedServiceInterface);
         List<MicoMessageResponseDTO> errorMessages = new ArrayList<>();
@@ -571,10 +583,10 @@ public class MicoStatusServiceTest {
 
         given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.empty());
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(micoService, SERVICE_INTERFACE_NAME))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         MicoServiceInterfaceStatusResponseDTO expectedServiceInterface = new MicoServiceInterfaceStatusResponseDTO()
-                .setName(SERVICE_INTERFACE_NAME); // Expect that there are no IPs
+            .setName(SERVICE_INTERFACE_NAME); // Expect that there are no IPs
         List<MicoServiceInterfaceStatusResponseDTO> expectedInterfaceStatusDTO = new LinkedList<>();
         expectedInterfaceStatusDTO.add(expectedServiceInterface);
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/PrometheusValueDeserializerTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/PrometheusValueDeserializerTest.java
@@ -19,14 +19,15 @@
 
 package io.github.ust.mico.core;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
 import org.junit.Test;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.io.IOException;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @ActiveProfiles("local")
 public class PrometheusValueDeserializerTest {
@@ -34,46 +35,63 @@ public class PrometheusValueDeserializerTest {
     @Test
     public void testDeserialize() {
         String testJsonForMemoryUsageRequest = "{\n" +
-                "    \"status\": \"success\",\n" +
-                "    \"data\": {\n" +
-                "        \"resultType\": \"vector\",\n" +
-                "        \"result\": [\n" +
-                "            {\n" +
-                "                \"metric\": {},\n" +
-                "                \"value\": [\n" +
-                "                    1552041266.607,\n" +
-                "                    \"310083584\"\n" +
-                "                ]\n" +
-                "            }\n" +
-                "        ]\n" +
-                "    }\n" +
-                "}";
+            "    \"status\": \"success\",\n" +
+            "    \"data\": {\n" +
+            "        \"resultType\": \"vector\",\n" +
+            "        \"result\": [\n" +
+            "            {\n" +
+            "                \"metric\": {},\n" +
+            "                \"value\": [\n" +
+            "                    1552041266.607,\n" +
+            "                    \"310083584\"\n" +
+            "                ]\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}";
 
         String testJsonForCpuLoadRequest = "{\n" +
-                "    \"status\": \"success\",\n" +
-                "    \"data\": {\n" +
-                "        \"resultType\": \"vector\",\n" +
-                "        \"result\": [\n" +
-                "            {\n" +
-                "                \"metric\": {},\n" +
-                "                \"value\": [\n" +
-                "                    1552042589.238,\n" +
-                "                    \"0\"\n" +
-                "                ]\n" +
-                "            }\n" +
-                "        ]\n" +
-                "    }\n" +
-                "}";
+            "    \"status\": \"success\",\n" +
+            "    \"data\": {\n" +
+            "        \"resultType\": \"vector\",\n" +
+            "        \"result\": [\n" +
+            "            {\n" +
+            "                \"metric\": {},\n" +
+            "                \"value\": [\n" +
+            "                    1552042589.238,\n" +
+            "                    \"0\"\n" +
+            "                ]\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}";
 
+        String testJsonForRequestWithNoValue = "{\n" +
+            "    \"status\": \"success\",\n" +
+            "    \"data\": {\n" +
+            "        \"resultType\": \"vector\",\n" +
+            "        \"result\": [\n" +
+            "            {\n" +
+            "                \"metric\": {},\n" +
+            "                \"value\": [\n" +
+            "                ]\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}";
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             PrometheusResponseDTO responseCpuLoad = objectMapper.readValue(testJsonForCpuLoadRequest, PrometheusResponseDTO.class);
-            assertEquals(true, responseCpuLoad.isSuccess());
+            assertTrue(responseCpuLoad.isSuccess());
             assertEquals(0, responseCpuLoad.getValue());
 
             PrometheusResponseDTO responseMemoryUsage = objectMapper.readValue(testJsonForMemoryUsageRequest, PrometheusResponseDTO.class);
-            assertEquals(true, responseMemoryUsage.isSuccess());
+            assertTrue(responseMemoryUsage.isSuccess());
             assertEquals(310083584, responseMemoryUsage.getValue());
+
+            PrometheusResponseDTO responseDtoWithoutValue = objectMapper.readValue(testJsonForRequestWithNoValue, PrometheusResponseDTO.class);
+            assertTrue(responseDtoWithoutValue.isSuccess());
+            assertEquals(0, responseDtoWithoutValue.getValue());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
@@ -97,8 +97,6 @@ import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_METRICS_AVE
 import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE;
 import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_NAME;
 import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO;
-import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1;
-import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2;
 import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1;
 import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2;
 import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1;
@@ -269,13 +267,11 @@ public class ServiceResourceIntegrationTests {
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_1, is(nodeName)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsagePod1)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoadPod1)))
-            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1, is(false)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_2, is(podName2)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_2, is(podPhase)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_2, is(nodeName)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsagePod2)))
             .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoadPod2)))
-            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2, is(true)))
             .andExpect(jsonPath(SERVICE_DTO_ERROR_MESSAGES, is(CollectionUtils.listOf())));
     }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
@@ -19,13 +19,27 @@
 
 package io.github.ust.mico.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.github.ust.mico.core.dto.request.MicoServiceRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
-import io.github.ust.mico.core.dto.response.status.*;
-import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.dto.response.status.KubernetesNodeMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodInformationResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceStatusResponseDTO;
+import io.github.ust.mico.core.model.MicoPortType;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDependency;
+import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.model.MicoServicePort;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.service.GitHubCrawler;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
@@ -48,23 +62,95 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.*;
-
-import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.JsonPathBuilder.HREF;
+import static io.github.ust.mico.core.JsonPathBuilder.LINKS;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT_EMBEDDED;
+import static io.github.ust.mico.core.JsonPathBuilder.SELF;
+import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
+import static io.github.ust.mico.core.TestConstants.BASE_URL;
+import static io.github.ust.mico.core.TestConstants.DEPENDEES_SUBPATH;
+import static io.github.ust.mico.core.TestConstants.DEPENDERS_SUBPATH;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_1;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_2;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_3;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.ID;
+import static io.github.ust.mico.core.TestConstants.ID_1;
+import static io.github.ust.mico.core.TestConstants.ID_2;
+import static io.github.ust.mico.core.TestConstants.NAME;
+import static io.github.ust.mico.core.TestConstants.NAME_1;
+import static io.github.ust.mico.core.TestConstants.NAME_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.NAME_2;
+import static io.github.ust.mico.core.TestConstants.NAME_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.NAME_3;
+import static io.github.ust.mico.core.TestConstants.NAME_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SERVICES_PATH;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_AVAILABLE_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_ERROR_MESSAGES;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_INTERFACES_INFORMATION;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_INTERFACES_INFORMATION_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_NODE_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_NODE_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_PHASE_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_PHASE_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_POD_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_POD_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_REQUESTED_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_SERVICE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME_1;
 import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_3;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_INVALID;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_MATCHER;
 import static io.github.ust.mico.core.TestConstants.VERSION;
-import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_3;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.VERSION_MATCHER;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @EnableAutoConfiguration
@@ -111,10 +197,10 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void getStatusOfService() throws Exception {
         MicoService micoService = new MicoService()
-                .setName(NAME)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION_1);
+            .setName(NAME)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION_1);
 
         String nodeName = "testNode";
         String podPhase = "Running";
@@ -132,131 +218,129 @@ public class ServiceResourceIntegrationTests {
 
         KubernetesPodInformationResponseDTO kubernetesPodInfo1 = new KubernetesPodInformationResponseDTO();
         kubernetesPodInfo1
-                .setHostIp(hostIp)
-                .setNodeName(nodeName)
-                .setPhase(podPhase)
-                .setPodName(podName1)
-                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setAvailable(false)
-                        .setCpuLoad(cpuLoadPod1)
-                        .setMemoryUsage(memoryUsagePod1));
+            .setHostIp(hostIp)
+            .setNodeName(nodeName)
+            .setPhase(podPhase)
+            .setPodName(podName1)
+            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                .setCpuLoad(cpuLoadPod1)
+                .setMemoryUsage(memoryUsagePod1));
         KubernetesPodInformationResponseDTO kubernetesPodInfo2 = new KubernetesPodInformationResponseDTO();
         kubernetesPodInfo2
-                .setHostIp(hostIp)
-                .setNodeName(nodeName)
-                .setPhase(podPhase)
-                .setPodName(podName2)
-                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setAvailable(true)
-                        .setCpuLoad(cpuLoadPod2)
-                        .setMemoryUsage(memoryUsagePod2));
+            .setHostIp(hostIp)
+            .setNodeName(nodeName)
+            .setPhase(podPhase)
+            .setPodName(podName2)
+            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                .setCpuLoad(cpuLoadPod2)
+                .setMemoryUsage(memoryUsagePod2));
 
         micoServiceStatus
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setShortName(SHORT_NAME)
-                .setAvailableReplicas(availableReplicas)
-                .setRequestedReplicas(requestedReplicas)
-                .setNodeMetrics(CollectionUtils.listOf(new KubernetesNodeMetricsResponseDTO()
-                        .setNodeName(nodeName)
-                        .setAverageCpuLoad(25)
-                        .setAverageMemoryUsage(60)
-                ))
-                .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
-                .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2));
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setShortName(SHORT_NAME)
+            .setAvailableReplicas(availableReplicas)
+            .setRequestedReplicas(requestedReplicas)
+            .setNodeMetrics(CollectionUtils.listOf(new KubernetesNodeMetricsResponseDTO()
+                .setNodeName(nodeName)
+                .setAverageCpuLoad(25)
+                .setAverageMemoryUsage(60)
+            ))
+            .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
+            .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2));
 
         given(micoStatusService.getServiceStatus(any(MicoService.class))).willReturn(micoServiceStatus);
         given(serviceRepository.findByShortNameAndVersion(ArgumentMatchers.anyString(), ArgumentMatchers.any())).willReturn(Optional.of(micoService));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/status"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SERVICE_DTO_SERVICE_NAME, is(NAME)))
-                .andExpect(jsonPath(SERVICE_DTO_REQUESTED_REPLICAS, is(requestedReplicas)))
-                .andExpect(jsonPath(SERVICE_DTO_AVAILABLE_REPLICAS, is(availableReplicas)))
-                .andExpect(jsonPath(SERVICE_DTO_NODE_NAME, is(nodeName)))
-                .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
-                .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
-                .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION, hasSize(1)))
-                .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION_NAME, is(SERVICE_INTERFACE_NAME)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO, hasSize(2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_1, is(podName1)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_1, is(podPhase)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_1, is(nodeName)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsagePod1)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoadPod1)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1, is(false)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_2, is(podName2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_2, is(podPhase)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_2, is(nodeName)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsagePod2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoadPod2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2, is(true)))
-                .andExpect(jsonPath(SERVICE_DTO_ERROR_MESSAGES, is(CollectionUtils.listOf())));
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SERVICE_DTO_SERVICE_NAME, is(NAME)))
+            .andExpect(jsonPath(SERVICE_DTO_REQUESTED_REPLICAS, is(requestedReplicas)))
+            .andExpect(jsonPath(SERVICE_DTO_AVAILABLE_REPLICAS, is(availableReplicas)))
+            .andExpect(jsonPath(SERVICE_DTO_NODE_NAME, is(nodeName)))
+            .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
+            .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
+            .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION, hasSize(1)))
+            .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION_NAME, is(SERVICE_INTERFACE_NAME)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO, hasSize(2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_1, is(podName1)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_1, is(podPhase)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_1, is(nodeName)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsagePod1)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoadPod1)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1, is(false)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_2, is(podName2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_2, is(podPhase)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_2, is(nodeName)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsagePod2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoadPod2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2, is(true)))
+            .andExpect(jsonPath(SERVICE_DTO_ERROR_MESSAGES, is(CollectionUtils.listOf())));
     }
 
     @Test
     public void getStatusOfNotExistentService() throws Exception {
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME_2 + "/" + VERSION + "/status"))
-                .andDo(print())
-                .andExpect(status().isNotFound());
+            .andDo(print())
+            .andExpect(status().isNotFound());
     }
 
     @Test
     public void getCompleteServiceList() throws Exception {
         given(serviceRepository.findAll(ArgumentMatchers.anyInt())).willReturn(
-                CollectionUtils.listOf(
-                        new MicoService().setShortName(SHORT_NAME_1).setVersion(VERSION_1_0_1).setName(NAME_1).setDescription(DESCRIPTION_1),
-                        new MicoService().setShortName(SHORT_NAME_2).setVersion(VERSION_1_0_2).setName(NAME_2).setDescription(DESCRIPTION_2),
-                        new MicoService().setShortName(SHORT_NAME_3).setVersion(VERSION_1_0_3).setName(NAME_3).setDescription(DESCRIPTION_3)));
+            CollectionUtils.listOf(
+                new MicoService().setShortName(SHORT_NAME_1).setVersion(VERSION_1_0_1).setName(NAME_1).setDescription(DESCRIPTION_1),
+                new MicoService().setShortName(SHORT_NAME_2).setVersion(VERSION_1_0_2).setName(NAME_2).setDescription(DESCRIPTION_2),
+                new MicoService().setShortName(SHORT_NAME_3).setVersion(VERSION_1_0_3).setName(NAME_3).setDescription(DESCRIPTION_3)));
 
         mvc.perform(get("/services").accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER +
-                        " && " + NAME_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER +
-                        " && " + NAME_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER +
-                        " && " + NAME_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER +
+                " && " + NAME_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER +
+                " && " + NAME_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER +
+                " && " + NAME_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH)))
+            .andReturn();
     }
 
     @Test
     public void getServiceViaShortNameAndVersion() throws Exception {
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(
-                Optional.of(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setDescription(DESCRIPTION)));
+            Optional.of(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setDescription(DESCRIPTION)));
 
         String urlPath = SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION;
         mvc.perform(get(urlPath).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
-                .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(DESCRIPTION)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)))
-                .andExpect(jsonPath(SERVICES_HREF, is(BASE_URL + SERVICES_PATH)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(DESCRIPTION)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)))
+            .andExpect(jsonPath(SERVICES_HREF, is(BASE_URL + SERVICES_PATH)))
+            .andReturn();
     }
 
     @Test
     public void createService() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         given(serviceRepository.save(any(MicoService.class))).willReturn(service);
 
         final ResultActions result = mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         result.andExpect(status().isCreated());
     }
@@ -264,53 +348,53 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void createServiceWithInvalidShortName() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME_INVALID)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME_INVALID)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void createServiceWithoutRequiredName() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(null)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(null)
+            .setDescription(DESCRIPTION);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void createServiceWithDescriptionSetToNull() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(null);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(null);
 
         MicoService expectedService = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription("");
 
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
         given(serviceRepository.save(any(MicoService.class))).willReturn(expectedService);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated());
 
         verify(serviceRepository, times(1)).save(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -321,25 +405,25 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void createServiceWithEmptyDescription() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription("");
 
         MicoService expectedService = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription("");
 
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
         given(serviceRepository.save(any(MicoService.class))).willReturn(expectedService);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated());
 
         verify(serviceRepository, times(1)).save(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -350,34 +434,34 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void createServiceWithInvalidGitCloneUrl() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION)
-                .setGitCloneUrl("invalid-url");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setGitCloneUrl("invalid-url");
 
         given(serviceRepository.save(any(MicoService.class))).willReturn(service);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service))).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service))).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void deleteAllServiceDependees() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(service));
         given(serviceRepository.save(any(MicoService.class))).willReturn(service);
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultDelete.andExpect(status().isNoContent());
     }
@@ -396,9 +480,9 @@ public class ServiceResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(shortNameToDelete, versionToDelete)).willReturn(Optional.of(serviceToDelete));
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + shortName + "/" + version +
-                DEPENDEES_SUBPATH + "/" + shortNameToDelete + "/" + versionToDelete)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            DEPENDEES_SUBPATH + "/" + shortNameToDelete + "/" + versionToDelete)
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultDelete.andExpect(status().isNoContent());
     }
@@ -406,67 +490,67 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void deleteAllServices() throws Exception {
         MicoService micoServiceOne = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         MicoService micoServiceTwo = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME);
         MicoService micoServiceThree = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION_1_0_2)
-                .setName(NAME);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION_1_0_2)
+            .setName(NAME);
 
         given(serviceRepository.findByShortName(SHORT_NAME)).willReturn(CollectionUtils.listOf(micoServiceOne, micoServiceTwo, micoServiceThree));
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME))
-                .andDo(print())
-                .andExpect(status().isNoContent())
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isNoContent())
+            .andReturn();
     }
 
     @Test
     public void corsPolicy() throws Exception {
         mvc.perform(get(SERVICES_PATH).accept(MediaTypes.HAL_JSON_VALUE)
-                .header("Origin", (Object[]) allowedOrigins))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SELF_HREF, endsWith(SERVICES_PATH))).andReturn();
+            .header("Origin", (Object[]) allowedOrigins))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SELF_HREF, endsWith(SERVICES_PATH))).andReturn();
     }
 
     @Test
     public void corsPolicyNotAllowedOrigin() throws Exception {
         mvc.perform(get(SERVICES_PATH).accept(MediaTypes.HAL_JSON_VALUE)
-                .header("Origin", "http://notAllowedOrigin.com"))
-                .andDo(print())
-                .andExpect(status().isForbidden())
-                .andExpect(content().string(is("Invalid CORS request")))
-                .andReturn();
+            .header("Origin", "http://notAllowedOrigin.com"))
+            .andDo(print())
+            .andExpect(status().isForbidden())
+            .andExpect(content().string(is("Invalid CORS request")))
+            .andReturn();
     }
 
     @Test
     public void getServiceDependers() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         MicoService service1 = new MicoService()
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME)
-                .setDescription(DESCRIPTION_1);
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME)
+            .setDescription(DESCRIPTION_1);
         MicoService service2 = new MicoService()
-                .setShortName(SHORT_NAME_2)
-                .setVersion(VERSION_1_0_2)
-                .setDescription(DESCRIPTION_2);
+            .setShortName(SHORT_NAME_2)
+            .setVersion(VERSION_1_0_2)
+            .setDescription(DESCRIPTION_2);
         MicoService service3 = new MicoService()
-                .setShortName(SHORT_NAME_3)
-                .setVersion(VERSION_1_0_3)
-                .setName(NAME)
-                .setDescription(DESCRIPTION_3);
+            .setShortName(SHORT_NAME_3)
+            .setVersion(VERSION_1_0_3)
+            .setName(NAME)
+            .setDescription(DESCRIPTION_3);
 
         MicoServiceDependency dependency1 = new MicoServiceDependency().setService(service1).setDependedService(service);
         MicoServiceDependency dependency2 = new MicoServiceDependency().setService(service2).setDependedService(service);
@@ -481,13 +565,13 @@ public class ServiceResourceIntegrationTests {
 
         String urlPath = SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDERS_SUBPATH;
         ResultActions result = mvc.perform(get(urlPath)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)));
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)));
 
         result.andExpect(status().isOk());
     }
@@ -496,32 +580,32 @@ public class ServiceResourceIntegrationTests {
     public void updateService() throws Exception {
         String updatedDescription = "updated description.";
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         MicoServiceRequestDTO updatedServiceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(updatedDescription);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(updatedDescription);
         MicoService expectedService = new MicoService()
-                .setId(existingService.getId())
-                .setShortName(updatedServiceRequestDto.getShortName())
-                .setVersion(updatedServiceRequestDto.getVersion())
-                .setName(updatedServiceRequestDto.getName())
-                .setDescription(updatedServiceRequestDto.getDescription());
+            .setId(existingService.getId())
+            .setShortName(updatedServiceRequestDto.getShortName())
+            .setVersion(updatedServiceRequestDto.getVersion())
+            .setName(updatedServiceRequestDto.getName())
+            .setDescription(updatedServiceRequestDto.getDescription());
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(existingService));
         given(serviceRepository.save(eq(expectedService))).willReturn(expectedService);
 
         ResultActions resultUpdate = mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedDescription)))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
-                .andExpect(jsonPath(VERSION_PATH, is(VERSION)));
+            .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedDescription)))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)));
 
         resultUpdate.andExpect(status().isOk());
     }
@@ -529,22 +613,22 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void updateServiceWithoutRequiredName() throws Exception {
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         MicoService updatedService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(null);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(null);
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(existingService));
 
         ResultActions resultUpdate = mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(updatedService)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(updatedService)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultUpdate.andExpect(status().isUnprocessableEntity());
     }
@@ -552,23 +636,23 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void updateServiceWithDescriptionSetToNull() throws Exception {
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
         MicoServiceRequestDTO updatedServiceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(null);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(null);
 
         MicoService expectedService = new MicoService()
-                .setId(existingService.getId())
-                .setShortName(existingService.getShortName())
-                .setVersion(existingService.getVersion())
-                .setName(existingService.getName())
-                .setDescription("");
+            .setId(existingService.getId())
+            .setShortName(existingService.getShortName())
+            .setVersion(existingService.getVersion())
+            .setName(existingService.getName())
+            .setDescription("");
 
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
@@ -576,10 +660,10 @@ public class ServiceResourceIntegrationTests {
         given(serviceRepository.save(any(MicoService.class))).willReturn(expectedService);
 
         mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk());
+            .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk());
 
         verify(serviceRepository, times(1)).save(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -590,16 +674,16 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void deleteService() throws Exception {
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(existingService));
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultDelete.andExpect(status().isNoContent());
     }
@@ -607,53 +691,53 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void getVersionsOfService() throws Exception {
         given(serviceRepository.findByShortName(SHORT_NAME)).willReturn(
-                CollectionUtils.listOf(
-                        new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setName(NAME),
-                        new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_1).setName(NAME),
-                        new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_2).setName(NAME)));
+            CollectionUtils.listOf(
+                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setName(NAME),
+                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_1).setName(NAME),
+                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_2).setName(NAME)));
 
         mvc.perform(get("/services/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME)))
+            .andReturn();
     }
 
     @Test
     public void createNewDependee() throws Exception {
         MicoService existingService1 = new MicoService()
-                .setId(ID_1)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID_1)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
 
         MicoService existingService2 = new MicoService()
-                .setId(ID_2)
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME);
+            .setId(ID_2)
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME);
 
         MicoServiceDependency newDependency = new MicoServiceDependency()
-                .setService(new MicoService()
-                        .setShortName(SHORT_NAME)
-                        .setVersion(VERSION)
-                        .setName(NAME))
-                .setDependedService(new MicoService()
-                        .setShortName(SHORT_NAME_1)
-                        .setVersion(VERSION_1_0_1)
-                        .setName(NAME));
-
-        MicoService expectedService = new MicoService()
-                .setId(ID_1)
+            .setService(new MicoService()
                 .setShortName(SHORT_NAME)
                 .setVersion(VERSION)
-                .setName(NAME)
-                .setDependencies(Collections.singletonList(newDependency));
+                .setName(NAME))
+            .setDependedService(new MicoService()
+                .setShortName(SHORT_NAME_1)
+                .setVersion(VERSION_1_0_1)
+                .setName(NAME));
+
+        MicoService expectedService = new MicoService()
+            .setId(ID_1)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDependencies(Collections.singletonList(newDependency));
 
         prettyPrint(expectedService);
 
@@ -662,9 +746,9 @@ public class ServiceResourceIntegrationTests {
         given(serviceRepository.save(any(MicoService.class))).willReturn(expectedService);
 
         final ResultActions result = mvc.perform(post(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION +
-                DEPENDEES_SUBPATH + "/" + newDependency.getDependedService().getShortName() + "/" + newDependency.getDependedService().getVersion())
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            DEPENDEES_SUBPATH + "/" + newDependency.getDependedService().getShortName() + "/" + newDependency.getDependedService().getVersion())
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         result.andExpect(status().isNoContent());
     }
@@ -682,19 +766,19 @@ public class ServiceResourceIntegrationTests {
     @Test
     public void getDependees() throws Exception {
         MicoService service1 = new MicoService()
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME_1)
-                .setDescription(DESCRIPTION_1);
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME_1)
+            .setDescription(DESCRIPTION_1);
         MicoService service2 = new MicoService()
-                .setShortName(SHORT_NAME_2)
-                .setVersion(VERSION_1_0_2)
-                .setName(NAME_2)
-                .setDescription(DESCRIPTION_2);
+            .setShortName(SHORT_NAME_2)
+            .setVersion(VERSION_1_0_2)
+            .setName(NAME_2)
+            .setDescription(DESCRIPTION_2);
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setName(NAME)
-                .setVersion(VERSION);
+            .setShortName(SHORT_NAME)
+            .setName(NAME)
+            .setVersion(VERSION);
         MicoServiceDependency dependency1 = new MicoServiceDependency().setService(service).setDependedService(service1);
         MicoServiceDependency dependency2 = new MicoServiceDependency().setService(service).setDependedService(service2);
         service.setDependencies(CollectionUtils.listOf(dependency1, dependency2));
@@ -703,46 +787,46 @@ public class ServiceResourceIntegrationTests {
         given(serviceRepository.findDependees(service.getShortName(), service.getVersion())).willReturn(CollectionUtils.listOf(service1, service2));
 
         mvc.perform(get("/services/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(2)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(2)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH)))
+            .andReturn();
     }
 
     @Test
     public void deleteServiceWithDeployedService() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION);
 
         given(serviceRepository.findByShortName(SHORT_NAME)).willReturn(Collections.singletonList(service));
         given(micoKubernetesClient.isMicoServiceDeployed(any())).willReturn(true);
 
         mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isConflict());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isConflict());
     }
 
     @Test
     public void deleteSpecificServiceWithDeployedService() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION);
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(service));
         given(micoKubernetesClient.isMicoServiceDeployed(any())).willReturn(true);
 
         mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isConflict());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isConflict());
     }
 
     @Test
@@ -750,13 +834,13 @@ public class ServiceResourceIntegrationTests {
         MicoServicePort port = new MicoServicePort().setPort(1234).setType(MicoPortType.TCP).setTargetPort(5678);
 
         MicoServiceInterface micoServiceInterface = new MicoServiceInterface()
-                .setId(2000L)
-                .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
-                .setPorts(CollectionUtils.listOf(port));
+            .setId(2000L)
+            .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
+            .setPorts(CollectionUtils.listOf(port));
 
         MicoServiceInterface micoServiceInterfaceTwo = new MicoServiceInterface()
-                .setId(3000L)
-                .setServiceInterfaceName(SERVICE_INTERFACE_NAME_1);
+            .setId(3000L)
+            .setServiceInterfaceName(SERVICE_INTERFACE_NAME_1);
 
         List<MicoServiceInterface> micoServiceInterfaces = new ArrayList<>();
         micoServiceInterfaces.add(micoServiceInterface);
@@ -764,11 +848,11 @@ public class ServiceResourceIntegrationTests {
 
 
         MicoService micoService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setDescription(DESCRIPTION_1)
-                .setServiceInterfaces(micoServiceInterfaces);
+            .setId(ID)
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setDescription(DESCRIPTION_1)
+            .setServiceInterfaces(micoServiceInterfaces);
 
         String newVersion = VERSION_1_0_1;
         Long newId = ID_1;
@@ -782,13 +866,13 @@ public class ServiceResourceIntegrationTests {
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
         mvc.perform(post(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_PROMOTE)
-                .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(savedPromotedService.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(newVersion)))
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(savedPromotedService.getDescription())))
-                .andExpect(status().isOk());
+            .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(savedPromotedService.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(newVersion)))
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(savedPromotedService.getDescription())))
+            .andExpect(status().isOk());
 
         verify(serviceRepository, times(1)).save(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -807,14 +891,13 @@ public class ServiceResourceIntegrationTests {
         given(crawler.getVersionsFromGitHubRepo(anyString())).willReturn(versions);
 
         ResultActions resultPromotion = mvc.perform(get(SERVICES_PATH + "/import/github")
-                .param("url", anyString()))
-                .andDo(print())
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[0].version", is(versions.get(0))))
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[1].version", is(versions.get(1))))
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[2].version", is(versions.get(2))));
+            .param("url", anyString()))
+            .andDo(print())
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[0].version", is(versions.get(0))))
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[1].version", is(versions.get(1))))
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[2].version", is(versions.get(2))));
 
         resultPromotion.andExpect(status().isOk());
     }
-
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceUnitTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceUnitTests.java
@@ -19,13 +19,22 @@
 
 package io.github.ust.mico.core;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.github.ust.mico.core.broker.MicoServiceBroker;
 import io.github.ust.mico.core.dto.request.MicoServiceRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
-import io.github.ust.mico.core.dto.response.status.*;
+import io.github.ust.mico.core.dto.response.status.KubernetesNodeMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodInformationResponseDTO;
+import io.github.ust.mico.core.dto.response.status.KubernetesPodMetricsResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
+import io.github.ust.mico.core.dto.response.status.MicoServiceStatusResponseDTO;
 import io.github.ust.mico.core.exception.MicoServiceHasDependersException;
 import io.github.ust.mico.core.exception.MicoServiceIsDeployedException;
 import io.github.ust.mico.core.model.MicoService;
@@ -52,26 +61,93 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
-import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.JsonPathBuilder.HREF;
+import static io.github.ust.mico.core.JsonPathBuilder.LINKS;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT_EMBEDDED;
+import static io.github.ust.mico.core.JsonPathBuilder.SELF;
+import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
+import static io.github.ust.mico.core.TestConstants.BASE_URL;
+import static io.github.ust.mico.core.TestConstants.DEPENDEES_SUBPATH;
+import static io.github.ust.mico.core.TestConstants.DEPENDERS_SUBPATH;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_1;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_2;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_3;
+import static io.github.ust.mico.core.TestConstants.DESCRIPTION_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.ID;
+import static io.github.ust.mico.core.TestConstants.ID_1;
+import static io.github.ust.mico.core.TestConstants.ID_2;
+import static io.github.ust.mico.core.TestConstants.NAME;
+import static io.github.ust.mico.core.TestConstants.NAME_1;
+import static io.github.ust.mico.core.TestConstants.NAME_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.NAME_2;
+import static io.github.ust.mico.core.TestConstants.NAME_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.NAME_3;
+import static io.github.ust.mico.core.TestConstants.NAME_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SERVICES_PATH;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_AVAILABLE_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_ERROR_MESSAGES;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_INTERFACES_INFORMATION;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_INTERFACES_INFORMATION_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_NODE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_NODE_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_NODE_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_PHASE_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_PHASE_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_POD_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_POD_INFO_POD_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_REQUESTED_REPLICAS;
+import static io.github.ust.mico.core.TestConstants.SERVICE_DTO_SERVICE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME;
+import static io.github.ust.mico.core.TestConstants.SERVICE_INTERFACE_NAME_1;
 import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_3;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_INVALID;
+import static io.github.ust.mico.core.TestConstants.SHORT_NAME_MATCHER;
 import static io.github.ust.mico.core.TestConstants.VERSION;
-import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_1_MATCHER;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_2_MATCHER;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_3;
+import static io.github.ust.mico.core.TestConstants.VERSION_1_0_3_MATCHER;
+import static io.github.ust.mico.core.TestConstants.VERSION_MATCHER;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @EnableAutoConfiguration
@@ -118,10 +194,10 @@ public class ServiceResourceUnitTests {
     @Test
     public void getStatusOfService() throws Exception {
         MicoService micoService = new MicoService()
-                .setName(NAME)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION_1);
+            .setName(NAME)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION_1);
 
         String nodeName = "testNode";
         String podPhase = "Running";
@@ -139,123 +215,119 @@ public class ServiceResourceUnitTests {
 
         KubernetesPodInformationResponseDTO kubernetesPodInfo1 = new KubernetesPodInformationResponseDTO();
         kubernetesPodInfo1
-                .setHostIp(hostIp)
-                .setNodeName(nodeName)
-                .setPhase(podPhase)
-                .setPodName(podName1)
-                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setAvailable(false)
-                        .setCpuLoad(cpuLoadPod1)
-                        .setMemoryUsage(memoryUsagePod1));
+            .setHostIp(hostIp)
+            .setNodeName(nodeName)
+            .setPhase(podPhase)
+            .setPodName(podName1)
+            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                .setCpuLoad(cpuLoadPod1)
+                .setMemoryUsage(memoryUsagePod1));
         KubernetesPodInformationResponseDTO kubernetesPodInfo2 = new KubernetesPodInformationResponseDTO();
         kubernetesPodInfo2
-                .setHostIp(hostIp)
-                .setNodeName(nodeName)
-                .setPhase(podPhase)
-                .setPodName(podName2)
-                .setMetrics(new KubernetesPodMetricsResponseDTO()
-                        .setAvailable(true)
-                        .setCpuLoad(cpuLoadPod2)
-                        .setMemoryUsage(memoryUsagePod2));
+            .setHostIp(hostIp)
+            .setNodeName(nodeName)
+            .setPhase(podPhase)
+            .setPodName(podName2)
+            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                .setCpuLoad(cpuLoadPod2)
+                .setMemoryUsage(memoryUsagePod2));
 
         micoServiceStatus
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setShortName(SHORT_NAME)
-                .setAvailableReplicas(availableReplicas)
-                .setRequestedReplicas(requestedReplicas)
-                .setNodeMetrics(CollectionUtils.listOf(new KubernetesNodeMetricsResponseDTO()
-                        .setNodeName(nodeName)
-                        .setAverageCpuLoad(25)
-                        .setAverageMemoryUsage(60)
-                ))
-                .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
-                .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2));
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setShortName(SHORT_NAME)
+            .setAvailableReplicas(availableReplicas)
+            .setRequestedReplicas(requestedReplicas)
+            .setNodeMetrics(CollectionUtils.listOf(new KubernetesNodeMetricsResponseDTO()
+                .setNodeName(nodeName)
+                .setAverageCpuLoad(25)
+                .setAverageMemoryUsage(60)
+            ))
+            .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
+            .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2));
 
         given(micoStatusService.getServiceStatus(any(MicoService.class))).willReturn(micoServiceStatus);
         given(micoServiceBroker.getServiceFromDatabase(ArgumentMatchers.anyString(), ArgumentMatchers.any())).willReturn(micoService);
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/status"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SERVICE_DTO_SERVICE_NAME, is(NAME)))
-                .andExpect(jsonPath(SERVICE_DTO_REQUESTED_REPLICAS, is(requestedReplicas)))
-                .andExpect(jsonPath(SERVICE_DTO_AVAILABLE_REPLICAS, is(availableReplicas)))
-                .andExpect(jsonPath(SERVICE_DTO_NODE_NAME, is(nodeName)))
-                .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
-                .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
-                .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION, hasSize(1)))
-                .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION_NAME, is(SERVICE_INTERFACE_NAME)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO, hasSize(2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_1, is(podName1)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_1, is(podPhase)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_1, is(nodeName)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsagePod1)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoadPod1)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1, is(false)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_2, is(podName2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_2, is(podPhase)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_2, is(nodeName)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsagePod2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoadPod2)))
-                .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2, is(true)))
-                .andExpect(jsonPath(SERVICE_DTO_ERROR_MESSAGES, is(CollectionUtils.listOf())));
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SERVICE_DTO_SERVICE_NAME, is(NAME)))
+            .andExpect(jsonPath(SERVICE_DTO_REQUESTED_REPLICAS, is(requestedReplicas)))
+            .andExpect(jsonPath(SERVICE_DTO_AVAILABLE_REPLICAS, is(availableReplicas)))
+            .andExpect(jsonPath(SERVICE_DTO_NODE_NAME, is(nodeName)))
+            .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_CPU_LOAD, is(25)))
+            .andExpect(jsonPath(SERVICE_DTO_NODE_METRICS_AVERAGE_MEMORY_USAGE, is(60)))
+            .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION, hasSize(1)))
+            .andExpect(jsonPath(SERVICE_DTO_INTERFACES_INFORMATION_NAME, is(SERVICE_INTERFACE_NAME)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO, hasSize(2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_1, is(podName1)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_1, is(podPhase)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_1, is(nodeName)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1, is(memoryUsagePod1)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1, is(cpuLoadPod1)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_POD_NAME_2, is(podName2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_PHASE_2, is(podPhase)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_NODE_NAME_2, is(nodeName)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2, is(memoryUsagePod2)))
+            .andExpect(jsonPath(SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2, is(cpuLoadPod2)))
+            .andExpect(jsonPath(SERVICE_DTO_ERROR_MESSAGES, is(CollectionUtils.listOf())));
     }
 
     @Test
     public void getAllServicesAsList() throws Exception {
         given(micoServiceBroker.getAllServicesAsList()).willReturn(CollectionUtils.listOf(
-                new MicoService().setShortName(SHORT_NAME_1).setVersion(VERSION_1_0_1).setName(NAME_1).setDescription(DESCRIPTION_1),
-                new MicoService().setShortName(SHORT_NAME_2).setVersion(VERSION_1_0_2).setName(NAME_2).setDescription(DESCRIPTION_2),
-                new MicoService().setShortName(SHORT_NAME_3).setVersion(VERSION_1_0_3).setName(NAME_3).setDescription(DESCRIPTION_3)));
+            new MicoService().setShortName(SHORT_NAME_1).setVersion(VERSION_1_0_1).setName(NAME_1).setDescription(DESCRIPTION_1),
+            new MicoService().setShortName(SHORT_NAME_2).setVersion(VERSION_1_0_2).setName(NAME_2).setDescription(DESCRIPTION_2),
+            new MicoService().setShortName(SHORT_NAME_3).setVersion(VERSION_1_0_3).setName(NAME_3).setDescription(DESCRIPTION_3)));
 
         mvc.perform(get("/services").accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER +
-                        " && " + NAME_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER +
-                        " && " + NAME_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER +
-                        " && " + NAME_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER +
+                " && " + NAME_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER +
+                " && " + NAME_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER +
+                " && " + NAME_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH)))
+            .andReturn();
     }
 
     @Test
     public void getServiceByShortNameAndVersion() throws Exception {
         given(micoServiceBroker.getServiceFromDatabase(SHORT_NAME, VERSION)).willReturn(
-                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setDescription(DESCRIPTION));
+            new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setDescription(DESCRIPTION));
 
         String urlPath = SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION;
         mvc.perform(get(urlPath).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
-                .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(DESCRIPTION)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)))
-                .andExpect(jsonPath(SERVICES_HREF, is(BASE_URL + SERVICES_PATH)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(DESCRIPTION)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)))
+            .andExpect(jsonPath(SERVICES_HREF, is(BASE_URL + SERVICES_PATH)))
+            .andReturn();
     }
 
     @Test
     public void createService() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         given(micoServiceBroker.persistService(any(MicoService.class))).willReturn(service);
 
         final ResultActions result = mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         result.andExpect(status().isCreated());
     }
@@ -263,53 +335,53 @@ public class ServiceResourceUnitTests {
     @Test
     public void createServiceWithInvalidShortName() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME_INVALID)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME_INVALID)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void createServiceWithoutRequiredName() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(null)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(null)
+            .setDescription(DESCRIPTION);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void createServiceWithDescriptionSetToNull() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(null);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(null);
 
         MicoService expectedService = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription("");
 
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
         given(micoServiceBroker.persistService(any(MicoService.class))).willReturn(expectedService);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated());
 
         verify(micoServiceBroker, times(1)).persistService(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -320,25 +392,25 @@ public class ServiceResourceUnitTests {
     @Test
     public void createServiceWithEmptyDescription() throws Exception {
         MicoServiceRequestDTO serviceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription("");
 
         MicoService expectedService = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription("");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription("");
 
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
         given(micoServiceBroker.persistService(any(MicoService.class))).willReturn(expectedService);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isCreated());
+            .content(mapper.writeValueAsBytes(serviceRequestDto)).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isCreated());
 
         verify(micoServiceBroker, times(1)).persistService(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -349,33 +421,33 @@ public class ServiceResourceUnitTests {
     @Test
     public void createServiceWithInvalidGitCloneUrl() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION)
-                .setGitCloneUrl("invalid-url");
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setGitCloneUrl("invalid-url");
 
         given(micoServiceBroker.persistService(any(MicoService.class))).willReturn(service);
 
         mvc.perform(post(SERVICES_PATH)
-                .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service))).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(service))).accept(MediaTypes.HAL_JSON_VALUE).contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
     public void deleteAllServiceDependees() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         given(micoServiceBroker.getServiceFromDatabase(SHORT_NAME, VERSION)).willReturn(service);
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultDelete.andExpect(status().isNoContent());
     }
@@ -393,9 +465,9 @@ public class ServiceResourceUnitTests {
         given(micoServiceBroker.getServiceFromDatabase(shortNameToDelete, versionToDelete)).willReturn(serviceToDelete);
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + shortName + "/" + version +
-                DEPENDEES_SUBPATH + "/" + shortNameToDelete + "/" + versionToDelete)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            DEPENDEES_SUBPATH + "/" + shortNameToDelete + "/" + versionToDelete)
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultDelete.andExpect(status().isNoContent());
     }
@@ -403,67 +475,67 @@ public class ServiceResourceUnitTests {
     @Test
     public void deleteAllVersionsOfService() throws Exception {
         MicoService micoServiceOne = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         MicoService micoServiceTwo = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME);
         MicoService micoServiceThree = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION_1_0_2)
-                .setName(NAME);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION_1_0_2)
+            .setName(NAME);
 
         given(micoServiceBroker.getAllVersionsOfServiceFromDatabase(SHORT_NAME)).willReturn(CollectionUtils.listOf(micoServiceOne, micoServiceTwo, micoServiceThree));
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME))
-                .andDo(print())
-                .andExpect(status().isNoContent())
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isNoContent())
+            .andReturn();
     }
 
     @Test
     public void corsPolicy() throws Exception {
         mvc.perform(get(SERVICES_PATH).accept(MediaTypes.HAL_JSON_VALUE)
-                .header("Origin", (Object[]) allowedOrigins))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath(SELF_HREF, endsWith(SERVICES_PATH))).andReturn();
+            .header("Origin", (Object[]) allowedOrigins))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SELF_HREF, endsWith(SERVICES_PATH))).andReturn();
     }
 
     @Test
     public void corsPolicyNotAllowedOrigin() throws Exception {
         mvc.perform(get(SERVICES_PATH).accept(MediaTypes.HAL_JSON_VALUE)
-                .header("Origin", "http://notAllowedOrigin.com"))
-                .andDo(print())
-                .andExpect(status().isForbidden())
-                .andExpect(content().string(is("Invalid CORS request")))
-                .andReturn();
+            .header("Origin", "http://notAllowedOrigin.com"))
+            .andDo(print())
+            .andExpect(status().isForbidden())
+            .andExpect(content().string(is("Invalid CORS request")))
+            .andReturn();
     }
 
     @Test
     public void getServiceDependers() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
 
         MicoService service1 = new MicoService()
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME)
-                .setDescription(DESCRIPTION_1);
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME)
+            .setDescription(DESCRIPTION_1);
         MicoService service2 = new MicoService()
-                .setShortName(SHORT_NAME_2)
-                .setVersion(VERSION_1_0_2)
-                .setDescription(DESCRIPTION_2);
+            .setShortName(SHORT_NAME_2)
+            .setVersion(VERSION_1_0_2)
+            .setDescription(DESCRIPTION_2);
         MicoService service3 = new MicoService()
-                .setShortName(SHORT_NAME_3)
-                .setVersion(VERSION_1_0_3)
-                .setName(NAME)
-                .setDescription(DESCRIPTION_3);
+            .setShortName(SHORT_NAME_3)
+            .setVersion(VERSION_1_0_3)
+            .setName(NAME)
+            .setDescription(DESCRIPTION_3);
 
         MicoServiceDependency dependency1 = new MicoServiceDependency().setService(service1).setDependedService(service);
         MicoServiceDependency dependency2 = new MicoServiceDependency().setService(service2).setDependedService(service);
@@ -478,13 +550,13 @@ public class ServiceResourceUnitTests {
 
         String urlPath = SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDERS_SUBPATH;
         ResultActions result = mvc.perform(get(urlPath)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)));
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + " && " + DESCRIPTION_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + " && " + DESCRIPTION_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_3_MATCHER + " && " + VERSION_1_0_3_MATCHER + " && " + DESCRIPTION_3_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + urlPath)));
 
         result.andExpect(status().isOk());
     }
@@ -493,32 +565,32 @@ public class ServiceResourceUnitTests {
     public void updateService() throws Exception {
         String updatedDescription = "updated description.";
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         MicoServiceRequestDTO updatedServiceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(updatedDescription);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(updatedDescription);
         MicoService expectedService = new MicoService()
-                .setId(existingService.getId())
-                .setShortName(updatedServiceRequestDto.getShortName())
-                .setVersion(updatedServiceRequestDto.getVersion())
-                .setName(updatedServiceRequestDto.getName())
-                .setDescription(updatedServiceRequestDto.getDescription());
+            .setId(existingService.getId())
+            .setShortName(updatedServiceRequestDto.getShortName())
+            .setVersion(updatedServiceRequestDto.getVersion())
+            .setName(updatedServiceRequestDto.getName())
+            .setDescription(updatedServiceRequestDto.getDescription());
 
         given(micoServiceBroker.getServiceFromDatabase(SHORT_NAME, VERSION)).willReturn(existingService);
         given(micoServiceBroker.updateExistingService(eq(expectedService))).willReturn(expectedService);
 
         ResultActions resultUpdate = mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedDescription)))
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
-                .andExpect(jsonPath(VERSION_PATH, is(VERSION)));
+            .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedDescription)))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)));
 
         resultUpdate.andExpect(status().isOk());
     }
@@ -526,22 +598,22 @@ public class ServiceResourceUnitTests {
     @Test
     public void updateServiceWithoutRequiredName() throws Exception {
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
         MicoService updatedService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(null);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(null);
 
         given(micoServiceBroker.getServiceFromDatabase(SHORT_NAME, VERSION)).willReturn(existingService);
 
         ResultActions resultUpdate = mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(updatedService)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .content(mapper.writeValueAsBytes(new MicoServiceRequestDTO(updatedService)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultUpdate.andExpect(status().isUnprocessableEntity());
     }
@@ -549,23 +621,23 @@ public class ServiceResourceUnitTests {
     @Test
     public void updateServiceWithDescriptionSetToNull() throws Exception {
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(DESCRIPTION);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(DESCRIPTION);
         MicoServiceRequestDTO updatedServiceRequestDto = new MicoServiceRequestDTO()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME)
-                .setDescription(null);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDescription(null);
 
         MicoService expectedService = new MicoService()
-                .setId(existingService.getId())
-                .setShortName(existingService.getShortName())
-                .setVersion(existingService.getVersion())
-                .setName(existingService.getName())
-                .setDescription("");
+            .setId(existingService.getId())
+            .setShortName(existingService.getShortName())
+            .setVersion(existingService.getVersion())
+            .setName(existingService.getName())
+            .setDescription("");
 
         ArgumentCaptor<MicoService> serviceArgumentCaptor = ArgumentCaptor.forClass(MicoService.class);
 
@@ -573,10 +645,10 @@ public class ServiceResourceUnitTests {
         given(micoServiceBroker.updateExistingService(expectedService)).willReturn(expectedService);
 
         mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk());
+            .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk());
 
         verify(micoServiceBroker, times(1)).updateExistingService(serviceArgumentCaptor.capture());
         MicoService savedMicoService = serviceArgumentCaptor.getValue();
@@ -587,16 +659,16 @@ public class ServiceResourceUnitTests {
     @Test
     public void deleteService() throws Exception {
         MicoService existingService = new MicoService()
-                .setId(ID)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
 
         given(micoServiceBroker.getServiceFromDatabase(SHORT_NAME, VERSION)).willReturn(existingService);
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         resultDelete.andExpect(status().isNoContent());
     }
@@ -604,53 +676,53 @@ public class ServiceResourceUnitTests {
     @Test
     public void getVersionsOfService() throws Exception {
         given(micoServiceBroker.getAllVersionsOfServiceFromDatabase(SHORT_NAME)).willReturn(
-                CollectionUtils.listOf(
-                        new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setName(NAME),
-                        new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_1).setName(NAME),
-                        new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_2).setName(NAME)));
+            CollectionUtils.listOf(
+                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION).setName(NAME),
+                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_1).setName(NAME),
+                new MicoService().setShortName(SHORT_NAME).setVersion(VERSION_1_0_2).setName(NAME)));
 
         mvc.perform(get("/services/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME)))
+            .andReturn();
     }
 
     @Test
     public void createNewDependee() throws Exception {
         MicoService existingService1 = new MicoService()
-                .setId(ID_1)
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setName(NAME);
+            .setId(ID_1)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME);
 
         MicoService existingService2 = new MicoService()
-                .setId(ID_2)
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME);
+            .setId(ID_2)
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME);
 
         MicoServiceDependency newDependency = new MicoServiceDependency()
-                .setService(new MicoService()
-                        .setShortName(SHORT_NAME)
-                        .setVersion(VERSION)
-                        .setName(NAME))
-                .setDependedService(new MicoService()
-                        .setShortName(SHORT_NAME_1)
-                        .setVersion(VERSION_1_0_1)
-                        .setName(NAME));
-
-        MicoService expectedService = new MicoService()
-                .setId(ID_1)
+            .setService(new MicoService()
                 .setShortName(SHORT_NAME)
                 .setVersion(VERSION)
-                .setName(NAME)
-                .setDependencies(Collections.singletonList(newDependency));
+                .setName(NAME))
+            .setDependedService(new MicoService()
+                .setShortName(SHORT_NAME_1)
+                .setVersion(VERSION_1_0_1)
+                .setName(NAME));
+
+        MicoService expectedService = new MicoService()
+            .setId(ID_1)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setDependencies(Collections.singletonList(newDependency));
 
         prettyPrint(expectedService);
 
@@ -659,9 +731,9 @@ public class ServiceResourceUnitTests {
         given(micoServiceBroker.persistNewDependencyBetweenServices(existingService1, existingService2)).willReturn(expectedService);
 
         final ResultActions result = mvc.perform(post(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION +
-                DEPENDEES_SUBPATH + "/" + newDependency.getDependedService().getShortName() + "/" + newDependency.getDependedService().getVersion())
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print());
+            DEPENDEES_SUBPATH + "/" + newDependency.getDependedService().getShortName() + "/" + newDependency.getDependedService().getVersion())
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
 
         result.andExpect(status().isNoContent());
     }
@@ -679,19 +751,19 @@ public class ServiceResourceUnitTests {
     @Test
     public void getDependees() throws Exception {
         MicoService service1 = new MicoService()
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setName(NAME_1)
-                .setDescription(DESCRIPTION_1);
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setName(NAME_1)
+            .setDescription(DESCRIPTION_1);
         MicoService service2 = new MicoService()
-                .setShortName(SHORT_NAME_2)
-                .setVersion(VERSION_1_0_2)
-                .setName(NAME_2)
-                .setDescription(DESCRIPTION_2);
+            .setShortName(SHORT_NAME_2)
+            .setVersion(VERSION_1_0_2)
+            .setName(NAME_2)
+            .setDescription(DESCRIPTION_2);
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setName(NAME)
-                .setVersion(VERSION);
+            .setShortName(SHORT_NAME)
+            .setName(NAME)
+            .setVersion(VERSION);
         MicoServiceDependency dependency1 = new MicoServiceDependency().setService(service).setDependedService(service1);
         MicoServiceDependency dependency2 = new MicoServiceDependency().setService(service).setDependedService(service2);
         service.setDependencies(CollectionUtils.listOf(dependency1, dependency2));
@@ -700,22 +772,22 @@ public class ServiceResourceUnitTests {
         given(micoServiceBroker.getDependeesByMicoService(service)).willReturn(CollectionUtils.listOf(service1, service2));
 
         mvc.perform(get("/services/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH).accept(MediaTypes.HAL_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(2)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
-                .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH)))
-                .andReturn();
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andExpect(jsonPath(SERVICE_LIST + "[*]", hasSize(2)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_1_MATCHER + " && " + VERSION_1_0_1_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SERVICE_LIST + "[?(" + SHORT_NAME_2_MATCHER + " && " + VERSION_1_0_2_MATCHER + ")]", hasSize(1)))
+            .andExpect(jsonPath(SELF_HREF, is(BASE_URL + SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + DEPENDEES_SUBPATH)))
+            .andReturn();
     }
 
     @Test
     public void deleteServicesWithDeployedService() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION);
 
         given(micoServiceBroker.getAllVersionsOfServiceFromDatabase(SHORT_NAME)).willReturn(Collections.singletonList(service));
         given(micoKubernetesClient.isMicoServiceDeployed(any())).willReturn(true);
@@ -723,17 +795,17 @@ public class ServiceResourceUnitTests {
         doThrow(MicoServiceIsDeployedException.class).when(micoServiceBroker).deleteService(service);
 
         mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isConflict());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isConflict());
     }
 
     @Test
     public void deleteSpecificServiceWithDeployedService() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION);
 
         given(micoServiceBroker.getServiceFromDatabase(service.getShortName(), service.getVersion())).willReturn(service);
         given(micoServiceBroker.findDependers(service)).willReturn(new LinkedList<>());
@@ -741,17 +813,17 @@ public class ServiceResourceUnitTests {
         doThrow(MicoServiceIsDeployedException.class).when(micoServiceBroker).deleteService(service);
 
         mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isConflict());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isConflict());
     }
 
     @Test
     public void deleteSpecificServiceWithDependers() throws Exception {
         MicoService service = new MicoService()
-                .setShortName(SHORT_NAME)
-                .setVersion(VERSION)
-                .setDescription(DESCRIPTION);
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setDescription(DESCRIPTION);
 
         given(micoServiceBroker.getServiceFromDatabase(service.getShortName(), service.getVersion())).willReturn(service);
         given(micoServiceBroker.findDependers(service)).willReturn(Collections.singletonList(service));
@@ -759,9 +831,9 @@ public class ServiceResourceUnitTests {
         doThrow(MicoServiceHasDependersException.class).when(micoServiceBroker).deleteService(service);
 
         mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -772,21 +844,21 @@ public class ServiceResourceUnitTests {
     @Test
     public void promoteService() throws Exception {
         MicoServiceInterface micoServiceInterface = new MicoServiceInterface()
-                .setServiceInterfaceName(SERVICE_INTERFACE_NAME);
+            .setServiceInterfaceName(SERVICE_INTERFACE_NAME);
 
         MicoServiceInterface micoServiceInterfaceTwo = new MicoServiceInterface()
-                .setServiceInterfaceName(SERVICE_INTERFACE_NAME_1);
+            .setServiceInterfaceName(SERVICE_INTERFACE_NAME_1);
 
         List<MicoServiceInterface> micoServiceInterfaces = new LinkedList<>();
         micoServiceInterfaces.add(micoServiceInterface);
         micoServiceInterfaces.add(micoServiceInterfaceTwo);
 
         MicoService micoService = new MicoService()
-                .setShortName(SHORT_NAME_1)
-                .setVersion(VERSION_1_0_1)
-                .setDescription(DESCRIPTION_1)
-                .setId(ID)
-                .setServiceInterfaces(micoServiceInterfaces);
+            .setShortName(SHORT_NAME_1)
+            .setVersion(VERSION_1_0_1)
+            .setDescription(DESCRIPTION_1)
+            .setId(ID)
+            .setServiceInterfaces(micoServiceInterfaces);
 
         String newVersion = VERSION_1_0_1;
         Long newId = ID_1;
@@ -798,12 +870,12 @@ public class ServiceResourceUnitTests {
         given(micoServiceBroker.promoteService(micoService, VERSION_1_0_1)).willReturn(savedPromotedService);
 
         ResultActions resultPromotion = mvc.perform(post(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_PROMOTE)
-                .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
-                .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-                .andDo(print())
-                .andExpect(jsonPath(SHORT_NAME_PATH, is(savedPromotedService.getShortName())))
-                .andExpect(jsonPath(VERSION_PATH, is(newVersion)))
-                .andExpect(jsonPath(DESCRIPTION_PATH, is(savedPromotedService.getDescription())));
+            .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(savedPromotedService.getShortName())))
+            .andExpect(jsonPath(VERSION_PATH, is(newVersion)))
+            .andExpect(jsonPath(DESCRIPTION_PATH, is(savedPromotedService.getDescription())));
 
         resultPromotion.andExpect(status().isOk());
     }
@@ -815,12 +887,12 @@ public class ServiceResourceUnitTests {
         given(crawler.getVersionsFromGitHubRepo(anyString())).willReturn(versions);
 
         ResultActions resultPromotion = mvc.perform(get(SERVICES_PATH + "/import/github")
-                .param("url", anyString()))
-                .andDo(print())
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[*]", hasSize(3)))
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[0].version", is(versions.get(0))))
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[1].version", is(versions.get(1))))
-                .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[2].version", is(versions.get(2))));
+            .param("url", anyString()))
+            .andDo(print())
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[*]", hasSize(3)))
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[0].version", is(versions.get(0))))
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[1].version", is(versions.get(1))))
+            .andExpect(jsonPath(SERVICE_VERSIONS_LIST + "[2].version", is(versions.get(2))));
 
         resultPromotion.andExpect(status().isOk());
     }

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -21,7 +21,9 @@ package io.github.ust.mico.core;
 
 import io.github.ust.mico.core.model.MicoVersion;
 
-import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
+import static io.github.ust.mico.core.JsonPathBuilder.buildAttributePath;
+import static io.github.ust.mico.core.JsonPathBuilder.buildPath;
 
 class TestConstants {
 
@@ -108,13 +110,11 @@ class TestConstants {
     static final String POD_INFO_NODE_NAME_1 = buildPath(SERVICE_STATUS_PATH, "podsInformation[0].nodeName");
     static final String POD_INFO_METRICS_MEMORY_USAGE_1 = buildPath(SERVICE_STATUS_PATH, "podsInformation[0].metrics.memoryUsage");
     static final String POD_INFO_METRICS_CPU_LOAD_1 = buildPath(SERVICE_STATUS_PATH, "podsInformation[0].metrics.cpuLoad");
-    static final String POD_INFO_METRICS_AVAILABLE_1 = buildPath(SERVICE_STATUS_PATH, "podsInformation[0].metrics.available");
     static final String POD_INFO_POD_NAME_2 = buildPath(SERVICE_STATUS_PATH, "podsInformation[1].podName");
     static final String POD_INFO_PHASE_2 = buildPath(SERVICE_STATUS_PATH, "podsInformation[1].phase");
     static final String POD_INFO_NODE_NAME_2 = buildPath(SERVICE_STATUS_PATH, "podsInformation[1].nodeName");
     static final String POD_INFO_METRICS_MEMORY_USAGE_2 = buildPath(SERVICE_STATUS_PATH, "podsInformation[1].metrics.memoryUsage");
     static final String POD_INFO_METRICS_CPU_LOAD_2 = buildPath(SERVICE_STATUS_PATH, "podsInformation[1].metrics.cpuLoad");
-    static final String POD_INFO_METRICS_AVAILABLE_2 = buildPath(SERVICE_STATUS_PATH, "podsInformation[1].metrics.available");
     static final String TOTAL_NUMBER_OF_MICO_SERVICES = buildPath(ROOT, "totalNumberOfMicoServices");
     static final String TOTAL_NUMBER_OF_AVAILABLE_REPLICAS = buildPath(ROOT, "totalNumberOfAvailableReplicas");
     static final String TOTAL_NUMBER_OF_REQUESTED_REPLICAS = buildPath(ROOT, "totalNumberOfRequestedReplicas");
@@ -141,13 +141,11 @@ class TestConstants {
     static final String SERVICE_DTO_POD_INFO_NODE_NAME_1 = buildPath(ROOT, "podsInformation[0].nodeName");
     static final String SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_1 = buildPath(ROOT, "podsInformation[0].metrics.memoryUsage");
     static final String SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_1 = buildPath(ROOT, "podsInformation[0].metrics.cpuLoad");
-    static final String SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_1 = buildPath(ROOT, "podsInformation[0].metrics.available");
     static final String SERVICE_DTO_POD_INFO_POD_NAME_2 = buildPath(ROOT, "podsInformation[1].podName");
     static final String SERVICE_DTO_POD_INFO_PHASE_2 = buildPath(ROOT, "podsInformation[1].phase");
     static final String SERVICE_DTO_POD_INFO_NODE_NAME_2 = buildPath(ROOT, "podsInformation[1].nodeName");
     static final String SERVICE_DTO_POD_INFO_METRICS_MEMORY_USAGE_2 = buildPath(ROOT, "podsInformation[1].metrics.memoryUsage");
     static final String SERVICE_DTO_POD_INFO_METRICS_CPU_LOAD_2 = buildPath(ROOT, "podsInformation[1].metrics.cpuLoad");
-    static final String SERVICE_DTO_POD_INFO_METRICS_AVAILABLE_2 = buildPath(ROOT, "podsInformation[1].metrics.available");
 
     static final String SDI_REPLICAS_PATH = buildPath(ROOT, "replicas");
     static final String SDI_LABELS_PATH = buildPath(ROOT, "labels");


### PR DESCRIPTION
- [X] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Ensure to use auto format in **all** files
- [X] Tests created for changes or:
  - [X] Test cases adapted.

---

## Short Description

Responses from Prometheus do not contain values for CPU load or memory usage, if the pod phase is unequal "Running". To avoid this, an exception handling is added in `PrometheusValueDeserializer`. In `MicoStatusService`, a check for the pod phase is added. Values are only requested from Prometheus, if this phase equals `Running`. 

## Resolving Issue/ Feature

Resolves #665 
