### PR TITLE
Add `MicoTopic` as a property of `MicoServiceDeploymentInfo` to MICO

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -259,11 +259,13 @@ public class MicoApplicationBroker {
                 micoService.getShortName(), micoService.getVersion());
             return;
         }
-        log.debug("Adding default environment variables to the Kafka-enabled MicoService '{}' '{}'.",
+        log.debug("Adding default environment variables and topics to the Kafka-enabled MicoService '{}' '{}'.",
             micoService.getShortName(), micoService.getVersion());
         List<MicoEnvironmentVariable> micoEnvironmentVariables = micoServiceDeploymentInfo.getEnvironmentVariables();
         micoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
         micoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
+        List<MicoTopicRole> topics = micoServiceDeploymentInfo.getTopics();
+        topics.addAll(kafkaConfig.getDefaultTopics(micoServiceDeploymentInfo));
     }
 
     public MicoApplication removeMicoServiceFromMicoApplicationByShortNameAndVersion(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException, MicoApplicationIsNotUndeployedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -50,6 +50,9 @@ public class MicoApplicationBroker {
     private MicoLabelRepository micoLabelRepository;
 
     @Autowired
+    private MicoTopicRepository micoTopicRepository;
+
+    @Autowired
     private MicoEnvironmentVariableRepository micoEnvironmentVariableRepository;
 
     @Autowired
@@ -327,6 +330,7 @@ public class MicoApplicationBroker {
         // the standard save() function of the service deployment information repository will not delete those
         // "tangling" (without relationships) labels (nodes), hence the manual clean up.
         micoLabelRepository.cleanUp();
+        micoTopicRepository.cleanUp();
         micoEnvironmentVariableRepository.cleanUp();
         kubernetesDeploymentInfoRepository.cleanUp();
         micoInterfaceConnectionRepository.cleanUp();

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -244,7 +244,7 @@ public class MicoApplicationBroker {
     }
 
     /**
-     * Sets the default environment variables for Kafka-enabled MicoServices. See {@link MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames}
+     * Sets the default environment variables for Kafka-enabled MicoServices. See {@link MicoEnvironmentVariable.DefaultNames}
      * for a complete list.
      *
      * @param micoServiceDeploymentInfo The {@link MicoServiceDeploymentInfo} with an corresponding MicoService

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -322,8 +322,8 @@ public class MicoApplicationBroker {
 
         int oldReplicas = storedServiceDeploymentInfo.getReplicas();
         // Update existing service deployment information and save it in the database.
-        storedServiceDeploymentInfo.applyValuesFrom(serviceDeploymentInfoDTO);
-        MicoServiceDeploymentInfo updatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(storedServiceDeploymentInfo);
+        MicoServiceDeploymentInfo updatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(
+            storedServiceDeploymentInfo.applyValuesFrom(serviceDeploymentInfoDTO));
 
         // In case addition properties (stored as separate node entity) such as labels, environment variables
         // have been removed from this service deployment information,

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
@@ -21,6 +21,9 @@ package io.github.ust.mico.core.configuration;
 
 import io.github.ust.mico.core.model.MicoEnvironmentVariable;
 import io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import io.github.ust.mico.core.model.MicoTopic;
+import io.github.ust.mico.core.model.MicoTopicRole;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -72,9 +75,17 @@ public class KafkaConfig {
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_GROUP_ID.name()).setValue(groupId));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_DEAD_LETTER.name()).setValue(deadLetterTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(invalidMessageTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(testMessageOutputTopic));
+        return micoEnvironmentVariables;
+    }
+
+    public List<MicoTopicRole> getDefaultTopics(MicoServiceDeploymentInfo sdi) {
+        LinkedList<MicoTopicRole> micoEnvironmentVariables = new LinkedList<>();
+        micoEnvironmentVariables.add(new MicoTopicRole().setServiceDeploymentInfo(sdi)
+            .setRole(MicoTopicRole.Role.DEAD_LETTER).setTopic(new MicoTopic().setName(deadLetterTopic)));
+        micoEnvironmentVariables.add(new MicoTopicRole().setServiceDeploymentInfo(sdi)
+            .setRole(MicoTopicRole.Role.INVALID_MESSAGE).setTopic(new MicoTopic().setName(invalidMessageTopic)));
+        micoEnvironmentVariables.add(new MicoTopicRole().setServiceDeploymentInfo(sdi)
+            .setRole(MicoTopicRole.Role.TEST_MESSAGE_OUTPUT).setTopic(new MicoTopic().setName(testMessageOutputTopic)));
         return micoEnvironmentVariables;
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
@@ -20,7 +20,7 @@
 package io.github.ust.mico.core.configuration;
 
 import io.github.ust.mico.core.model.MicoEnvironmentVariable;
-import io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames;
+import io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultNames;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.github.ust.mico.core.model.MicoTopic;
 import io.github.ust.mico.core.model.MicoTopicRole;
@@ -73,8 +73,8 @@ public class KafkaConfig {
 
     public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForKafka() {
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_GROUP_ID.name()).setValue(groupId));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultNames.KAFKA_GROUP_ID.name()).setValue(groupId));
         return micoEnvironmentVariables;
     }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
@@ -48,7 +48,7 @@ public class OpenFaaSConfig {
 
     public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForOpenFaaS() {
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames.OPENFAAS_GATEWAY.name()).setValue(gateway));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(MicoEnvironmentVariable.DefaultNames.OPENFAAS_GATEWAY.name()).setValue(gateway));
         return micoEnvironmentVariables;
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
@@ -49,7 +49,7 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Accessors(chain = true)
-public class    MicoServiceDeploymentInfoRequestDTO {
+public class MicoServiceDeploymentInfoRequestDTO {
 
     /**
      * Number of desired instances. Defaults to 1.
@@ -100,6 +100,21 @@ public class    MicoServiceDeploymentInfoRequestDTO {
     private List<MicoLabelRequestDTO> labels = new ArrayList<>();
 
     /**
+     * Topics that are
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Topics"),
+            @ExtensionProperty(name = "x-order", value = "42"),
+            @ExtensionProperty(name = "description", value = "Topics")
+        }
+    )})
+    @JsonSetter(nulls = Nulls.SKIP)
+    @Valid
+    private List<MicoTopicRequestDTO> topics = new ArrayList<>();
+
+    /**
      * Environment variables as key-value pairs that are attached to the deployment
      * of this {@link MicoService}. These environment values can be used by the deployed
      * {@link MicoService} during runtime. This could be useful to pass information to the
@@ -143,6 +158,7 @@ public class    MicoServiceDeploymentInfoRequestDTO {
     @Valid
     private List<MicoInterfaceConnectionRequestDTO> interfaceConnections = new ArrayList<>();
 
+
     /**
      * Indicates whether and when to pull the image.
      * Default image pull policy is {@link ImagePullPolicy#ALWAYS Always}.
@@ -178,6 +194,7 @@ public class    MicoServiceDeploymentInfoRequestDTO {
         this.environmentVariables = serviceDeploymentInfo.getEnvironmentVariables().stream().map(MicoEnvironmentVariableRequestDTO::new).collect(Collectors.toList());
         this.interfaceConnections = serviceDeploymentInfo.getInterfaceConnections().stream().map(MicoInterfaceConnectionRequestDTO::new).collect(Collectors.toList());
         this.imagePullPolicy = serviceDeploymentInfo.getImagePullPolicy();
+        this.topics = serviceDeploymentInfo.getTopics().stream().map(MicoTopicRequestDTO::new).collect(Collectors.toList());
     }
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
@@ -100,7 +100,7 @@ public class MicoServiceDeploymentInfoRequestDTO {
     private List<MicoLabelRequestDTO> labels = new ArrayList<>();
 
     /**
-     * Topics that are
+     * Topics that are TODO: Description
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
@@ -49,7 +49,7 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Accessors(chain = true)
-public class MicoServiceDeploymentInfoRequestDTO {
+public class    MicoServiceDeploymentInfoRequestDTO {
 
     /**
      * Number of desired instances. Defaults to 1.

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
@@ -100,14 +100,15 @@ public class MicoServiceDeploymentInfoRequestDTO {
     private List<MicoLabelRequestDTO> labels = new ArrayList<>();
 
     /**
-     * Topics that are TODO: Description
+     * Kafka topics that are TODO: Description
+     * Possible roles for the topics are INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
             @ExtensionProperty(name = "title", value = "Topics"),
             @ExtensionProperty(name = "x-order", value = "42"),
-            @ExtensionProperty(name = "description", value = "Topics")
+            @ExtensionProperty(name = "description", value = "Topics ")
         }
     )})
     @JsonSetter(nulls = Nulls.SKIP)

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoServiceDeploymentInfoRequestDTO.java
@@ -19,16 +19,8 @@
 
 package io.github.ust.mico.core.dto.request;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Positive;
-
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
@@ -41,6 +33,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * DTO for {@link MicoServiceDeploymentInfo} intended to use with requests only.

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
@@ -41,7 +41,7 @@ import javax.validation.constraints.Size;
 public class MicoTopicRequestDTO {
 
     /**
-     * Role of the topic.
+     * Role of the topic. Default is {@code MicoTopicRole.Role#INPUT}
      */
     @ApiModelProperty(required = true, extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
@@ -1,0 +1,31 @@
+package io.github.ust.mico.core.dto.request;
+
+import io.github.ust.mico.core.model.MicoTopic;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+public class MicoTopicRequestDTO {
+
+
+    private String topicName;
+
+    // -------------------
+    // -> Constructors ---
+    // -------------------
+
+    /**
+     * Creates an instance of {@code MicoTopicRequestDTO} based on a
+     * {@code MicoTopic}.
+     *
+     * @param micoTopic the {@link MicoTopic}.
+     */
+    public MicoTopicRequestDTO(MicoTopic micoTopic) {
+        this.topicName = micoTopic.getTopicName();
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
@@ -32,7 +32,7 @@ import lombok.experimental.Accessors;
 public class MicoTopicRequestDTO {
 
 
-    private String topicName;
+    private String name;
 
     // -------------------
     // -> Constructors ---
@@ -45,6 +45,6 @@ public class MicoTopicRequestDTO {
      * @param micoTopic the {@link MicoTopic}.
      */
     public MicoTopicRequestDTO(MicoTopic micoTopic) {
-        this.topicName = micoTopic.getTopicName();
+        this.name = micoTopic.getName();
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
@@ -19,10 +19,7 @@
 
 package io.github.ust.mico.core.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
-import io.github.ust.mico.core.model.MicoTopic;
 import io.github.ust.mico.core.model.MicoTopicRole;
 import io.github.ust.mico.core.util.Patterns;
 import io.swagger.annotations.ApiModelProperty;
@@ -33,16 +30,29 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Accessors(chain = true)
 public class MicoTopicRequestDTO {
+
+    /**
+     * Role of the topic.
+     */
+    @ApiModelProperty(required = true, extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Role"),
+            @ExtensionProperty(name = "x-order", value = "10"),
+            @ExtensionProperty(name = "description", value = "Role of the topic.")
+        }
+    )})
+    @NotNull
+    private MicoTopicRole.Role role;
 
     /**
      * Name of the topic.
@@ -54,7 +64,7 @@ public class MicoTopicRequestDTO {
             @ExtensionProperty(name = "pattern", value = Patterns.KAFKA_TOPIC_NAME_REGEX),
             @ExtensionProperty(name = "minLength", value = "1"),
             @ExtensionProperty(name = "maxLength", value = "249"),
-            @ExtensionProperty(name = "x-order", value = "10"),
+            @ExtensionProperty(name = "x-order", value = "20"),
             @ExtensionProperty(name = "description", value = "Name of the topic.")
         }
     )})
@@ -62,20 +72,6 @@ public class MicoTopicRequestDTO {
     @Pattern(regexp = Patterns.KAFKA_TOPIC_NAME_REGEX, message = Patterns.KAFKA_TOPIC_NAME_MESSAGE)
     private String name;
 
-    /**
-     * Role of the topic.
-     */
-    @ApiModelProperty(required = true, extensions = {@Extension(
-        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
-        properties = {
-            @ExtensionProperty(name = "title", value = "Role"),
-            @ExtensionProperty(name = "x-order", value = "20"),
-            @ExtensionProperty(name = "description", value = "Role of the topic. " +
-                "Possible values: INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT")
-        }
-    )})
-    @JsonSetter(nulls = Nulls.SKIP)
-    private MicoTopicRole.Role role;
 
     // -------------------
     // -> Constructors ---
@@ -88,7 +84,7 @@ public class MicoTopicRequestDTO {
      * @param micoTopicRole the {@link MicoTopicRole}.
      */
     public MicoTopicRequestDTO(MicoTopicRole micoTopicRole) {
-        this.name = micoTopicRole.getTopic().getName();
         this.role = micoTopicRole.getRole();
+        this.name = micoTopicRole.getTopic().getName();
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
@@ -19,11 +19,24 @@
 
 package io.github.ust.mico.core.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.model.MicoTopic;
+import io.github.ust.mico.core.model.MicoTopicRole;
+import io.github.ust.mico.core.util.Patterns;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 @Data
 @NoArgsConstructor
@@ -31,8 +44,38 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class MicoTopicRequestDTO {
 
-
+    /**
+     * Name of the topic.
+     */
+    @ApiModelProperty(required = true, extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Name"),
+            @ExtensionProperty(name = "pattern", value = Patterns.KAFKA_TOPIC_NAME_REGEX),
+            @ExtensionProperty(name = "minLength", value = "1"),
+            @ExtensionProperty(name = "maxLength", value = "249"),
+            @ExtensionProperty(name = "x-order", value = "10"),
+            @ExtensionProperty(name = "description", value = "Name of the topic.")
+        }
+    )})
+    @Size(min = 1, max = 249, message = "must have a length between 1 and 249")
+    @Pattern(regexp = Patterns.KAFKA_TOPIC_NAME_REGEX, message = Patterns.KAFKA_TOPIC_NAME_MESSAGE)
     private String name;
+
+    /**
+     * Role of the topic.
+     */
+    @ApiModelProperty(required = true, extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Role"),
+            @ExtensionProperty(name = "x-order", value = "20"),
+            @ExtensionProperty(name = "description", value = "Role of the topic. " +
+                "Possible values: INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT")
+        }
+    )})
+    @JsonSetter(nulls = Nulls.SKIP)
+    private MicoTopicRole.Role role;
 
     // -------------------
     // -> Constructors ---
@@ -40,11 +83,12 @@ public class MicoTopicRequestDTO {
 
     /**
      * Creates an instance of {@code MicoTopicRequestDTO} based on a
-     * {@code MicoTopic}.
+     * {@code MicoTopicRole} that includes the {@code MicoTopic} and a role.
      *
-     * @param micoTopic the {@link MicoTopic}.
+     * @param micoTopicRole the {@link MicoTopicRole}.
      */
-    public MicoTopicRequestDTO(MicoTopic micoTopic) {
-        this.name = micoTopic.getName();
+    public MicoTopicRequestDTO(MicoTopicRole micoTopicRole) {
+        this.name = micoTopicRole.getTopic().getName();
+        this.role = micoTopicRole.getRole();
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/MicoTopicRequestDTO.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.github.ust.mico.core.dto.request;
 
 import io.github.ust.mico.core.model.MicoTopic;

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
@@ -19,8 +19,6 @@
 
 package io.github.ust.mico.core.dto.response;
 
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -30,12 +28,10 @@ import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.Extension;
 import io.swagger.annotations.ExtensionProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.Accessors;
+
+import java.util.stream.Collectors;
 
 /**
  * DTO for {@link MicoServiceDeploymentInfo} intended to use with responses only.

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
@@ -94,6 +94,8 @@ public class MicoServiceDeploymentInfoResponseDTO extends MicoServiceDeploymentI
         // in MicoServiceDeploymentInfoRequestDTO and typed to MicoInterfaceConnectionRequestDTO.
         setInterfaceConnections(serviceDeploymentInfo.getInterfaceConnections().stream().map(MicoInterfaceConnectionResponseDTO::new).collect(Collectors.toList()));
 
+        setTopics(serviceDeploymentInfo.getTopics().stream().map(MicoTopicResponseDTO::new).collect(Collectors.toList()));
+
         // Kubernetes deployment info maybe null if not available
         if (serviceDeploymentInfo.getKubernetesDeploymentInfo() != null) {
             setKubernetesDeploymentInfo(new KubernetesDeploymentInfoResponseDTO(serviceDeploymentInfo.getKubernetesDeploymentInfo()));

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoTopicResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoTopicResponseDTO.java
@@ -21,6 +21,7 @@ package io.github.ust.mico.core.dto.response;
 
 import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
 import io.github.ust.mico.core.model.MicoTopic;
+import io.github.ust.mico.core.model.MicoTopicRole;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -45,11 +46,11 @@ public class MicoTopicResponseDTO extends MicoTopicRequestDTO {
 
     /**
      * Creates an instance of {@code MicoTopicResponseDTO} based on a
-     * {@code MicoTopic}.
+     * {@code MicoTopicRole}.
      *
-     * @param micoTopic {@link MicoTopic}.
+     * @param micoTopicRole {@link MicoTopicRole}.
      */
-    public MicoTopicResponseDTO(MicoTopic micoTopic) {
-        super(micoTopic);
+    public MicoTopicResponseDTO(MicoTopicRole micoTopicRole) {
+        super(micoTopicRole);
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoTopicResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoTopicResponseDTO.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.github.ust.mico.core.dto.response;
 
 import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoTopicResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoTopicResponseDTO.java
@@ -1,0 +1,36 @@
+package io.github.ust.mico.core.dto.response;
+
+import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
+import io.github.ust.mico.core.model.MicoTopic;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * DTO for a {@link MicoTopic} for response only use
+ */
+
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@Accessors(chain = true)
+public class MicoTopicResponseDTO extends MicoTopicRequestDTO {
+
+
+    // -------------------
+    // -> Constructors ---
+    // -------------------
+
+    /**
+     * Creates an instance of {@code MicoTopicResponseDTO} based on a
+     * {@code MicoTopic}.
+     *
+     * @param micoTopic {@link MicoTopic}.
+     */
+    public MicoTopicResponseDTO(MicoTopic micoTopic) {
+        super(micoTopic);
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoTopicRoleNotUniqueException.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoTopicRoleNotUniqueException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.exception;
+
+import io.github.ust.mico.core.model.MicoTopicRole;
+
+import java.util.List;
+
+public class MicoTopicRoleNotUniqueException extends Exception {
+
+    private static final long serialVersionUID = -8891759393985996523L;
+
+    public MicoTopicRoleNotUniqueException(MicoTopicRole.Role role, List<String> topicNames) {
+        super("Topic role '" + role.toString() + "' must be unique, but is used by '" + topicNames.toString() + "'.");
+    }
+
+    public MicoTopicRoleNotUniqueException(MicoTopicRole.Role role) {
+        super("Topic role '" + role.toString() + "' must be unique.");
+    }
+
+    public MicoTopicRoleNotUniqueException() {
+        super("Topic role must be unique.");
+    }
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoTopicRoleUsedMultipleTimesException.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoTopicRoleUsedMultipleTimesException.java
@@ -21,22 +21,16 @@ package io.github.ust.mico.core.exception;
 
 import io.github.ust.mico.core.model.MicoTopicRole;
 
-import java.util.List;
-
-public class MicoTopicRoleNotUniqueException extends Exception {
+public class MicoTopicRoleUsedMultipleTimesException extends Exception {
 
     private static final long serialVersionUID = -8891759393985996523L;
 
-    public MicoTopicRoleNotUniqueException(MicoTopicRole.Role role, List<String> topicNames) {
-        super("Topic role '" + role.toString() + "' must be unique, but is used by '" + topicNames.toString() + "'.");
+    public MicoTopicRoleUsedMultipleTimesException(MicoTopicRole.Role role) {
+        super("Topic role '" + role.toString() + "' must not be used multiple times.");
     }
 
-    public MicoTopicRoleNotUniqueException(MicoTopicRole.Role role) {
-        super("Topic role '" + role.toString() + "' must be unique.");
-    }
-
-    public MicoTopicRoleNotUniqueException() {
-        super("Topic role must be unique.");
+    public MicoTopicRoleUsedMultipleTimesException() {
+        super("Topic role must not be used multiple times.");
     }
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
@@ -47,9 +47,11 @@ public class MicoEnvironmentVariable {
     /**
      * The default environment variables for a Kafka-enabled MicoServices.
      */
-    public enum DefaultEnvironmentVariableKafkaNames {
+    public enum DefaultNames {
         KAFKA_BOOTSTRAP_SERVERS,
         KAFKA_GROUP_ID,
+        KAFKA_TOPIC_INPUT,
+        KAFKA_TOPIC_OUTPUT,
         KAFKA_TOPIC_INVALID_MESSAGE,
         KAFKA_TOPIC_DEAD_LETTER,
         KAFKA_TOPIC_TEST_MESSAGE_OUTPUT,

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -118,7 +118,7 @@ public class MicoServiceDeploymentInfo {
      */
 
     @Relationship(type = "HAS")
-    private List<MicoTopic> topics = new ArrayList<>();
+    private List<MicoTopicRole> topics = new ArrayList<>();
 
 
     /**
@@ -176,8 +176,7 @@ public class MicoServiceDeploymentInfo {
             .setEnvironmentVariables(serviceDeploymentInfoDto.getEnvironmentVariables().stream().map(MicoEnvironmentVariable::valueOf).collect(Collectors.toList()))
             .setInterfaceConnections(serviceDeploymentInfoDto.getInterfaceConnections().stream().map(MicoInterfaceConnection::valueOf).collect(Collectors.toList()))
             .setImagePullPolicy(serviceDeploymentInfoDto.getImagePullPolicy())
-            .setTopics(serviceDeploymentInfoDto.getTopics().stream().map(MicoTopic::valueOf).collect(Collectors.toList()));
-
+            .setTopics(serviceDeploymentInfoDto.getTopics().stream().map(topicDto -> MicoTopicRole.valueOf(topicDto, this)).collect(Collectors.toList()));
     }
 
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -114,6 +114,15 @@ public class MicoServiceDeploymentInfo {
     @Relationship(type = "HAS")
     private List<MicoInterfaceConnection> interfaceConnections = new ArrayList<>();
 
+
+    /**
+     * The list of topics that are used in the deployment of this {@link MicoService}.
+     */
+
+    @Relationship(type = "HAS")
+    private List<MicoTopic> topics = new ArrayList<>();
+
+
     /**
      * Indicates whether and when to pull the image.
      * Default image pull policy is {@link ImagePullPolicy#ALWAYS Always}.

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -19,17 +19,7 @@
 
 package io.github.ust.mico.core.model;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.neo4j.ogm.annotation.GeneratedValue;
-import org.neo4j.ogm.annotation.Id;
-import org.neo4j.ogm.annotation.NodeEntity;
-import org.neo4j.ogm.annotation.Relationship;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
@@ -39,6 +29,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Represents the information necessary for deploying a {@link MicoApplication}.

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -177,7 +177,9 @@ public class MicoServiceDeploymentInfo {
             .setLabels(serviceDeploymentInfoDto.getLabels().stream().map(MicoLabel::valueOf).collect(Collectors.toList()))
             .setEnvironmentVariables(serviceDeploymentInfoDto.getEnvironmentVariables().stream().map(MicoEnvironmentVariable::valueOf).collect(Collectors.toList()))
             .setInterfaceConnections(serviceDeploymentInfoDto.getInterfaceConnections().stream().map(MicoInterfaceConnection::valueOf).collect(Collectors.toList()))
-            .setImagePullPolicy(serviceDeploymentInfoDto.getImagePullPolicy());
+            .setImagePullPolicy(serviceDeploymentInfoDto.getImagePullPolicy())
+            .setTopics(serviceDeploymentInfoDto.getTopics().stream().map(MicoTopic::valueOf).collect(Collectors.toList()));
+
     }
 
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -1,0 +1,6 @@
+package io.github.ust.mico.core.model;
+
+
+public class MicoTopic {
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -32,6 +32,7 @@ import org.neo4j.ogm.annotation.NodeEntity;
 /**
  * A Topic represented a kafka-topic
  * Instances of this class are persisted as nodes in the neo4j database
+ * Possible roles for the topics are INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT
  * <p>
  */
 @Data

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.github.ust.mico.core.model;
 
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -46,23 +46,8 @@ public class MicoTopic {
     @GeneratedValue
     private Long id;
 
-    // TODO: Roles as relationship?
-
     /**
      * Name of the topic
      */
     private String name;
-
-    // ----------------------
-    // -> Static Creators ---
-    // ----------------------
-
-    /**
-     * Creates a new {@code MicoTopic} based on a {@code MicoTopicRequestDTO}.
-     */
-
-    public static MicoTopic valueOf(MicoTopicRequestDTO topicDto) {
-        return new MicoTopic()
-            .setName(topicDto.getName());
-    }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -50,7 +50,7 @@ public class MicoTopic {
     /**
      * Name of the topic
      */
-    private String topicName;
+    private String name;
 
     // ----------------------
     // -> Static Creators ---
@@ -62,6 +62,6 @@ public class MicoTopic {
 
     public static MicoTopic valueOf(MicoTopicRequestDTO topicDto) {
         return new MicoTopic()
-            .setTopicName(topicDto.getTopicName());
+            .setName(topicDto.getName());
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -20,7 +20,6 @@
 package io.github.ust.mico.core.model;
 
 
-import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -1,6 +1,46 @@
 package io.github.ust.mico.core.model;
 
 
+import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * A Topic represented a kafka-topic
+ * Instances of this class are persisted as nodes in the neo4j database
+ * <p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+@NodeEntity
 public class MicoTopic {
 
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    /**
+     * Name of the topic
+     */
+    private String topicName;
+
+    // ----------------------
+    // -> Static Creators ---
+    // ----------------------
+
+    /**
+     * Creates a new {@code MicoTopic} based on a {@code MicoTopicRequestDTO}.
+     */
+
+    public static MicoTopic valueOf(MicoTopicRequestDTO topicDto) {
+        return new MicoTopic()
+            .setTopicName(topicDto.getTopicName());
+    }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -45,6 +45,8 @@ public class MicoTopic {
     @GeneratedValue
     private Long id;
 
+
+
     /**
      * Name of the topic
      */

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopic.java
@@ -45,7 +45,7 @@ public class MicoTopic {
     @GeneratedValue
     private Long id;
 
-
+    // TODO: Roles as relationship?
 
     /**
      * Name of the topic

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopicRole.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopicRole.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
+import lombok.*;
+import lombok.experimental.Accessors;
+import org.neo4j.ogm.annotation.*;
+
+/**
+ * Represents a role of a {@link MicoTopic}.
+ * <p>
+ * An instance of this class is persisted as a relationship between
+ * between a {@link MicoServiceDeploymentInfo} and a {@link MicoTopic} node
+ * in the Neo4j database.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+@RelationshipEntity(type = "HAS")
+public class MicoTopicRole {
+
+    /**
+     * The id of this topic role.
+     */
+    @Id
+    @GeneratedValue
+    private Long id;
+
+
+    // ----------------------
+    // -> Required Fields ---
+    // ----------------------
+
+    /**
+     * This is the {@link MicoServiceDeploymentInfo} that includes
+     * the {@link MicoTopicRole#topic}.
+     */
+    @JsonBackReference
+    @StartNode
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private MicoServiceDeploymentInfo serviceDeploymentInfo;
+
+    /**
+     * This is the role of the {@link MicoTopicRole#topic}
+     */
+    private Role role;
+
+    /**
+     * This is the {@link MicoTopic} included by the
+     * {@link MicoTopicRole#serviceDeploymentInfo}.
+     */
+    @EndNode
+    private MicoTopic topic;
+
+    public enum Role {
+        UNKNOWN, INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT
+    }
+
+
+    // ----------------------
+    // -> Static Creators ---
+    // ----------------------
+
+    /**
+     * Creates a new {@code MicoTopicRole} based on a {@code MicoTopicRequestDTO}.
+     */
+    public static MicoTopicRole valueOf(MicoTopicRequestDTO topicDto,
+                                        MicoServiceDeploymentInfo serviceDeploymentInfo) {
+        return new MicoTopicRole()
+            .setTopic(new MicoTopic()
+                .setName(topicDto.getName()))
+            .setRole(topicDto.getRole())
+            .setServiceDeploymentInfo(serviceDeploymentInfo);
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopicRole.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopicRole.java
@@ -74,7 +74,7 @@ public class MicoTopicRole {
     private Role role;
 
     public enum Role {
-        UNKNOWN, INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT
+        INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT
     }
 
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopicRole.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoTopicRole.java
@@ -62,16 +62,16 @@ public class MicoTopicRole {
     private MicoServiceDeploymentInfo serviceDeploymentInfo;
 
     /**
-     * This is the role of the {@link MicoTopicRole#topic}
-     */
-    private Role role;
-
-    /**
      * This is the {@link MicoTopic} included by the
      * {@link MicoTopicRole#serviceDeploymentInfo}.
      */
     @EndNode
     private MicoTopic topic;
+
+    /**
+     * This is the role of the {@link MicoTopicRole#topic}
+     */
+    private Role role;
 
     public enum Role {
         UNKNOWN, INPUT, OUTPUT, DEAD_LETTER, INVALID_MESSAGE, TEST_MESSAGE_OUTPUT

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoTopicRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoTopicRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.persistence;
+
+import io.github.ust.mico.core.model.MicoTopic;
+import org.springframework.data.neo4j.annotation.Query;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface MicoTopicRepository extends Neo4jRepository<MicoTopic, Long> {
+    /**
+     * Deletes all topics that do <b>not</b> have any relationship to another node.
+     */
+    @Query("MATCH (topic:MicoTopic) WHERE size((topic)--()) = 0 DELETE topic")
+    void cleanUp();
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoTopicRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoTopicRepository.java
@@ -23,10 +23,14 @@ import io.github.ust.mico.core.model.MicoTopic;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 
+import java.util.Optional;
+
 public interface MicoTopicRepository extends Neo4jRepository<MicoTopic, Long> {
     /**
      * Deletes all topics that do <b>not</b> have any relationship to another node.
      */
     @Query("MATCH (topic:MicoTopic) WHERE size((topic)--()) = 0 DELETE topic")
     void cleanUp();
+
+    Optional<MicoTopic> findByName(String name);
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -262,6 +262,8 @@ public class ApplicationResource {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationDoesNotIncludeMicoServiceException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (MicoTopicRoleNotUniqueException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
         }
 
         // Convert to service deployment info DTO and return it

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -262,7 +262,7 @@ public class ApplicationResource {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationDoesNotIncludeMicoServiceException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
-        } catch (MicoTopicRoleNotUniqueException e) {
+        } catch (MicoTopicRoleUsedMultipleTimesException e) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
         }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/util/Patterns.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/util/Patterns.java
@@ -102,7 +102,7 @@ public class Patterns {
      * Regex for strings that MUST be a relative path.
      */
     public static final String RELATIVE_PATH_REGEX = "^(?!/.*$).*";
-    
+
     /**
      * Regex to ensure to only use letters (may be empty).
      */
@@ -124,7 +124,7 @@ public class Patterns {
     public static final String SEMANTIC_VERSION_REGEX = "^" + SEMANTIC_VERSION_TEMP_REGEX + "$";
 
     /**
-     * Regex for a semantic version with a prefix (optional) consisting of letters. 
+     * Regex for a semantic version with a prefix (optional) consisting of letters.
      */
     public static final String SEMANTIC_VERSION_WITH_PREFIX_REGEX = "^[a-zA-Z]*" + SEMANTIC_VERSION_TEMP_REGEX + "$";
 
@@ -132,4 +132,16 @@ public class Patterns {
      * Message is used if a match with the {@link Patterns#SEMANTIC_VERSION_WITH_PREFIX_REGEX} fails.
      */
     public static final String SEMANTIC_VERSIONING_MESSAGE = "must be using Semantic Versioning";
+
+    /**
+     * Kafka topic names must only contain letters, numbers, dots, underscores and minus symbols.
+     */
+    public static final String KAFKA_TOPIC_NAME_REGEX = "[a-zA-Z0-9\\._\\-]+";
+
+    /**
+     * Message is used if a match with the {@link Patterns#KAFKA_TOPIC_NAME_REGEX} fails.
+     */
+    public static final String KAFKA_TOPIC_NAME_MESSAGE = "must be a valid Kafka topic name: " +
+        "Must not contain a character other than ASCII alphanumerics, '.', '_' and '-'.";
+
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -22,10 +22,7 @@ package io.github.ust.mico.core;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ust.mico.core.configuration.KafkaConfig;
 import io.github.ust.mico.core.configuration.OpenFaaSConfig;
-import io.github.ust.mico.core.dto.request.MicoApplicationRequestDTO;
-import io.github.ust.mico.core.dto.request.MicoLabelRequestDTO;
-import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
-import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
+import io.github.ust.mico.core.dto.request.*;
 import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
 import io.github.ust.mico.core.dto.response.MicoLabelResponseDTO;
 import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
@@ -107,6 +104,9 @@ public class ApplicationResourceIntegrationTests {
 
     @MockBean
     private MicoLabelRepository micoLabelRepository;
+
+    @MockBean
+    private MicoTopicRepository micoTopicRepository;
 
     @MockBean
     private MicoEnvironmentVariableRepository micoEnvironmentVariableRepository;
@@ -988,7 +988,8 @@ public class ApplicationResourceIntegrationTests {
         MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
             .setReplicas(5)
             .setLabels(CollectionUtils.listOf(new MicoLabelRequestDTO().setKey("key-updated").setValue("value-updated")))
-            .setImagePullPolicy(ImagePullPolicy.NEVER);
+            .setImagePullPolicy(ImagePullPolicy.NEVER)
+            .setTopics(CollectionUtils.listOf(new MicoTopicRequestDTO().setName("topic-name").setRole(MicoTopicRole.Role.INPUT)));;
 
         application.getServices().add(service);
         application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
@@ -1009,6 +1010,8 @@ public class ApplicationResourceIntegrationTests {
             .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getKey())))
             .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getValue())))
             .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(updatedServiceDeploymentInfoDTO.getImagePullPolicy().toString())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].name", is(updatedServiceDeploymentInfoDTO.getTopics().get(0).getName())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].role", is(updatedServiceDeploymentInfoDTO.getTopics().get(0).getRole().toString())))
             .andReturn();
     }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -1203,12 +1203,18 @@ public class ApplicationResourceIntegrationTests {
         verify(applicationRepository, times(1)).save(applicationCaptor.capture());
         MicoApplication savedApplication = applicationCaptor.getValue();
         assertThat(savedApplication.getServiceDeploymentInfos(), hasSize(1));
+        MicoServiceDeploymentInfo actualServiceDeploymentInfo = savedApplication.getServiceDeploymentInfos().get(0);
+
         LinkedList<MicoEnvironmentVariable> expectedMicoEnvironmentVariables = new LinkedList<>();
         expectedMicoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
         expectedMicoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
-        List<MicoEnvironmentVariable> actualEnvironmentVariables = savedApplication.getServiceDeploymentInfos().get(0).getEnvironmentVariables();
+        List<MicoEnvironmentVariable> actualEnvironmentVariables = actualServiceDeploymentInfo.getEnvironmentVariables();
         assertThat(actualEnvironmentVariables, containsInAnyOrder(expectedMicoEnvironmentVariables.toArray()));
 
+        LinkedList<MicoTopicRole> expectedMicoTopics = new LinkedList<>();
+        expectedMicoTopics.addAll(kafkaConfig.getDefaultTopics(actualServiceDeploymentInfo));
+        List<MicoTopicRole> actualTopics = actualServiceDeploymentInfo.getTopics();
+        assertThat(actualTopics, containsInAnyOrder(expectedMicoTopics.toArray()));
     }
 
     @Test

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
@@ -22,6 +22,9 @@ package io.github.ust.mico.core;
 import io.github.ust.mico.core.configuration.KafkaConfig;
 import io.github.ust.mico.core.configuration.OpenFaaSConfig;
 import io.github.ust.mico.core.model.MicoEnvironmentVariable;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import io.github.ust.mico.core.model.MicoTopic;
+import io.github.ust.mico.core.model.MicoTopicRole;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,12 +65,26 @@ public class DefaultEnvironmentVariablesConfigurationTests {
         List<MicoEnvironmentVariable> expectedEnvironmentVariables = new LinkedList<>();
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_BOOTSTRAP_SERVERS.name()).setValue(kafkaConfig.getBootstrapServers()));
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_GROUP_ID.name()).setValue(kafkaConfig.getGroupId()));
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_DEAD_LETTER.name()).setValue(kafkaConfig.getDeadLetterTopic()));
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(kafkaConfig.getInvalidMessageTopic()));
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(kafkaConfig.getTestMessageOutputTopic()));
 
-        assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKafka(), hasSize(5));
-        assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKafka(), containsInAnyOrder(expectedEnvironmentVariables.toArray()));
+        List<MicoEnvironmentVariable> actualEnvVars = kafkaConfig.getDefaultEnvironmentVariablesForKafka();
+        assertThat(actualEnvVars, hasSize(2));
+        assertThat(actualEnvVars, containsInAnyOrder(expectedEnvironmentVariables.toArray()));
+    }
+
+    @Test
+    public void testKafkaConfigForTopics() {
+        MicoServiceDeploymentInfo sdi = new MicoServiceDeploymentInfo().setId(1000L);
+        List<MicoTopicRole> expectedTopics = new LinkedList<>();
+        expectedTopics.add(new MicoTopicRole().setServiceDeploymentInfo(sdi)
+            .setRole(MicoTopicRole.Role.DEAD_LETTER).setTopic(new MicoTopic().setName(kafkaConfig.getDeadLetterTopic())));
+        expectedTopics.add(new MicoTopicRole().setServiceDeploymentInfo(sdi)
+            .setRole(MicoTopicRole.Role.INVALID_MESSAGE).setTopic(new MicoTopic().setName(kafkaConfig.getInvalidMessageTopic())));
+        expectedTopics.add(new MicoTopicRole().setServiceDeploymentInfo(sdi)
+            .setRole(MicoTopicRole.Role.TEST_MESSAGE_OUTPUT).setTopic(new MicoTopic().setName(kafkaConfig.getTestMessageOutputTopic())));
+
+        List<MicoTopicRole> actualTopics = kafkaConfig.getDefaultTopics(sdi);
+        assertThat(actualTopics, hasSize(3));
+        assertThat(actualTopics, containsInAnyOrder(expectedTopics.toArray()));
     }
 
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.LinkedList;
 import java.util.List;
 
-import static io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames.*;
+import static io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultNames.*;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -148,6 +148,7 @@ public class MicoKubernetesClientTests {
 
         MicoLabel label = new MicoLabel().setKey("some-label-key").setValue("some-label-value");
         MicoEnvironmentVariable environmentVariable = new MicoEnvironmentVariable().setName("some-env-name").setValue("some-env-value");
+        MicoTopicRole topicRole = new MicoTopicRole().setRole(MicoTopicRole.Role.INPUT).setTopic(new MicoTopic().setName("input-topic"));
         MicoInterfaceConnection interfaceConnection = new MicoInterfaceConnection()
             .setEnvironmentVariableName("ENV_VAR")
             .setMicoServiceInterfaceName("INTERFACE_NAME")
@@ -158,6 +159,7 @@ public class MicoKubernetesClientTests {
             .setImagePullPolicy(MicoServiceDeploymentInfo.ImagePullPolicy.NEVER)
             .setLabels(CollectionUtils.listOf(label))
             .setEnvironmentVariables(CollectionUtils.listOf(environmentVariable))
+            .setTopics(CollectionUtils.listOf(topicRole))
             .setInterfaceConnections(CollectionUtils.listOf(interfaceConnection));
 
         micoKubernetesClient.createMicoService(serviceDeploymentInfo);
@@ -177,6 +179,8 @@ public class MicoKubernetesClientTests {
         List<EnvVar> actualEnvVarList = actualDeployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         Optional<EnvVar> actualCustomEnvVar = actualEnvVarList.stream().filter(envVar -> envVar.getName().equals(environmentVariable.getName()) && envVar.getValue().equals(environmentVariable.getValue())).findFirst();
         assertTrue("Custom environment variable is not present", actualCustomEnvVar.isPresent());
+        Optional<EnvVar> actualTopicEnvVar = actualEnvVarList.stream().filter(envVar -> envVar.getName().equals(MicoEnvironmentVariable.DefaultNames.KAFKA_TOPIC_INPUT.name()) && envVar.getValue().equals(topicRole.getTopic().getName())).findFirst();
+        assertTrue("Topic environment variable is not present", actualTopicEnvVar.isPresent());
     }
 
     @Test

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoRepositoryTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoRepositoryTests.java
@@ -23,12 +23,15 @@ public class MicoRepositoryTests {
 
     @Autowired
     MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
-	
-	@Autowired
+
+    @Autowired
     KubernetesDeploymentInfoRepository kubernetesDeploymentInfoRepository;
 
     @Autowired
     MicoLabelRepository labelRepository;
+
+    @Autowired
+    MicoTopicRepository topicRepository;
 
     @Autowired
     MicoEnvironmentVariableRepository environmentVariableRepository;
@@ -36,20 +39,21 @@ public class MicoRepositoryTests {
     @Autowired
     MicoInterfaceConnectionRepository interfaceConnectionRepository;
 
-	/**
-	 * Deletes all data in the database.
-	 */
-	void deleteAllData() {
-		applicationRepository.deleteAll();
-		serviceRepository.deleteAll();
-		serviceInterfaceRepository.deleteAll();
-		servicePortRepository.deleteAll();
-		serviceDependencyRepository.deleteAll();
-		serviceDeploymentInfoRepository.deleteAll();
-		kubernetesDeploymentInfoRepository.deleteAll();
-		labelRepository.deleteAll();
-		environmentVariableRepository.deleteAll();
-		interfaceConnectionRepository.deleteAll();
-	}
+    /**
+     * Deletes all data in the database.
+     */
+    void deleteAllData() {
+        applicationRepository.deleteAll();
+        serviceRepository.deleteAll();
+        serviceInterfaceRepository.deleteAll();
+        servicePortRepository.deleteAll();
+        serviceDependencyRepository.deleteAll();
+        serviceDeploymentInfoRepository.deleteAll();
+        kubernetesDeploymentInfoRepository.deleteAll();
+        labelRepository.deleteAll();
+        topicRepository.deleteAll();
+        environmentVariableRepository.deleteAll();
+        interfaceConnectionRepository.deleteAll();
+    }
 
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoRepositoryTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoRepositoryTests.java
@@ -24,7 +24,7 @@ public class MicoRepositoryTests {
     @Autowired
     MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
 
-    @Autowired
+	@Autowired
     KubernetesDeploymentInfoRepository kubernetesDeploymentInfoRepository;
 
     @Autowired

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoTopicRepositoryTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoTopicRepositoryTests.java
@@ -1,0 +1,75 @@
+package io.github.ust.mico.core;
+
+
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoLabel;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoTopic;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static io.github.ust.mico.core.util.MicoRepositoryTestUtils.*;
+import static io.github.ust.mico.core.util.MicoRepositoryTestUtils.getMicoServiceDeploymentInfoLabel;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class MicoTopicRepositoryTests extends MicoRepositoryTests {
+
+
+    @Before
+    public void setUp() {
+        deleteAllData();
+    }
+
+    @Commit
+    @Test
+    public void removeUnnecessaryTopics() {
+        // Setup some applications
+        MicoApplication a0 = getPureMicoApplication(0);
+        MicoApplication a1 = getPureMicoApplication(1);
+        MicoApplication a2 = getPureMicoApplication(2);
+
+        // Setup some services
+        MicoService s0 = getMicoService(0);
+        MicoService s1 = getMicoService(1);
+        MicoService s2 = getMicoService(2);
+
+        // Application #0 includes services #0 and #1
+        // Application #1 only includes the service #1
+        // Application #2 only includes the service #2
+        addMicoServicesWithServiceDeploymentInfo(a0, s0, s1);
+        addMicoServicesWithServiceDeploymentInfo(a1, s1);
+        addMicoServicesWithServiceDeploymentInfo(a2, s2);
+
+        // Setup some labels
+        MicoTopic l0 = getMicoServiceDeploymentInfoTopic("topic0");
+        MicoTopic l1 = getMicoServiceDeploymentInfoTopic("topic1");
+        MicoTopic l2 = getMicoServiceDeploymentInfoTopic("topic2");
+
+        // Save
+        applicationRepository.save(a0);
+        applicationRepository.save(a1);
+        applicationRepository.save(a2);
+        topicRepository.save(l0);
+        topicRepository.save(l1);
+        topicRepository.save(l2);
+
+        //  3 (created topics)
+        assertEquals(3, topicRepository.count());
+
+        // Remove all topics that do not have any relationship with another node
+        topicRepository.cleanUp();
+        assertEquals(0, topicRepository.count());
+        // Check if all applications did not change
+        assertEquals(a0, applicationRepository.findByShortNameAndVersion(a0.getShortName(), a0.getVersion()).get());
+        assertEquals(a1, applicationRepository.findByShortNameAndVersion(a1.getShortName(), a1.getVersion()).get());
+        assertEquals(a2, applicationRepository.findByShortNameAndVersion(a2.getShortName(), a2.getVersion()).get());
+    }
+}

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -150,6 +150,7 @@ class TestConstants {
 
     static final String SDI_REPLICAS_PATH = buildPath(ROOT, "replicas");
     static final String SDI_LABELS_PATH = buildPath(ROOT, "labels");
+    static final String SDI_TOPICS_PATH = buildPath(ROOT, "topics");
     static final String SDI_IMAGE_PULLPOLICY_PATH = buildPath(ROOT, "imagePullPolicy");
 
     static class IntegrationTest {

--- a/mico-core/src/test/java/io/github/ust/mico/core/util/MicoRepositoryTestUtils.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/util/MicoRepositoryTestUtils.java
@@ -179,6 +179,10 @@ public class MicoRepositoryTestUtils {
         return new MicoEnvironmentVariable().setName("key-env-label-" + number).setValue("value-env-label-" + number);
     }
 
+    public static final MicoTopic getMicoServiceDeploymentInfoTopic(String topicName) {
+        return new MicoTopic().setTopicName(topicName);
+    }
+
     public static final KubernetesDeploymentInfo getMicoServiceDeploymentInfoKubernetesDeploymentInfo(int number) {
         return new KubernetesDeploymentInfo()
             .setDeploymentName("kdi-deployment-name-" + number)

--- a/mico-core/src/test/java/io/github/ust/mico/core/util/MicoRepositoryTestUtils.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/util/MicoRepositoryTestUtils.java
@@ -183,6 +183,13 @@ public class MicoRepositoryTestUtils {
         return new MicoTopic().setName(name);
     }
 
+    public static final MicoTopicRole getMicoServiceDeploymentInfoTopicRole(MicoTopic topic, MicoServiceDeploymentInfo sdi, MicoTopicRole.Role role) {
+        return new MicoTopicRole()
+            .setServiceDeploymentInfo(sdi)
+            .setRole(role)
+            .setTopic(topic);
+    }
+
     public static final KubernetesDeploymentInfo getMicoServiceDeploymentInfoKubernetesDeploymentInfo(int number) {
         return new KubernetesDeploymentInfo()
             .setDeploymentName("kdi-deployment-name-" + number)

--- a/mico-core/src/test/java/io/github/ust/mico/core/util/MicoRepositoryTestUtils.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/util/MicoRepositoryTestUtils.java
@@ -179,8 +179,8 @@ public class MicoRepositoryTestUtils {
         return new MicoEnvironmentVariable().setName("key-env-label-" + number).setValue("value-env-label-" + number);
     }
 
-    public static final MicoTopic getMicoServiceDeploymentInfoTopic(String topicName) {
-        return new MicoTopic().setTopicName(topicName);
+    public static final MicoTopic getMicoServiceDeploymentInfoTopic(String name) {
+        return new MicoTopic().setName(name);
     }
 
     public static final KubernetesDeploymentInfo getMicoServiceDeploymentInfoKubernetesDeploymentInfo(int number) {


### PR DESCRIPTION
# Still in Progress

# Resolves / is related to

Closes #751 

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [x] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`ng serve --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
