### PR TITLE
Fix get application by short name

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -67,12 +67,8 @@ public class MicoApplicationBroker {
         return micoApplicationOptional.get();
     }
 
-    public List<MicoApplication> getMicoApplicationsByShortName(String shortName) throws MicoApplicationNotFoundException {
-        List<MicoApplication> micoApplicationList = applicationRepository.findByShortName(shortName);
-        if (micoApplicationList.isEmpty()) {
-            throw new MicoApplicationNotFoundException(shortName);
-        }
-        return micoApplicationList;
+    public List<MicoApplication> getMicoApplicationsByShortName(String shortName) {
+        return applicationRepository.findByShortName(shortName);
     }
 
     public List<MicoApplication> getMicoApplications() {

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -80,12 +80,7 @@ public class ApplicationResource {
 
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}")
     public ResponseEntity<Resources<Resource<MicoApplicationWithServicesResponseDTO>>> getApplicationsByShortName(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName) {
-        List<MicoApplication> applications;
-        try {
-            applications = broker.getMicoApplicationsByShortName(shortName);
-        } catch (MicoApplicationNotFoundException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
+        List<MicoApplication> applications = broker.getMicoApplicationsByShortName(shortName);
 
         return ResponseEntity.ok(
                 new Resources<>(getApplicationWithServicesResponseDTOResourceList(applications),


### PR DESCRIPTION
Endpoint must return an empty list if there are no applications instead of throwing an error
