### PR TITLE
Bump Spring Boot to version 2.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.1.7.RELEASE</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Bump Spring Boot to version 2.1.7 (before 2.1.6).
Changelog: https://github.com/spring-projects/spring-boot/releases/tag/v2.1.7.RELEASE