### PR TITLE
Fix/interface connection port

### DIFF
--- a/mico-admin/src/app/app-detail-public-ip/app-detail-public-ip.component.html
+++ b/mico-admin/src/app/app-detail-public-ip/app-detail-public-ip.component.html
@@ -5,7 +5,7 @@
     <mat-card-content>
         <div *ngFor="let ip of publicIps?.values()">
             {{ip?.name}}:
-            <a target="_blank" rel="noopener" href="http://{{ip?.externalIp}}">
+            <a target="_blank" rel="noopener" href="http://{{ip?.externalIp}}:{{ip?.port}}">
                 {{ip?.externalIp}}
             </a><br />
         </div>

--- a/mico-admin/src/app/app-detail-public-ip/app-detail-public-ip.component.html
+++ b/mico-admin/src/app/app-detail-public-ip/app-detail-public-ip.component.html
@@ -6,7 +6,7 @@
         <div *ngFor="let ip of publicIps?.values()">
             {{ip?.name}}:
             <a target="_blank" rel="noopener" href="http://{{ip?.externalIp}}:{{ip?.port}}">
-                {{ip?.externalIp}}
+                {{ip?.externalIp}}:{{ip?.port}}
             </a><br />
         </div>
     </mat-card-content>

--- a/mico-admin/src/app/app-detail-public-ip/app-detail-public-ip.component.html
+++ b/mico-admin/src/app/app-detail-public-ip/app-detail-public-ip.component.html
@@ -5,9 +5,7 @@
     <mat-card-content>
         <div *ngFor="let ip of publicIps?.values()">
             {{ip?.name}}:
-            <a target="_blank" rel="noopener" href="http://{{ip?.externalIp}}:{{ip?.port}}">
-                {{ip?.externalIp}}:{{ip?.port}}
-            </a><br />
+            <a target="_blank" rel="noopener" href="http://{{ip?.externalIp}}:{{ip?.port}}">{{ip?.externalIp}}:{{ip?.port}}</a><br />
         </div>
     </mat-card-content>
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceInterfaceBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceInterfaceBroker.java
@@ -1,7 +1,5 @@
 package io.github.ust.mico.core.broker;
 
-import io.fabric8.kubernetes.api.model.LoadBalancerIngress;
-import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
 import io.github.ust.mico.core.exception.MicoServiceInterfaceAlreadyExistsException;
 import io.github.ust.mico.core.exception.MicoServiceInterfaceNotFoundException;
 import io.github.ust.mico.core.exception.MicoServiceIsDeployedException;
@@ -13,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,26 +39,6 @@ public class MicoServiceInterfaceBroker {
         }
 
         return micoServiceInterfaceOptional.get();
-    }
-
-    public List<String> getPublicIpsOfInterfaceByInterfaceName(String shortName, String version, String serviceInterfaceName, io.fabric8.kubernetes.api.model.Service kubernetesService) {
-        List<String> publicIps = new ArrayList<>();
-        LoadBalancerStatus loadBalancer = kubernetesService.getStatus().getLoadBalancer();
-
-        if (loadBalancer != null) {
-            List<LoadBalancerIngress> ingressList = loadBalancer.getIngress();
-            if (ingressList != null && !ingressList.isEmpty()) {
-                log.debug("There is/are {} ingress(es) defined for Kubernetes service '{}' (MicoServiceInterface '{}').",
-                        ingressList.size(), kubernetesService.getMetadata().getName(), serviceInterfaceName);
-                for (LoadBalancerIngress ingress : ingressList) {
-                    publicIps.add(ingress.getIp());
-                }
-                log.info("Service interface with name '{}' of MicoService '{}' in version '{}' has external IPs: {}",
-                        serviceInterfaceName, shortName, version, publicIps);
-            }
-        }
-
-        return publicIps;
     }
 
     public void deleteMicoServiceInterface(MicoService micoService, String serviceInterfaceName) throws MicoServiceIsDeployedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceInterfaceRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceInterfaceRequestDTO.java
@@ -77,6 +77,7 @@ public class MicoServiceInterfaceRequestDTO {
     /**
      * The list of ports.
      * Must not be empty.
+     * Only one port per interface is supported.
      */
     @ApiModelProperty(required = true, extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
@@ -84,8 +85,9 @@ public class MicoServiceInterfaceRequestDTO {
             @ExtensionProperty(name = "title", value = "Ports"),
             @ExtensionProperty(name = "x-order", value = "200"),
             @ExtensionProperty(name = "minItems", value = "1"),
+            @ExtensionProperty(name = "maxItems", value = "1"),
             @ExtensionProperty(name = "description", value = "The list of ports of this interface.\n" +
-                " Must not be empty.")
+                " Must not be empty. Only one port per interface is supported.")
         }
     )})
     @NotEmpty

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/KubernetesNodeMetricsResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/KubernetesNodeMetricsResponseDTO.java
@@ -60,9 +60,10 @@ public class KubernetesNodeMetricsResponseDTO {
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "Average CPU Load"),
+            @ExtensionProperty(name = "title", value = "Average CPU Load (%)"),
             @ExtensionProperty(name = "x-order", value = "20"),
-            @ExtensionProperty(name = "description", value = "The average CPU load of all pods of one MicoService running on this Node.")
+            @ExtensionProperty(name = "description", value = "The average CPU load of all pods of one MicoService running on this Node " +
+                "based on the average of the last 10s in percent (0-100 %).")
         }
     )})
     private int averageCpuLoad;
@@ -73,9 +74,9 @@ public class KubernetesNodeMetricsResponseDTO {
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "Average Memory Usage"),
+            @ExtensionProperty(name = "title", value = "Average Memory Usage (bytes)"),
             @ExtensionProperty(name = "x-order", value = "30"),
-            @ExtensionProperty(name = "description", value = "The average memory usage of all pods of one MicoService running on this Node.")
+            @ExtensionProperty(name = "description", value = "The average memory usage of all pods of one MicoService running on this Node in bytes.")
         }
     )})
     private int averageMemoryUsage;

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/KubernetesPodMetricsResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/KubernetesPodMetricsResponseDTO.java
@@ -44,9 +44,9 @@ public class KubernetesPodMetricsResponseDTO {
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "Memory Usage"),
+            @ExtensionProperty(name = "title", value = "Memory Usage (bytes)"),
             @ExtensionProperty(name = "x-order", value = "10"),
-            @ExtensionProperty(name = "description", value = "Memory usage of a pod.")
+            @ExtensionProperty(name = "description", value = "Memory usage of a pod in bytes.")
         }
     )})
     private int memoryUsage;
@@ -57,9 +57,10 @@ public class KubernetesPodMetricsResponseDTO {
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "CPU Load"),
+            @ExtensionProperty(name = "title", value = "CPU Load (%)"),
             @ExtensionProperty(name = "x-order", value = "20"),
-            @ExtensionProperty(name = "description", value = "CPU load of a pod.")
+            @ExtensionProperty(name = "description", value = "CPU load of a pod " +
+                "based on the average of the last 10s in percent (0-100 %).")
         }
     )})
     private int cpuLoad;

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceInterfaceStatusResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceInterfaceStatusResponseDTO.java
@@ -81,4 +81,17 @@ public class MicoServiceInterfaceStatusResponseDTO {
         }
     )})
     private String externalIp;
+
+    /**
+     * The exposed port of this {@link MicoServiceInterface}.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Port"),
+            @ExtensionProperty(name = "x-order", value = "40"),
+            @ExtensionProperty(name = "description", value = "The exposed port of this MicoServiceInterface.")
+        }
+    )})
+    private int port;
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceInterfaceResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceInterfaceResource.java
@@ -24,10 +24,7 @@ import io.github.ust.mico.core.broker.MicoServiceInterfaceBroker;
 import io.github.ust.mico.core.dto.request.MicoServiceInterfaceRequestDTO;
 import io.github.ust.mico.core.dto.response.MicoServiceInterfaceResponseDTO;
 import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
-import io.github.ust.mico.core.exception.MicoServiceInterfaceAlreadyExistsException;
-import io.github.ust.mico.core.exception.MicoServiceInterfaceNotFoundException;
-import io.github.ust.mico.core.exception.MicoServiceIsDeployedException;
-import io.github.ust.mico.core.exception.MicoServiceNotFoundException;
+import io.github.ust.mico.core.exception.*;
 import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceInterface;
 import io.github.ust.mico.core.service.MicoStatusService;
@@ -96,8 +93,14 @@ public class ServiceInterfaceResource {
                                                                    @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                                    @PathVariable(PATH_VARIABLE_SERVICE_INTERFACE_NAME) String serviceInterfaceName) {
         MicoService micoService = getServiceFromServiceBroker(shortName, version);
+        MicoServiceInterface serviceInterface = getServiceInterfaceFromServiceInterfaceBroker(shortName, version, serviceInterfaceName);
 
-        MicoServiceInterfaceStatusResponseDTO serviceInterfaceStatusResponseDTO = micoStatusService.getPublicIpOfKubernetesService(micoService, serviceInterfaceName);
+        MicoServiceInterfaceStatusResponseDTO serviceInterfaceStatusResponseDTO;
+        try {
+            serviceInterfaceStatusResponseDTO = micoStatusService.getPublicIpOfKubernetesService(micoService, serviceInterface);
+        } catch (KubernetesResourceException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        }
         return ResponseEntity.ok().body(serviceInterfaceStatusResponseDTO);
     }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
@@ -342,9 +342,24 @@ public class MicoKubernetesClient {
 
         String namespace = targetKubernetesService.getMetadata().getNamespace();
         String kubernetesServiceName = targetKubernetesService.getMetadata().getName();
-        String dns = kubernetesServiceName + "." + namespace + ".svc.cluster.local";
+
+        List<MicoServicePort> servicePorts = targetMicoServiceInterface.getPorts();
+        int port = 80;
+        if (servicePorts.isEmpty()) {
+            log.warn("There are no ports defined for interface '{}' of MicoService '{}' '{}'. Using default port {}.",
+                targetMicoServiceInterface.getServiceInterfaceName(), targetMicoService.getShortName(),
+                targetMicoService.getVersion(), port);
+        } else {
+            port = servicePorts.get(0).getPort();
+            if (servicePorts.size() > 1) {
+                log.warn("There are {} ports defined for interface '{}' of MicoService '{}' '{}'. Using first port {}.",
+                    servicePorts.size(), targetMicoServiceInterface.getServiceInterfaceName(),
+                    targetMicoService.getShortName(), targetMicoService.getVersion(), port);
+            }
+        }
+        String dns = kubernetesServiceName + "." + namespace + ".svc.cluster.local:" + port;
         log.debug("For the connection between '{}' '{}' and the interface '{}' of '{}' '{}' the DNS record '{}' is used.",
-            micoServiceToUpdate.getShortName(), micoServiceToUpdate.getVersion(), targetMicoServiceInterface,
+            micoServiceToUpdate.getShortName(), micoServiceToUpdate.getVersion(), targetMicoServiceInterface.getServiceInterfaceName(),
             targetMicoService.getShortName(), targetMicoService.getVersion(), dns);
 
         Optional<Container> containerToUpdateOptional = deploymentToUpdate.getSpec().getTemplate().getSpec().getContainers().stream().filter(

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -24,13 +24,13 @@ import java.util.*;
 
 import javax.validation.constraints.NotNull;
 
+import io.github.ust.mico.core.exception.KubernetesResourceException;
+import io.github.ust.mico.core.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import io.fabric8.kubernetes.api.model.*;
@@ -40,10 +40,6 @@ import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
 import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
 import io.github.ust.mico.core.dto.response.status.*;
 import io.github.ust.mico.core.exception.PrometheusRequestFailedException;
-import io.github.ust.mico.core.model.MicoApplication;
-import io.github.ust.mico.core.model.MicoMessage;
-import io.github.ust.mico.core.model.MicoService;
-import io.github.ust.mico.core.model.MicoServiceInterface;
 import io.github.ust.mico.core.persistence.MicoApplicationRepository;
 import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
@@ -241,9 +237,9 @@ public class MicoStatusService {
         for (MicoServiceInterface serviceInterface : micoService.getServiceInterfaces()) {
             String serviceInterfaceName = serviceInterface.getServiceInterfaceName();
             try {
-                MicoServiceInterfaceStatusResponseDTO interfaceStatusResponseDTO = getPublicIpOfKubernetesService(micoService, serviceInterfaceName);
+                MicoServiceInterfaceStatusResponseDTO interfaceStatusResponseDTO = getPublicIpOfKubernetesService(micoService, serviceInterface);
                 interfacesInformation.add(interfaceStatusResponseDTO);
-            } catch (ResponseStatusException e) {
+            } catch (KubernetesResourceException e) {
                 interfacesInformation.add(new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName));
                 errorMessages.add(new MicoMessageResponseDTO(MicoMessage.error(e.getMessage())));
             }
@@ -255,43 +251,62 @@ public class MicoStatusService {
      * Get the public IP of a {@link MicoServiceInterface} by providing the corresponding Kubernetes {@link Service}.
      *
      * @param micoService          is the {@link MicoService}, that has a {@link MicoServiceInterface}, which is
-     *                             deployed on Kubernetes.
-     * @param serviceInterfaceName is the MicoServiceInterface, that is deployed as Kubernetes service .
+     *                             deployed on Kubernetes
+     * @param serviceInterface     the {@link MicoServiceInterface}, that is deployed as a Kubernetes service
      * @return the  public IP of the provided Kubernetes Service
+     * @throws KubernetesResourceException if it's not possible to get the Kubernetes service
      */
-    public MicoServiceInterfaceStatusResponseDTO getPublicIpOfKubernetesService(MicoService micoService, String serviceInterfaceName) {
-        Optional<MicoServiceInterface> serviceInterfaceOptional = serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), serviceInterfaceName);
-        if (!serviceInterfaceOptional.isPresent()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                "Service interface '" + serviceInterfaceName + "' of MicoService '" + micoService.getShortName() + "' '" + micoService.getVersion() + "' was not found!");
-        }
+    public MicoServiceInterfaceStatusResponseDTO getPublicIpOfKubernetesService(MicoService micoService, MicoServiceInterface serviceInterface) throws KubernetesResourceException {
+        String serviceInterfaceName = serviceInterface.getServiceInterfaceName();
+
         Optional<Service> kubernetesServiceOptional = micoKubernetesClient.getInterfaceByNameOfMicoService(micoService, serviceInterfaceName);
         if (!kubernetesServiceOptional.isPresent()) {
             log.warn("There is no Kubernetes service deployed for MicoServiceInterface with name '{}' of MicoService '{}' in version '{}'.",
                 serviceInterfaceName, micoService.getShortName(), micoService.getVersion());
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                "No deployed service interface '" + serviceInterfaceName + "' of MicoService '" + micoService.getShortName() + "' '" + micoService.getVersion() + "' was found!");
+            throw new KubernetesResourceException("No deployed service interface '" + serviceInterfaceName
+                + "' of MicoService '" + micoService.getShortName() + "' '" + micoService.getVersion() + "' was found!");
         }
         Service kubernetesService = kubernetesServiceOptional.get();
         LoadBalancerStatus loadBalancerStatus = kubernetesService.getStatus().getLoadBalancer();
-        if (loadBalancerStatus != null) {
-            List<LoadBalancerIngress> ingressList = loadBalancerStatus.getIngress();
-            if (ingressList != null && ingressList.size() == 1) {
-                log.info("Service interface with name '{}' of MicoService '{}' in version '{}' has external IP: {}",
-                    serviceInterfaceName, micoService.getShortName(), micoService.getVersion(), ingressList.get(0).getIp());
-                return new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName).setExternalIp(ingressList.get(0).getIp()).setExternalIpIsAvailable(true);
-            } else if (ingressList != null && ingressList.size() > 1) {
-                log.warn("There are " + ingressList.size() + " IP addresses for the MicoServiceInterface " + serviceInterfaceName + ". Only one IP address is returned.");
-                return new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName).setExternalIp(ingressList.get(0).getIp()).setExternalIpIsAvailable(true);
-            } else {
-                log.info("The IP address for the Kubernetes service of the MicoServiceInterface '{}' is in a pending state.", serviceInterfaceName);
-                return new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName);
-            }
-        } else {
+        if (loadBalancerStatus == null) {
             log.error("There is no Load Balancer service for the Kubernetes service of the MicoServiceInterface '{}'.", serviceInterfaceName);
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "There is no Load Balancer service for the Kubernetes service of the MicoServiceInterface '" +
+            throw new KubernetesResourceException("There is no Load Balancer service for the Kubernetes service of the MicoServiceInterface '" +
                 serviceInterfaceName + "'.");
         }
+
+        Optional<String> ip;
+        List<LoadBalancerIngress> ingressList = loadBalancerStatus.getIngress();
+        if (ingressList != null && ingressList.size() == 1) {
+            ip = Optional.ofNullable(ingressList.get(0).getIp());
+            log.info("Service interface with name '{}' of MicoService '{}' in version '{}' has external IP: {}",
+                serviceInterfaceName, micoService.getShortName(), micoService.getVersion(), ip);
+        } else if (ingressList != null && ingressList.size() > 1) {
+            ip = Optional.ofNullable(ingressList.get(0).getIp());
+            log.warn("There are " + ingressList.size() + " IP addresses for the MicoServiceInterface " + serviceInterfaceName + ". Only one IP address is returned.");
+        } else {
+            ip = Optional.empty();
+            log.info("The IP address for the Kubernetes service of the MicoServiceInterface '{}' is in a pending state.", serviceInterfaceName);
+        }
+        List<MicoServicePort> servicePorts = serviceInterface.getPorts();
+        int port = 80;
+        if (servicePorts.isEmpty()) {
+            log.warn("There are no ports defined for interface '{}' of MicoService '{}' '{}'. Using default port {}.",
+                serviceInterfaceName, micoService.getShortName(), micoService.getVersion(), port);
+        } else {
+            port = servicePorts.get(0).getPort();
+            if (servicePorts.size() > 1) {
+                log.warn("There are {} ports defined for interface '{}' of MicoService '{}' '{}'. Using first port {}.",
+                    servicePorts.size(), serviceInterface, micoService.getShortName(), micoService.getVersion(), port);
+            }
+        }
+        MicoServiceInterfaceStatusResponseDTO responseDTO = new MicoServiceInterfaceStatusResponseDTO()
+            .setName(serviceInterfaceName)
+            .setPort(port);
+        if(ip.isPresent()) {
+            responseDTO.setExternalIpIsAvailable(true);
+            responseDTO.setExternalIp(ip.get());
+        }
+        return responseDTO;
     }
 
     /**

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -62,19 +62,16 @@ public class MicoStatusService {
     private final MicoKubernetesClient micoKubernetesClient;
     private final RestTemplate restTemplate;
     private final MicoServiceRepository serviceRepository;
-    private final MicoServiceInterfaceRepository serviceInterfaceRepository;
     private final MicoApplicationRepository micoApplicationRepository;
 
     @Autowired
     public MicoStatusService(PrometheusConfig prometheusConfig, MicoKubernetesClient micoKubernetesClient,
                              RestTemplate restTemplate, MicoServiceRepository serviceRepository,
-                             MicoServiceInterfaceRepository serviceInterfaceRepository,
                              MicoApplicationRepository micoApplicationRepository) {
         this.prometheusConfig = prometheusConfig;
         this.micoKubernetesClient = micoKubernetesClient;
         this.restTemplate = restTemplate;
         this.serviceRepository = serviceRepository;
-        this.serviceInterfaceRepository = serviceInterfaceRepository;
         this.micoApplicationRepository = micoApplicationRepository;
     }
 
@@ -250,9 +247,9 @@ public class MicoStatusService {
     /**
      * Get the public IP of a {@link MicoServiceInterface} by providing the corresponding Kubernetes {@link Service}.
      *
-     * @param micoService          is the {@link MicoService}, that has a {@link MicoServiceInterface}, which is
-     *                             deployed on Kubernetes
-     * @param serviceInterface     the {@link MicoServiceInterface}, that is deployed as a Kubernetes service
+     * @param micoService      is the {@link MicoService}, that has a {@link MicoServiceInterface}, which is
+     *                         deployed on Kubernetes
+     * @param serviceInterface the {@link MicoServiceInterface}, that is deployed as a Kubernetes service
      * @return the  public IP of the provided Kubernetes Service
      * @throws KubernetesResourceException if it's not possible to get the Kubernetes service
      */
@@ -302,7 +299,7 @@ public class MicoStatusService {
         MicoServiceInterfaceStatusResponseDTO responseDTO = new MicoServiceInterfaceStatusResponseDTO()
             .setName(serviceInterfaceName)
             .setPort(port);
-        if(ip.isPresent()) {
+        if (ip.isPresent()) {
             responseDTO.setExternalIpIsAvailable(true);
             responseDTO.setExternalIp(ip.get());
         }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -135,19 +135,16 @@ public class MicoStatusServiceTest {
         micoService = new MicoService()
             .setName(NAME)
             .setShortName(SHORT_NAME)
-            .setVersion(VERSION)
-            .setServiceInterfaces(CollectionUtils.listOf(
-                new MicoServiceInterface()
-                    .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
-            ));
+            .setVersion(VERSION);
 
         micoServiceInterface = new MicoServiceInterface()
             .setServiceInterfaceName(SERVICE_INTERFACE_NAME)
             .setPorts(CollectionUtils.listOf(new MicoServicePort()
-                .setPort(80)
-                .setTargetPort(80)
+                .setPort(8080)
+                .setTargetPort(8080)
                 .setType(MicoPortType.TCP)));
-
+        micoService.setServiceInterfaces(CollectionUtils.listOf(micoServiceInterface));
+        
         micoApplication.getServices().add(micoService);
         micoApplication.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo().setService(micoService));
 
@@ -291,7 +288,8 @@ public class MicoStatusServiceTest {
                     new MicoServiceInterfaceStatusResponseDTO()
                         .setName(SERVICE_INTERFACE_NAME)
                         .setExternalIpIsAvailable(true)
-                        .setExternalIp("192.168.2.112")))));
+                        .setExternalIp("192.168.2.112")
+                        .setPort(8080)))));
         given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(deployment);
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(kubernetesService);
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podList.getItems());
@@ -356,7 +354,7 @@ public class MicoStatusServiceTest {
                             .setMemoryUsage(memoryUsagePod1)
                             .setCpuLoad(cpuLoadPod1))))
                 .setErrorMessages(CollectionUtils.listOf(
-                    new MicoMessageResponseDTO().setContent("404 NOT_FOUND \"No deployed service interface 'service-interface-name' of MicoService 'short-name' '1.0.0' was found!\"").setType(Type.ERROR)))
+                    new MicoMessageResponseDTO().setContent("No deployed service interface 'service-interface-name' of MicoService 'short-name' '1.0.0' was found!").setType(Type.ERROR)))
                 .setInterfacesInformation(CollectionUtils.listOf(
                     new MicoServiceInterfaceStatusResponseDTO()
                         .setName(SERVICE_INTERFACE_NAME))))); // No IPs
@@ -476,7 +474,8 @@ public class MicoStatusServiceTest {
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO()
                 .setName(SERVICE_INTERFACE_NAME)
                 .setExternalIpIsAvailable(true)
-                .setExternalIp("192.168.2.112")));
+                .setExternalIp("192.168.2.112")
+                .setPort(8080)));
 
         given(micoKubernetesClient.getDeploymentOfMicoService(any(MicoService.class))).willReturn(deployment);
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(kubernetesService);
@@ -516,7 +515,8 @@ public class MicoStatusServiceTest {
         MicoServiceInterfaceStatusResponseDTO expectedServiceInterface = new MicoServiceInterfaceStatusResponseDTO()
             .setName(SERVICE_INTERFACE_NAME)
             .setExternalIpIsAvailable(true)
-            .setExternalIp("192.168.2.112");
+            .setExternalIp("192.168.2.112")
+            .setPort(8080);
         List<MicoServiceInterfaceStatusResponseDTO> expectedInterfaceStatusDTO = new LinkedList<>();
         expectedInterfaceStatusDTO.add(expectedServiceInterface);
         List<MicoMessageResponseDTO> errorMessages = new ArrayList<>();

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceResourceIntegrationTests.java
@@ -228,7 +228,8 @@ public class ServiceInterfaceResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoService));
         given(serviceInterfaceRepository.findByServiceAndName(SHORT_NAME, VERSION, serviceInterfaceName)).willReturn(Optional.of(micoServiceInterface));
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(eq(micoService), eq(serviceInterfaceName))).willReturn(kubernetesService);
-        given(micoStatusService.getPublicIpOfKubernetesService(micoService, serviceInterfaceName)).willReturn(new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName).setExternalIp(externalIP));
+        given(micoStatusService.getPublicIpOfKubernetesService(micoService, micoServiceInterface))
+            .willReturn(new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName).setExternalIp(externalIP).setPort(INTERFACE_PORT));
 
         mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
@@ -250,7 +251,7 @@ public class ServiceInterfaceResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoService));
         given(serviceInterfaceRepository.findByServiceAndName(SHORT_NAME, VERSION, serviceInterfaceName)).willReturn(Optional.of(micoServiceInterface));
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(eq(micoService), eq(serviceInterfaceName))).willReturn(kubernetesService);
-        given(micoStatusService.getPublicIpOfKubernetesService(micoService, serviceInterfaceName)).willReturn(interfaceStatusResponseDTO);
+        given(micoStatusService.getPublicIpOfKubernetesService(micoService, micoServiceInterface)).willReturn(interfaceStatusResponseDTO);
 
         mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Tests created for changes

---

## Short Description

<!-- Summarize the new functionalities/fixes -->

* Port is now part of the service interface status response
* Port of interface is now used to set the correct environment variable for an interface connection
* Only one port is allowed per interface
* Add unit descriptions to memory usage (`bytes`) and CPU load (`%`) of the status response DTO

## API Changes

* `GET /services/{{serviceShortName}}/{{serviceVersion}}/interfaces/{{serviceInterfaceName}}/publicIP`: added property `port` to response body:
  ```
  {
    "name": "backend",
    "externalIpIsAvailable": true,
    "externalIp": "52.166.34.210",
    "port": 8080
  }
  ```