### PR TITLE
Add new MicoService property 'kafkaEnabled'

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
@@ -190,7 +190,9 @@ public class DeploymentBroker {
             throw new MicoApplicationDoesNotIncludeMicoServiceException(micoApplication.getShortName(), micoApplication.getVersion());
         }
         for (MicoService micoService : micoApplication.getServices()) {
-            if (micoService.getServiceInterfaces() == null || micoService.getServiceInterfaces().isEmpty()) {
+            // If the service is not Kafka enabled, there must be at least one interface.
+            if (!micoService.isKafkaEnabled() &&
+                (micoService.getServiceInterfaces() == null || micoService.getServiceInterfaces().isEmpty())) {
                 throw new MicoServiceInterfaceNotFoundException(micoService.getShortName(), micoService.getVersion());
             }
             if (!micoService.getDependencies().isEmpty()) {

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceRequestDTO.java
@@ -135,6 +135,21 @@ public class MicoServiceRequestDTO {
     // ----------------------
 
     /**
+     * Indicates whether this service wants to communicate with Kafka.
+     * If so this service is handled differently (e.g. it's not mandatory to have interfaces).
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Kafka Enabled"),
+            @ExtensionProperty(name = "x-order", value = "50"),
+            @ExtensionProperty(name = "default", value = "false"),
+            @ExtensionProperty(name = "description", value = "Enable communication with Kafka.")
+        }
+    )})
+    private boolean kafkaEnabled = false;
+
+    /**
      * Human readable contact information for support purposes.
      */
     @ApiModelProperty(extensions = {@Extension(
@@ -230,6 +245,7 @@ public class MicoServiceRequestDTO {
         this.gitCloneUrl = service.getGitCloneUrl();
         this.dockerfilePath = service.getDockerfilePath();
         this.dockerImageUri = service.getDockerImageUri();
+        this.kafkaEnabled = service.isKafkaEnabled();
     }
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoService.java
@@ -99,6 +99,12 @@ public class MicoService {
     // ----------------------
 
     /**
+     * Indicates whether this service wants to communicate with Kafka.
+     * If so this service is handled differently (e.g. it's not mandatory to have interfaces).
+     */
+    private boolean kafkaEnabled;
+
+    /**
      * The list of interfaces this service provides.
      * Is read only. Use special API for updating.
      */
@@ -171,7 +177,8 @@ public class MicoService {
             .setOwner(serviceDto.getOwner())
             .setGitCloneUrl(serviceDto.getGitCloneUrl())
             .setDockerfilePath(serviceDto.getDockerfilePath())
-            .setDockerImageUri(serviceDto.getDockerImageUri());
+            .setDockerImageUri(serviceDto.getDockerImageUri())
+            .setKafkaEnabled(serviceDto.isKafkaEnabled());
     }
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
@@ -558,7 +558,9 @@ public class MicoKubernetesClient {
                         }
                     }
 
-                    if (micoService.getServiceInterfaces().isEmpty()) {
+                    // If the service is not enabled for Kafka and has no interfaces defined,
+                    // the deployment is considered to be incomplete.
+                    if (!micoService.isKafkaEnabled() && micoService.getServiceInterfaces().isEmpty()) {
                         message = "There are no interfaces defined for the MicoService '" + micoService.getShortName()
                             + "' '" + micoService.getVersion() + "'.";
                         log.warn(message);

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
@@ -168,6 +168,7 @@ public class ServiceResourceIntegrationTests {
     private static final String SHORT_NAME_PATH = buildPath(ROOT, "shortName");
     private static final String DESCRIPTION_PATH = buildPath(ROOT, "description");
     private static final String VERSION_PATH = buildPath(ROOT, "version");
+    private static final String KAFKA_ENABLED = buildPath(ROOT, "kafkaEnabled");
     private static final String SERVICE_VERSIONS_LIST = buildPath(ROOT_EMBEDDED, "micoVersionRequestDTOList");
     private static final String PATH_PROMOTE = "promote";
 
@@ -602,6 +603,41 @@ public class ServiceResourceIntegrationTests {
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(jsonPath(DESCRIPTION_PATH, is(updatedDescription)))
+            .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
+            .andExpect(jsonPath(VERSION_PATH, is(VERSION)));
+
+        resultUpdate.andExpect(status().isOk());
+    }
+
+    @Test
+    public void updateServiceWithBooleanValueTrue() throws Exception {
+        MicoService existingService = new MicoService()
+            .setId(ID)
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setKafkaEnabled(false);
+        MicoServiceRequestDTO updatedServiceRequestDto = new MicoServiceRequestDTO()
+            .setShortName(SHORT_NAME)
+            .setVersion(VERSION)
+            .setName(NAME)
+            .setKafkaEnabled(true);
+        MicoService expectedService = new MicoService()
+            .setId(existingService.getId())
+            .setShortName(updatedServiceRequestDto.getShortName())
+            .setVersion(updatedServiceRequestDto.getVersion())
+            .setName(updatedServiceRequestDto.getName())
+            .setDescription(updatedServiceRequestDto.getDescription())
+            .setKafkaEnabled(updatedServiceRequestDto.isKafkaEnabled());
+
+        given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(existingService));
+        given(serviceRepository.save(eq(expectedService))).willReturn(expectedService);
+
+        ResultActions resultUpdate = mvc.perform(put(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
+            .content(mapper.writeValueAsBytes(updatedServiceRequestDto))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath(KAFKA_ENABLED, is(true)))
             .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
             .andExpect(jsonPath(VERSION_PATH, is(VERSION)));
 


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

If the property 'kafkaEnabled' of an *MicoService* is set to `true`, no service interface is required during deployment.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Closes #744

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [x] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`ng serve --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
