### PR TITLE
Bump Neo4j to version 3.5.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   neo4j:
-    image: "neo4j:3.5.2"
+    image: "neo4j:3.5.8"
     container_name: neo4j
     ports:
      - "7474:7474"

--- a/install/kubernetes/neo4j.yaml
+++ b/install/kubernetes/neo4j.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: neo4j
-          image: 'neo4j:3.5.3'
+          image: 'neo4j:3.5.8'
           imagePullPolicy: 'IfNotPresent'
           env:
             - name: NEO4J_dbms_security_auth__enabled


### PR DESCRIPTION
Bump Neo4j to version 3.5.8 (before 3.5.3).
Changelog: https://neo4j.com/release-notes/

Tested locally.