### PR TITLE
Feature/readiness

### DIFF
--- a/install/kubernetes/mico-core.yaml
+++ b/install/kubernetes/mico-core.yaml
@@ -32,10 +32,14 @@ metadata:
   name: mico-core
   namespace: mico-system
 spec:
+  replicas: 1
   selector:
     matchLabels:
       run: mico-core
-  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       namespace: mico-system
@@ -54,3 +58,10 @@ spec:
                 configMapKeyRef:
                   name: mico-core
                   key: spring.profiles.active
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            failureThreshold: 3

--- a/install/kubernetes/mico-core.yaml
+++ b/install/kubernetes/mico-core.yaml
@@ -39,6 +39,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
+      maxSurge: 1
       maxUnavailable: 0
   template:
     metadata:
@@ -62,6 +63,6 @@ spec:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 10
+            initialDelaySeconds: 15
             periodSeconds: 3
             failureThreshold: 3

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoHealthIndicator.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoHealthIndicator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.service;
+
+import io.github.ust.mico.core.service.imagebuilder.ImageBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MicoHealthIndicator implements HealthIndicator {
+
+    private final ImageBuilder imageBuilder;
+
+    @Autowired
+    public MicoHealthIndicator(ImageBuilder imageBuilder) {
+        this.imageBuilder = imageBuilder;
+    }
+
+    @Override
+    public Health health() {
+        // Application is considered healthy if the Image Builder could be initialized successfully.
+        return imageBuilder.isInitialized() ? Health.up().build() : Health.down().build();
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/imagebuilder/ImageBuilder.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/imagebuilder/ImageBuilder.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.*;
 
 import io.fabric8.kubernetes.api.model.ContainerStatus;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
@@ -66,6 +67,9 @@ public class ImageBuilder {
 
     private NonNamespaceOperation<Build, BuildList, DoneableBuild, Resource<Build, DoneableBuild>> buildClient;
     private ScheduledExecutorService scheduledBuildStatusCheckService;
+
+    @Getter
+    private boolean isInitialized = false;
 
 
     /**
@@ -113,6 +117,8 @@ public class ImageBuilder {
      */
     public void init() throws NotInitializedException {
         log.info("Initializing image builder...");
+        isInitialized = false;
+
         String namespace = buildBotConfig.getNamespaceBuildExecution();
         String serviceAccountName = buildBotConfig.getDockerRegistryServiceAccountName();
 
@@ -143,6 +149,7 @@ public class ImageBuilder {
         }
 
         scheduledBuildStatusCheckService = Executors.newSingleThreadScheduledExecutor();
+        isInitialized = true;
         log.info("Finished initializing image builder.");
     }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/imagebuilder/ImageBuilder.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/imagebuilder/ImageBuilder.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.*;
 
 import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -103,7 +104,11 @@ public class ImageBuilder {
             log.info("Local profile is active. Don't initialize image builder.");
             return;
         }
-        init();
+        try {
+            init();
+        } catch(Exception e) {
+            log.error("Failed to initialize image builder. Caused by: " + e.getMessage(), e);
+        }
     }
 
     /**
@@ -157,8 +162,9 @@ public class ImageBuilder {
      * Returns the build CRD if exists
      *
      * @return the build CRD
+     * @throws KubernetesClientException if operation fails
      */
-    public Optional<CustomResourceDefinition> getBuildCRD() {
+    public Optional<CustomResourceDefinition> getBuildCRD() throws KubernetesClientException {
         List<CustomResourceDefinition> crdsItems = getCustomResourceDefinitions();
 
         for (CustomResourceDefinition crd : crdsItems) {
@@ -216,7 +222,7 @@ public class ImageBuilder {
      * @throws NotInitializedException if the image builder was not initialized
      */
     private Build createBuild(String buildName, String destination, String dockerfile, String gitUrl, String gitRevision, String namespace) throws NotInitializedException {
-        if (buildClient == null) {
+        if (!isInitialized) {
             throw new NotInitializedException("ImageBuilder is not initialized.");
         }
 

--- a/mico-core/src/main/resources/application.properties
+++ b/mico-core/src/main/resources/application.properties
@@ -28,8 +28,7 @@ server.port=8080
 spring.profiles.active=dev
 
 # Actuator
-management.endpoint.restart.enabled=true
-management.endpoints.web.exposure.include=info,health,loggers,configprops,metrics
+management.endpoints.web.exposure.include=configprops,env,health,httptrace,info,loggers,metrics
 
 # Logging
 logging.level.io.github.ust.mico.core=DEBUG


### PR DESCRIPTION
Add readiness probe to `mico-core` deployment to be able to perform a rolling update.
Image builder initialization status is used to know whether `mico-core` is healthy.
In addition the logging of requests is improved.