### PR TITLE
Fix get all versions of a MICO service

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceBroker.java
@@ -63,12 +63,8 @@ public class MicoServiceBroker {
         return serviceOptional.get();
     }
 
-    public List<MicoService> getAllVersionsOfServiceFromDatabase(String shortName) throws ResponseStatusException, MicoServiceNotFoundException {
-        List<MicoService> micoServiceList = serviceRepository.findByShortName(shortName);
-        if (micoServiceList.isEmpty()) {
-            throw new MicoServiceNotFoundException(shortName);
-        }
-        return micoServiceList;
+    public List<MicoService> getAllVersionsOfServiceFromDatabase(String shortName) throws ResponseStatusException {
+        return serviceRepository.findByShortName(shortName);
     }
 
     public void deleteService(MicoService service) throws KubernetesResourceException, MicoServiceHasDependersException, MicoServiceIsDeployedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceInterfaceBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceInterfaceBroker.java
@@ -27,9 +27,7 @@ public class MicoServiceInterfaceBroker {
     private MicoServiceBroker micoServiceBroker;
 
     public List<MicoServiceInterface> getInterfacesOfService(String shortName, String version) {
-        List<MicoServiceInterface> serviceInterfaces = serviceInterfaceRepository.findByService(shortName, version);
-
-        return serviceInterfaces;
+        return serviceInterfaceRepository.findByService(shortName, version);
     }
 
     public MicoServiceInterface getInterfaceOfServiceByName(String shortName, String version, String interfaceName) throws MicoServiceInterfaceNotFoundException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceResource.java
@@ -165,13 +165,7 @@ public class ServiceResource {
 
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}")
     public ResponseEntity<Resources<Resource<MicoServiceResponseDTO>>> getVersionsOfService(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName) {
-        List<MicoService> services;
-        try {
-            services = micoServiceBroker.getAllVersionsOfServiceFromDatabase(shortName);
-        } catch (MicoServiceNotFoundException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-
+        List<MicoService> services = micoServiceBroker.getAllVersionsOfServiceFromDatabase(shortName);
         List<Resource<MicoServiceResponseDTO>> serviceResources = getServiceResponseDTOResourcesList(services);
 
         return ResponseEntity.ok(
@@ -406,13 +400,7 @@ public class ServiceResource {
     }
 
     private List<MicoService> getAllVersionsOfServiceFromMicoServiceBroker(String shortName) throws ResponseStatusException {
-        List<MicoService> micoServiceList;
-        try {
-            micoServiceList = micoServiceBroker.getAllVersionsOfServiceFromDatabase(shortName);
-        } catch (MicoServiceNotFoundException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-        return micoServiceList;
+        return micoServiceBroker.getAllVersionsOfServiceFromDatabase(shortName);
     }
 
 }


### PR DESCRIPTION
Endpoint should return an empty list if there are no MICO services with the particular short name instead of returning an error status code.