### PR TITLE
Feature/mico#748 default environment variables for kafka services

### DIFF
--- a/install/kubernetes/mico-core.yaml
+++ b/install/kubernetes/mico-core.yaml
@@ -11,6 +11,8 @@ data:
     kubernetes.prometheus.uri=http://prometheus.monitoring:9090/api/v1/query
     spring.redis.host=redis.mico-system
     spring.redis.port=6379
+    kafka.bootstrap-servers=bootstrap.kafka:9092
+    openfaas.gateway=http://gateway.openfaas:8080
 ---
 apiVersion: v1
 kind: Service

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -243,7 +243,7 @@ public class MicoApplicationBroker {
         if(!micoServiceDeploymentInfo.getService().isKafkaEnabled()){
             return;
         }
-        log.debug("Adding default environment variables to the Kafka enabled MicoService '{}'", micoServiceDeploymentInfo.getService());
+        log.debug("Adding default environment variables to the Kafka enabled MicoService '{}:{}'", micoServiceDeploymentInfo.getService().getShortName(),micoServiceDeploymentInfo.getService().getVersion());
         List<MicoEnvironmentVariable>  micoEnvironmentVariables = micoServiceDeploymentInfo.getEnvironmentVariables();
         micoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKakfa());
         micoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import com.sun.javaws.exceptions.InvalidArgumentException;
 import io.github.ust.mico.core.configuration.KafkaConfig;
 import io.github.ust.mico.core.configuration.OpenFaaSConfig;
 import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
@@ -18,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Service;
-
 import io.github.ust.mico.core.dto.response.status.MicoApplicationStatusResponseDTO;
 import io.github.ust.mico.core.exception.*;
 import io.github.ust.mico.core.persistence.*;
@@ -235,7 +232,7 @@ public class MicoApplicationBroker {
     }
 
     /**
-     * Sets the default environment variables for Kafka enabled MicoServices. See {@link MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames}
+     * Sets the default environment variables for Kafka enabled MicoServices. See {@link MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames}
      * for a complete list.
      * @param micoServiceDeploymentInfo The correct service needs to be set already
      */

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -180,6 +180,9 @@ public class MicoApplicationBroker {
     }
 
     public MicoApplication addMicoServiceToMicoApplicationByShortNameAndVersion(String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion) throws MicoApplicationNotFoundException, MicoServiceNotFoundException, MicoServiceAlreadyAddedToMicoApplicationException, MicoServiceAddedMoreThanOnceToMicoApplicationException, MicoApplicationIsNotUndeployedException {
+
+        log.debug("Adding MicoService '{}' '{}' to MicoApplication '{}' '{}'.",
+            serviceShortName, serviceVersion, applicationShortName, applicationVersion);
         // Retrieve application and service from database (checks whether they exist)
         MicoApplication micoApplication = getMicoApplicationByShortNameAndVersion(applicationShortName, applicationVersion);
 
@@ -192,6 +195,8 @@ public class MicoApplicationBroker {
 
         // Find all services with identical short name within this application
         List<MicoService> micoServices = micoApplication.getServices().stream().filter(s -> s.getShortName().equals(serviceShortName)).collect(Collectors.toList());
+        log.debug("Found {} MicoService(s) with short name '{}' within application '{}' '{}'.",
+            micoServices.size(), serviceShortName, applicationShortName, applicationVersion);
 
         if (micoServices.size() > 1) {
             // Illegal state, each service is allowed only once in every application
@@ -199,16 +204,20 @@ public class MicoApplicationBroker {
         } else if (micoServices.size() == 0) {
             // Service not included yet, simply add it
             MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setService(micoService);
+            setDefaultEnvironmentVariablesForKafkaEnabledService(micoServiceDeploymentInfo);
+
             // Both the service list and the service deployment info list of the application need to be updated ...
             micoApplication.getServices().add(micoService);
             micoApplication.getServiceDeploymentInfos().add(micoServiceDeploymentInfo);
 
-            setDefaultEnvironmentVariablesForKafkaEnabledServices(micoServiceDeploymentInfo);
             // ... before the application can be saved.
             return applicationRepository.save(micoApplication);
         } else {
             // Service already included, replace it with its newer version, ...
             MicoService existingMicoService = micoServices.get(0);
+            log.debug("MicoService '{}' is already included in application '{}' '{}' in version '{}'. " +
+                    "Replace it with the version '{}'.", serviceShortName, applicationShortName, applicationVersion,
+                existingMicoService.getVersion(), serviceVersion);
 
             // ... but only replace if the new version is different from the current version
             if (existingMicoService.getVersion().equals(serviceVersion)) {
@@ -238,14 +247,18 @@ public class MicoApplicationBroker {
      *
      * @param micoServiceDeploymentInfo The {@link MicoServiceDeploymentInfo} with an corresponding MicoService
      */
-    private void setDefaultEnvironmentVariablesForKafkaEnabledServices(MicoServiceDeploymentInfo micoServiceDeploymentInfo) {
-        if (micoServiceDeploymentInfo.getService() == null) {
+    private void setDefaultEnvironmentVariablesForKafkaEnabledService(MicoServiceDeploymentInfo micoServiceDeploymentInfo) {
+        MicoService micoService = micoServiceDeploymentInfo.getService();
+        if (micoService == null) {
             throw new IllegalArgumentException("The MicoServiceDeploymentInfo needs a valid MicoService set to check if the service is Kafka enabled");
         }
-        if (!micoServiceDeploymentInfo.getService().isKafkaEnabled()) {
+        if (!micoService.isKafkaEnabled()) {
+            log.debug("MicoService '{}' '{}' is not Kafka-enabled. Not necessary to adding specific env variables.",
+                micoService.getShortName(), micoService.getVersion());
             return;
         }
-        log.debug("Adding default environment variables to the Kafka enabled MicoService '{}:{}'", micoServiceDeploymentInfo.getService().getShortName(), micoServiceDeploymentInfo.getService().getVersion());
+        log.debug("Adding default environment variables to the Kafka-enabled MicoService '{}' '{}'.",
+            micoService.getShortName(), micoService.getVersion());
         List<MicoEnvironmentVariable> micoEnvironmentVariables = micoServiceDeploymentInfo.getEnvironmentVariables();
         micoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
         micoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 import javax.validation.constraints.NotBlank;
 import java.util.LinkedList;
 import java.util.List;
-import io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames;
+import io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames;
 
 /**
  * Configuration of the kafka connection.
@@ -82,13 +82,13 @@ public class KafkaConfig {
 
     public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForKakfa(){
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_GROUP_ID.name()).setValue(groupId));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_DEAD_LETTER.name()).setValue(deadLetterTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_INPUT.name()).setValue(inputTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(invalidMessageTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_OUTPUT.name()).setValue(outputTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(testMessageOutputTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_GROUP_ID.name()).setValue(groupId));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_DEAD_LETTER.name()).setValue(deadLetterTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_INPUT.name()).setValue(inputTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(invalidMessageTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_OUTPUT.name()).setValue(outputTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(testMessageOutputTopic));
         return micoEnvironmentVariables;
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
@@ -54,18 +54,6 @@ public class KafkaConfig {
     private String groupId;
 
     /**
-     * The Kafka input topic.
-     */
-    @NotBlank
-    private String inputTopic;
-
-    /**
-     * The Kafka output topic.
-     */
-    @NotBlank
-    private String outputTopic;
-
-    /**
      * Used to report message processing errors
      */
     @NotBlank
@@ -85,9 +73,7 @@ public class KafkaConfig {
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_GROUP_ID.name()).setValue(groupId));
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_DEAD_LETTER.name()).setValue(deadLetterTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_INPUT.name()).setValue(inputTopic));
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(invalidMessageTopic));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_OUTPUT.name()).setValue(outputTopic));
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironmentVariableKafkaNames.KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(testMessageOutputTopic));
         return micoEnvironmentVariables;
     }

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.configuration;
+
+import io.github.ust.mico.core.model.MicoEnvironmentVariable;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import javax.validation.constraints.NotBlank;
+import java.util.LinkedList;
+import java.util.List;
+import io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames;
+
+/**
+ * Configuration of the kafka connection.
+ */
+@Component
+@Setter
+@Getter
+@ConfigurationProperties("kafka")
+public class KafkaConfig {
+
+    /**
+     * The URLs of the Kafka bootstrap servers in a comma separated list.
+     * Example: localhost:9092,localhost:9093
+     */
+    @NotBlank
+    private String bootstrapServers;
+
+    /**
+     * The group id is a string that uniquely identifies the group
+     * of consumer processes to which this consumer belongs.
+     */
+    @NotBlank
+    private String groupId;
+
+    /**
+     * The Kafka input topic.
+     */
+    @NotBlank
+    private String inputTopic;
+
+    /**
+     * The Kafka output topic.
+     */
+    @NotBlank
+    private String outputTopic;
+
+    /**
+     * Used to report message processing errors
+     */
+    @NotBlank
+    private String invalidMessageTopic;
+
+    /**
+     * Used to report routing errors
+     */
+    @NotBlank
+    private String deadLetterTopic;
+
+    @NotBlank
+    private String testMessageOutputTopic;
+
+    public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForKakfa(){
+        LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_GROUP_ID.name()).setValue(groupId));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_DEAD_LETTER.name()).setValue(deadLetterTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_INPUT.name()).setValue(inputTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(invalidMessageTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_OUTPUT.name()).setValue(outputTopic));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultEnvironemntVariableKafkaNames.KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(testMessageOutputTopic));
+        return micoEnvironmentVariables;
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.configuration;
+
+import io.github.ust.mico.core.model.MicoEnvironmentVariable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Configuration for the OpenFaaS connection.
+ */
+@Slf4j
+@Component
+@Setter
+@Getter
+@ConfigurationProperties("openfaas")
+public class OpenFaaSConfig {
+
+    /**
+     * The URL of the OpenFaaS gateway.
+     */
+    @NotBlank
+    private String gateway;
+
+    public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForOpenFaaS(){
+        LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames.OPENFAAS_GATEWAY.name()).setValue(gateway));
+        return micoEnvironmentVariables;
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
@@ -27,13 +27,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 /**
  * Configuration for the OpenFaaS connection.
@@ -53,7 +50,7 @@ public class OpenFaaSConfig {
 
     public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForOpenFaaS(){
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames.OPENFAAS_GATEWAY.name()).setValue(gateway));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames.OPENFAAS_GATEWAY.name()).setValue(gateway));
         return micoEnvironmentVariables;
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
@@ -46,6 +46,17 @@ import lombok.experimental.Accessors;
 @NodeEntity
 public class MicoEnvironmentVariable {
 
+    public enum DefaultEnvironemntVariableKafkaNames{
+        KAFKA_BOOTSTRAP_SERVERS,
+        KAFKA_GROUP_ID,
+        KAFKA_TOPIC_INPUT,
+        KAFKA_TOPIC_OUTPUT,
+        KAFKA_TOPIC_INVALID_MESSAGE,
+        KAFKA_TOPIC_DEAD_LETTER,
+        KAFKA_TOPIC_TEST_MESSAGE_OUTPUT,
+        OPENFAAS_GATEWAY
+    }
+
     @Id
     @GeneratedValue
     private Long id;

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
@@ -46,7 +46,10 @@ import lombok.experimental.Accessors;
 @NodeEntity
 public class MicoEnvironmentVariable {
 
-    public enum DefaultEnvironemntVariableKafkaNames{
+    /**
+     * The default environment variables for a Kafka-enabled micoservices.
+     */
+    public enum DefaultEnvironmentVariableKafkaNames {
         KAFKA_BOOTSTRAP_SERVERS,
         KAFKA_GROUP_ID,
         KAFKA_TOPIC_INPUT,

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoEnvironmentVariable.java
@@ -50,8 +50,6 @@ public class MicoEnvironmentVariable {
     public enum DefaultEnvironmentVariableKafkaNames {
         KAFKA_BOOTSTRAP_SERVERS,
         KAFKA_GROUP_ID,
-        KAFKA_TOPIC_INPUT,
-        KAFKA_TOPIC_OUTPUT,
         KAFKA_TOPIC_INVALID_MESSAGE,
         KAFKA_TOPIC_DEAD_LETTER,
         KAFKA_TOPIC_TEST_MESSAGE_OUTPUT,

--- a/mico-core/src/main/resources/application-local.properties
+++ b/mico-core/src/main/resources/application-local.properties
@@ -28,3 +28,16 @@ logging.level.io.github.ust.mico.core=DEBUG
 # Redis
 spring.redis.host=localhost
 spring.redis.port=6379
+
+# OpenFaaS (will be set by the Kubernetes ConfigMap)
+openfaas.gateway=localhost:8080
+
+# Kafka (will be set by the Kubernetes ConfigMap)
+kafka.bootstrap-servers=localhost:9092
+
+kafka.group-id=mico
+kafka.input-topic=transform-request
+kafka.output-topic=transform-result
+kafka.invalid-message-topic=InvalidMessage
+kafka.dead-letter-topic=DeadLetter
+kafka.test-message-output-topic=TestMessagesOutput

--- a/mico-core/src/main/resources/application-prod.properties
+++ b/mico-core/src/main/resources/application-prod.properties
@@ -45,3 +45,16 @@ spring.data.neo4j.uri=
 # Redis (will be set by the Kubernetes ConfigMap)
 spring.redis.host=
 spring.redis.port=
+
+# OpenFaaS (will be set by the Kubernetes ConfigMap)
+openfaas.gateway=
+
+# Kafka (will be set by the Kubernetes ConfigMap)
+kafka.bootstrap-servers=
+
+kafka.group-id=mico
+kafka.input-topic=transform-request
+kafka.output-topic=transform-result
+kafka.invalid-message-topic=InvalidMessage
+kafka.dead-letter-topic=DeadLetter
+kafka.test-message-output-topic=TestMessagesOutput

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
@@ -25,6 +25,8 @@ import io.github.ust.mico.core.model.MicoEnvironmentVariable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -39,6 +41,8 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
 @ActiveProfiles("local")
 public class DefaultEnvironmentVariablesConfiguration {
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core;
+
+import io.github.ust.mico.core.configuration.KafkaConfig;
+import io.github.ust.mico.core.configuration.OpenFaaSConfig;
+import io.github.ust.mico.core.model.MicoEnvironmentVariable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ActiveProfiles("local")
+public class DefaultEnvironmentVariablesConfiguration {
+
+    @Autowired
+    OpenFaaSConfig openFaaSConfig;
+
+    @Autowired
+    KafkaConfig kafkaConfig;
+
+    @Test
+    public void testOpenFaaSConfigForEnvironmentVariables(){
+        List<MicoEnvironmentVariable> expectedEnvironmentVariables = new LinkedList<>();
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(OPENFAAS_GATEWAY.name()).setValue(openFaaSConfig.getGateway()));
+
+        assertThat(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS(),hasSize(1));
+        assertThat(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS(),containsInAnyOrder(expectedEnvironmentVariables.toArray()));
+    }
+
+    @Test
+    public void testKafkaConfigForEnvironmentVariables(){
+        List<MicoEnvironmentVariable> expectedEnvironmentVariables = new LinkedList<>();
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_BOOTSTRAP_SERVERS.name()).setValue(kafkaConfig.getBootstrapServers()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_GROUP_ID.name()).setValue(kafkaConfig.getGroupId()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_INPUT.name()).setValue(kafkaConfig.getInputTopic()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_OUTPUT.name()).setValue(kafkaConfig.getOutputTopic()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_DEAD_LETTER.name()).setValue(kafkaConfig.getDeadLetterTopic()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(kafkaConfig.getInvalidMessageTopic()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(kafkaConfig.getTestMessageOutputTopic()));
+
+        assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKakfa(),hasSize(7));
+        assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKakfa(),containsInAnyOrder(expectedEnvironmentVariables.toArray()));
+    }
+
+}

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
@@ -62,8 +62,6 @@ public class DefaultEnvironmentVariablesConfiguration {
         List<MicoEnvironmentVariable> expectedEnvironmentVariables = new LinkedList<>();
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_BOOTSTRAP_SERVERS.name()).setValue(kafkaConfig.getBootstrapServers()));
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_GROUP_ID.name()).setValue(kafkaConfig.getGroupId()));
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_INPUT.name()).setValue(kafkaConfig.getInputTopic()));
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_OUTPUT.name()).setValue(kafkaConfig.getOutputTopic()));
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_DEAD_LETTER.name()).setValue(kafkaConfig.getDeadLetterTopic()));
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(kafkaConfig.getInvalidMessageTopic()));
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(kafkaConfig.getTestMessageOutputTopic()));

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfiguration.java
@@ -28,13 +28,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-
-import static io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironemntVariableKafkaNames.*;
+import static io.github.ust.mico.core.model.MicoEnvironmentVariable.DefaultEnvironmentVariableKafkaNames.*;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
@@ -25,8 +25,6 @@ import io.github.ust.mico.core.model.MicoEnvironmentVariable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -41,10 +39,8 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@AutoConfigureMockMvc
-@EnableAutoConfiguration
 @ActiveProfiles("local")
-public class DefaultEnvironmentVariablesConfiguration {
+public class DefaultEnvironmentVariablesConfigurationTests {
 
     @Autowired
     OpenFaaSConfig openFaaSConfig;
@@ -70,7 +66,7 @@ public class DefaultEnvironmentVariablesConfiguration {
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_INVALID_MESSAGE.name()).setValue(kafkaConfig.getInvalidMessageTopic()));
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_TOPIC_TEST_MESSAGE_OUTPUT.name()).setValue(kafkaConfig.getTestMessageOutputTopic()));
 
-        assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKafka(), hasSize(7));
+        assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKafka(), hasSize(5));
         assertThat(kafkaConfig.getDefaultEnvironmentVariablesForKafka(), containsInAnyOrder(expectedEnvironmentVariables.toArray()));
     }
 


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Kafka-enabled micoservices need the flowing environment variables to function properly:
* KAFKA_BOOTSTRAP_SERVERS
* KAFKA_GROUP_ID
* KAFKA_TOPIC_INVALID_MESSAGE
* KAFKA_TOPIC_DEAD_LETTER
* KAFKA_TOPIC_TEST_MESSAGE_OUTPUT
* OPENFAAS_GATEWAY

This PR adds the variables with default values to each Kafka-enabled micoservice.

TODO:
JavaDoc

# Resolves / is related to
Closes #748

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`ng serve --prod`)
- [ ] Documentation

# Checklist

- [X] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
