### PR TITLE
Refactor MicoServiceDeploymentInfo and fix Neo4j bug

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -167,7 +167,9 @@ public class MicoApplicationBroker {
         return applicationRepository.findAllByUsedService(serviceShortName, serviceVersion);
     }
 
-    public void addMicoServiceToMicoApplicationByShortNameAndVersion(String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion) throws MicoApplicationNotFoundException, MicoServiceNotFoundException, MicoServiceAlreadyAddedToMicoApplicationException, MicoServiceAddedMoreThanOnceToMicoApplicationException, MicoApplicationIsNotUndeployedException, MicoTopicRoleUsedMultipleTimesException, MicoServiceDeploymentInformationNotFoundException, KubernetesResourceException, MicoApplicationDoesNotIncludeMicoServiceException {
+    public void addMicoServiceToMicoApplicationByShortNameAndVersion(String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion)
+        throws MicoApplicationNotFoundException, MicoServiceNotFoundException, MicoServiceAlreadyAddedToMicoApplicationException, MicoServiceAddedMoreThanOnceToMicoApplicationException,
+        MicoApplicationIsNotUndeployedException, MicoTopicRoleUsedMultipleTimesException, MicoServiceDeploymentInformationNotFoundException, KubernetesResourceException, MicoApplicationDoesNotIncludeMicoServiceException {
 
         log.debug("Adding MicoService '{}' '{}' to MicoApplication '{}' '{}'.",
             serviceShortName, serviceVersion, applicationShortName, applicationVersion);
@@ -258,7 +260,7 @@ public class MicoApplicationBroker {
         // TODO: Update Kubernetes deployment (see issue mico#627)
     }
 
-    public MicoApplication checkForMicoServiceInMicoApplication(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException {
+    MicoApplication checkForMicoServiceInMicoApplication(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException {
         MicoApplication micoApplication = getMicoApplicationByShortNameAndVersion(applicationShortName, applicationVersion);
 
         if (micoApplication.getServices().stream().noneMatch(service -> service.getShortName().equals(serviceShortName))) {

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.broker;
+
+import io.github.ust.mico.core.configuration.KafkaConfig;
+import io.github.ust.mico.core.configuration.OpenFaaSConfig;
+import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
+import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
+import io.github.ust.mico.core.exception.*;
+import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.persistence.*;
+import io.github.ust.mico.core.service.MicoKubernetesClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class MicoServiceDeploymentInfoBroker {
+
+    @Autowired
+    private MicoApplicationBroker applicationBroker;
+
+    @Autowired
+    private MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
+
+    @Autowired
+    private MicoKubernetesClient micoKubernetesClient;
+
+    @Autowired
+    private MicoLabelRepository micoLabelRepository;
+
+    @Autowired
+    private MicoTopicRepository micoTopicRepository;
+
+    @Autowired
+    private MicoEnvironmentVariableRepository micoEnvironmentVariableRepository;
+
+    @Autowired
+    private KubernetesDeploymentInfoRepository kubernetesDeploymentInfoRepository;
+
+    @Autowired
+    private MicoInterfaceConnectionRepository micoInterfaceConnectionRepository;
+
+    @Autowired
+    private KafkaConfig kafkaConfig;
+
+    @Autowired
+    private OpenFaaSConfig openFaaSConfig;
+
+    public MicoServiceDeploymentInfo getMicoServiceDeploymentInformation(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoServiceDeploymentInformationNotFoundException, MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException {
+        applicationBroker.checkForMicoServiceInMicoApplication(applicationShortName, applicationVersion, serviceShortName);
+
+        Optional<MicoServiceDeploymentInfo> micoServiceDeploymentInfoOptional = serviceDeploymentInfoRepository.findByApplicationAndService(applicationShortName, applicationVersion, serviceShortName);
+        if (micoServiceDeploymentInfoOptional.isPresent()) {
+            return micoServiceDeploymentInfoOptional.get();
+        } else {
+            throw new MicoServiceDeploymentInformationNotFoundException(applicationShortName, applicationVersion, serviceShortName);
+        }
+    }
+
+    public MicoServiceDeploymentInfo updateMicoServiceDeploymentInformation(String applicationShortName, String applicationVersion,
+                                                                            String serviceShortName, MicoServiceDeploymentInfoRequestDTO serviceDeploymentInfoDTO) throws
+        MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException,
+        MicoServiceDeploymentInformationNotFoundException, KubernetesResourceException, MicoTopicRoleUsedMultipleTimesException {
+
+        validateTopics(serviceDeploymentInfoDTO);
+
+        MicoApplication micoApplication = applicationBroker.getMicoApplicationByShortNameAndVersion(applicationShortName, applicationVersion);
+        MicoServiceDeploymentInfo storedServiceDeploymentInfo = getMicoServiceDeploymentInformation(applicationShortName, applicationVersion, serviceShortName);
+
+        int oldReplicas = storedServiceDeploymentInfo.getReplicas();
+
+        MicoServiceDeploymentInfo sdiWithAppliedValues = storedServiceDeploymentInfo.applyValuesFrom(serviceDeploymentInfoDTO);
+        // At first save the service deployment information with the new values without topics.
+        // This is a workaround to save them later with new relationships. Otherwise Neo4j sometimes deletes the relationships!?
+        sdiWithAppliedValues.setTopics(new ArrayList<>());
+        MicoServiceDeploymentInfo updatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(sdiWithAppliedValues);
+
+        // If there are topics, apply them and save the service deployment information again.
+        if (!serviceDeploymentInfoDTO.getTopics().isEmpty()) {
+            MicoServiceDeploymentInfo sdiWithTopics = updatedServiceDeploymentInfo.setTopics(
+                serviceDeploymentInfoDTO.getTopics().stream().map(topicDto -> MicoTopicRole.valueOf(topicDto, storedServiceDeploymentInfo)).collect(Collectors.toList()));
+            // Check if topics with the same names already exist, if so reuse them.
+            MicoServiceDeploymentInfo sdiWithReusedTopics = createOrReuseTopics(sdiWithTopics);
+            updatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(sdiWithReusedTopics);
+        }
+
+        // In case addition properties (stored as separate node entity) such as labels, environment variables
+        // have been removed from this service deployment information,
+        // the standard save() function of the service deployment information repository will not delete those
+        // "tangling" (without relationships) labels (nodes), hence the manual clean up.
+        micoLabelRepository.cleanUp();
+        micoTopicRepository.cleanUp();
+        micoEnvironmentVariableRepository.cleanUp();
+        kubernetesDeploymentInfoRepository.cleanUp();
+        micoInterfaceConnectionRepository.cleanUp();
+
+        // FIXME: Currently we only supported scale in / scale out.
+        // 		  If the MICO service is already deployed, we only update the replicas.
+        // 	      The other properties are ignored!
+        if (micoKubernetesClient.isApplicationDeployed(micoApplication)) {
+            MicoService micoService = updatedServiceDeploymentInfo.getService();
+            log.info("MicoApplication '{}' {}' is already deployed. Update the deployment of the included MicoService '{} '{}'.",
+                micoApplication.getShortName(), micoApplication.getVersion(), micoService.getShortName(), micoService.getVersion());
+
+            // MICO service is already deployed. Update the replicas.
+            int replicasDiff = serviceDeploymentInfoDTO.getReplicas() - oldReplicas;
+            if (replicasDiff > 0) {
+                log.debug("Increase replicas of MicoService '{}' '{}' by {}.", micoService.getShortName(), micoService.getVersion(), replicasDiff);
+                micoKubernetesClient.scaleOut(updatedServiceDeploymentInfo, replicasDiff);
+            } else if (replicasDiff < 0) {
+                log.debug("Decrease replicas of MicoService '{}' '{}' by {}.", micoService.getShortName(), micoService.getVersion(), replicasDiff);
+                micoKubernetesClient.scaleIn(updatedServiceDeploymentInfo, Math.abs(replicasDiff));
+            } else {
+                // TODO: If no scale operation is required, maybe some other
+                // 		 information still needs to be updated.
+            }
+        }
+
+        return updatedServiceDeploymentInfo;
+    }
+
+    /**
+     * Validates the topics.
+     * Throws an error if there are multiple topics with the same role.
+     *
+     * @param serviceDeploymentInfoDTO the {@link MicoServiceDeploymentInfoRequestDTO}
+     * @throws MicoTopicRoleUsedMultipleTimesException if an {@code MicoTopicRole.Role} is not unique
+     */
+    private void validateTopics(MicoServiceDeploymentInfoRequestDTO serviceDeploymentInfoDTO) throws MicoTopicRoleUsedMultipleTimesException {
+        List<MicoTopicRequestDTO> newTopics = serviceDeploymentInfoDTO.getTopics();
+        Set<MicoTopicRole.Role> usedRoles = new HashSet<>();
+        for (MicoTopicRequestDTO requestDTO : newTopics) {
+            if (!usedRoles.add(requestDTO.getRole())) {
+                // Role is used twice, however a role should be used only once
+                throw new MicoTopicRoleUsedMultipleTimesException(requestDTO.getRole());
+            }
+        }
+    }
+
+    /**
+     * Checks if topics with the same name already exists.
+     * If so reuse them by setting the id of the existing Neo4j node and save them.
+     * If not create them in the database.
+     *
+     * @param serviceDeploymentInfo the {@link MicoServiceDeploymentInfo} containing topics
+     */
+    private MicoServiceDeploymentInfo createOrReuseTopics(MicoServiceDeploymentInfo serviceDeploymentInfo) {
+        List<MicoTopicRole> topicRoles = serviceDeploymentInfo.getTopics();
+
+        for (MicoTopicRole topicRole : topicRoles) {
+            String topicName = topicRole.getTopic().getName();
+            Optional<MicoTopic> existingTopic = micoTopicRepository.findByName(topicName);
+            if (existingTopic.isPresent()) {
+                topicRole.setTopic(existingTopic.get());
+            } else {
+                MicoTopic savedTopic = micoTopicRepository.save(topicRole.getTopic());
+                topicRole.setTopic(savedTopic);
+            }
+        }
+        return serviceDeploymentInfo;
+    }
+
+
+    /**
+     * Sets the default environment variables for Kafka-enabled MicoServices. See {@link MicoEnvironmentVariable.DefaultNames}
+     * for a complete list.
+     *
+     * @param micoServiceDeploymentInfo The {@link MicoServiceDeploymentInfo} with an corresponding MicoService
+     */
+    public void setDefaultDeploymentInformationForKafkaEnabledService(MicoServiceDeploymentInfo micoServiceDeploymentInfo) {
+        MicoService micoService = micoServiceDeploymentInfo.getService();
+        if (micoService == null) {
+            throw new IllegalArgumentException("The MicoServiceDeploymentInfo needs a valid MicoService set to check if the service is Kafka enabled");
+        }
+        if (!micoService.isKafkaEnabled()) {
+            log.debug("MicoService '{}' '{}' is not Kafka-enabled. Not necessary to adding specific env variables.",
+                micoService.getShortName(), micoService.getVersion());
+            return;
+        }
+        log.debug("Adding default environment variables and topics to the Kafka-enabled MicoService '{}' '{}'.",
+            micoService.getShortName(), micoService.getVersion());
+        List<MicoEnvironmentVariable> micoEnvironmentVariables = micoServiceDeploymentInfo.getEnvironmentVariables();
+        micoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
+        micoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
+        List<MicoTopicRole> topics = micoServiceDeploymentInfo.getTopics();
+        topics.addAll(kafkaConfig.getDefaultTopics(micoServiceDeploymentInfo));
+    }
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -19,25 +19,6 @@
 
 package io.github.ust.mico.core.resource;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-
-import io.github.ust.mico.core.model.MicoApplicationDeploymentStatus;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.Resources;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-
 import io.github.ust.mico.core.broker.MicoApplicationBroker;
 import io.github.ust.mico.core.dto.request.MicoApplicationRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
@@ -49,9 +30,26 @@ import io.github.ust.mico.core.dto.response.status.MicoApplicationDeploymentStat
 import io.github.ust.mico.core.dto.response.status.MicoApplicationStatusResponseDTO;
 import io.github.ust.mico.core.exception.*;
 import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoApplicationDeploymentStatus;
 import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @Slf4j
 @RestController
@@ -204,10 +202,12 @@ public class ApplicationResource {
                                                         @PathVariable(PATH_VARIABLE_SERVICE_VERSION) String serviceVersion) {
         try {
             broker.addMicoServiceToMicoApplicationByShortNameAndVersion(applicationShortName, applicationVersion, serviceShortName, serviceVersion);
-        } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException e) {
+        } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        } catch (MicoServiceAlreadyAddedToMicoApplicationException | MicoServiceAddedMoreThanOnceToMicoApplicationException | MicoApplicationIsNotUndeployedException e) {
+        } catch (MicoServiceAlreadyAddedToMicoApplicationException | MicoServiceAddedMoreThanOnceToMicoApplicationException | MicoApplicationIsNotUndeployedException | MicoApplicationDoesNotIncludeMicoServiceException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (MicoTopicRoleUsedMultipleTimesException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
         }
 
         return ResponseEntity.noContent().build();

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceDeploymentInfoResource.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.resource;
+
+import io.github.ust.mico.core.broker.MicoServiceDeploymentInfoBroker;
+import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
+import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
+import io.github.ust.mico.core.exception.*;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.validation.Valid;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/applications", produces = MediaTypes.HAL_JSON_VALUE)
+public class ServiceDeploymentInfoResource {
+
+    private static final String PATH_DEPLOYMENT_INFORMATION = "deploymentInformation";
+
+    private static final String PATH_VARIABLE_SHORT_NAME = "micoApplicationShortName";
+    private static final String PATH_VARIABLE_VERSION = "micoApplicationVersion";
+    private static final String PATH_VARIABLE_SERVICE_SHORT_NAME = "micoServiceShortName";
+
+    @Autowired
+    private MicoServiceDeploymentInfoBroker broker;
+
+    @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_DEPLOYMENT_INFORMATION + "/{" + PATH_VARIABLE_SERVICE_SHORT_NAME + "}")
+    public ResponseEntity<Resource<MicoServiceDeploymentInfoResponseDTO>> getServiceDeploymentInformation(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                          @PathVariable(PATH_VARIABLE_VERSION) String version,
+                                                                                                          @PathVariable(PATH_VARIABLE_SERVICE_SHORT_NAME) String serviceShortName) {
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo;
+        try {
+            micoServiceDeploymentInfo = broker.getMicoServiceDeploymentInformation(shortName, version, serviceShortName);
+        } catch (MicoServiceDeploymentInformationNotFoundException | MicoApplicationNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (MicoApplicationDoesNotIncludeMicoServiceException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        }
+
+        // Convert to service deployment info DTO and return it
+        MicoServiceDeploymentInfoResponseDTO serviceDeploymentInfoResponseDto = new MicoServiceDeploymentInfoResponseDTO(micoServiceDeploymentInfo);
+        return ResponseEntity.ok(new Resource<>(serviceDeploymentInfoResponseDto,
+            linkTo(methodOn(ServiceDeploymentInfoResource.class)
+                .getServiceDeploymentInformation(shortName, version, serviceShortName)).withSelfRel()));
+    }
+
+    @PutMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_DEPLOYMENT_INFORMATION + "/{" + PATH_VARIABLE_SERVICE_SHORT_NAME + "}")
+    public ResponseEntity<Resource<MicoServiceDeploymentInfoResponseDTO>> updateServiceDeploymentInformation(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                             @PathVariable(PATH_VARIABLE_VERSION) String version,
+                                                                                                             @PathVariable(PATH_VARIABLE_SERVICE_SHORT_NAME) String serviceShortName,
+                                                                                                             @Valid @RequestBody MicoServiceDeploymentInfoRequestDTO serviceDeploymentInfoRequestDto) {
+        MicoServiceDeploymentInfo updatedServiceDeploymentInfo;
+        try {
+            updatedServiceDeploymentInfo = broker.updateMicoServiceDeploymentInformation(
+                shortName, version, serviceShortName, serviceDeploymentInfoRequestDto);
+        } catch (MicoApplicationNotFoundException | MicoServiceDeploymentInformationNotFoundException
+            | KubernetesResourceException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (MicoApplicationDoesNotIncludeMicoServiceException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (MicoTopicRoleUsedMultipleTimesException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        }
+
+        // Convert to service deployment info DTO and return it
+        MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDto = new MicoServiceDeploymentInfoResponseDTO(updatedServiceDeploymentInfo);
+        return ResponseEntity.ok(new Resource<>(updatedServiceDeploymentInfoDto,
+            linkTo(methodOn(ServiceDeploymentInfoResource.class).getServiceDeploymentInformation(shortName, version, serviceShortName))
+                .withSelfRel()));
+    }
+
+}

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core;
+
+import io.github.ust.mico.core.configuration.KafkaConfig;
+import io.github.ust.mico.core.configuration.OpenFaaSConfig;
+import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.persistence.MicoApplicationRepository;
+import io.github.ust.mico.core.persistence.MicoServiceRepository;
+import io.github.ust.mico.core.service.MicoKubernetesClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.github.ust.mico.core.TestConstants.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@EnableAutoConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
+
+    private static final String BASE_PATH = "/applications";
+    private static final String PATH_SERVICES = "services";
+
+    @Autowired
+    MicoApplicationRepository applicationRepository;
+
+    @Autowired
+    MicoServiceRepository serviceRepository;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private OpenFaaSConfig openFaaSConfig;
+
+    @Autowired
+    private KafkaConfig kafkaConfig;
+
+    @MockBean
+    private MicoKubernetesClient micoKubernetesClient;
+
+    @Test
+    public void testDefaultVariablesAddedToKafkaEnabledService() throws Exception {
+        MicoApplication micoApplication = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
+        applicationRepository.save(micoApplication);
+        MicoService service1 = new MicoService().setShortName(SERVICE_SHORT_NAME).setVersion(VERSION_1_0_1).setKafkaEnabled(true);
+        serviceRepository.save(service1);
+
+        given(micoKubernetesClient.isApplicationUndeployed(micoApplication)).willReturn(true);
+
+        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        Optional<MicoApplication> savedApplicationOpt = applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION);
+        assertTrue(savedApplicationOpt.isPresent());
+        MicoApplication savedApplication = savedApplicationOpt.get();
+        assertThat(savedApplication.getServiceDeploymentInfos(), hasSize(1));
+
+        MicoServiceDeploymentInfo actualServiceDeploymentInfo = savedApplication.getServiceDeploymentInfos().get(0);
+        LinkedList<MicoEnvironmentVariable> expectedMicoEnvironmentVariables = new LinkedList<>();
+        expectedMicoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
+        expectedMicoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
+        List<MicoEnvironmentVariable> actualEnvironmentVariables = actualServiceDeploymentInfo.getEnvironmentVariables();
+        assertEquals(3, actualEnvironmentVariables.size());
+        assertThat(actualEnvironmentVariables.stream().map(MicoEnvironmentVariable::getName).collect(Collectors.toList()),
+            containsInAnyOrder(expectedMicoEnvironmentVariables.stream().map(MicoEnvironmentVariable::getName).toArray()));
+
+        LinkedList<MicoTopicRole> expectedMicoTopics = new LinkedList<>();
+        expectedMicoTopics.addAll(kafkaConfig.getDefaultTopics(actualServiceDeploymentInfo));
+        List<MicoTopicRole> actualTopics = actualServiceDeploymentInfo.getTopics();
+        assertEquals(3, actualTopics.size());
+        assertThat(actualTopics.stream().map(MicoTopicRole::getRole).collect(Collectors.toList()),
+            containsInAnyOrder(expectedMicoTopics.stream().map(MicoTopicRole::getRole).toArray()));
+    }
+
+    @Test
+    public void testDefaultVariablesNotAddedToNormalService() throws Exception {
+        MicoApplication micoApplication = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
+        applicationRepository.save(micoApplication);
+        MicoService service1 = new MicoService().setShortName(SERVICE_SHORT_NAME).setVersion(VERSION_1_0_1);
+        //Kafka enabled is not set
+        serviceRepository.save(service1);
+
+        given(micoKubernetesClient.isApplicationUndeployed(micoApplication)).willReturn(true);
+
+        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        Optional<MicoApplication> savedApplicationOpt = applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION);
+        assertTrue(savedApplicationOpt.isPresent());
+        MicoApplication savedApplication = savedApplicationOpt.get();
+        assertThat(savedApplication.getServiceDeploymentInfos(), hasSize(1));
+        List<MicoEnvironmentVariable> actualEnvironmentVariables = savedApplication.getServiceDeploymentInfos().get(0).getEnvironmentVariables();
+        assertThat(actualEnvironmentVariables, hasSize(0));
+
+    }
+}

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -20,15 +20,15 @@
 package io.github.ust.mico.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.ust.mico.core.broker.MicoServiceDeploymentInfoBroker;
 import io.github.ust.mico.core.configuration.KafkaConfig;
 import io.github.ust.mico.core.configuration.OpenFaaSConfig;
-import io.github.ust.mico.core.dto.request.*;
+import io.github.ust.mico.core.dto.request.MicoApplicationRequestDTO;
+import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
+import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
 import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
-import io.github.ust.mico.core.dto.response.MicoLabelResponseDTO;
-import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
 import io.github.ust.mico.core.dto.response.status.*;
 import io.github.ust.mico.core.model.*;
-import io.github.ust.mico.core.model.MicoServiceDeploymentInfo.ImagePullPolicy;
 import io.github.ust.mico.core.persistence.*;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
 import io.github.ust.mico.core.service.MicoStatusService;
@@ -47,7 +47,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -88,7 +87,6 @@ public class ApplicationResourceIntegrationTests {
     private static final String JSON_PATH_LINKS_SECTION = "$._links.";
     private static final String BASE_PATH = "/applications";
     private static final String PATH_SERVICES = "services";
-    private static final String PATH_DEPLOYMENT_INFORMATION = "deploymentInformation";
     private static final String PATH_PROMOTE = "promote";
     private static final String PATH_DEPLOYMENT_STATUS = "deploymentStatus";
     private static final String PATH_STATUS = "status";
@@ -122,6 +120,9 @@ public class ApplicationResourceIntegrationTests {
 
     @MockBean
     private MicoStatusService micoStatusService;
+
+    @MockBean
+    private MicoServiceDeploymentInfoBroker micoServiceDeploymentInfoBroker;
 
     @Autowired
     private MockMvc mvc;
@@ -895,6 +896,8 @@ public class ApplicationResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
         given(serviceRepository.findAllByApplication(SHORT_NAME, VERSION)).willReturn(CollectionUtils.listOf(service));
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
+        given(micoServiceDeploymentInfoBroker.updateMicoServiceDeploymentInformation(
+            eq(SHORT_NAME), eq(VERSION), eq(SERVICE_SHORT_NAME), any(MicoServiceDeploymentInfoRequestDTO.class))).willReturn(new MicoServiceDeploymentInfo());
 
         ArgumentCaptor<MicoApplication> micoApplicationCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
@@ -929,191 +932,6 @@ public class ApplicationResourceIntegrationTests {
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
             .andDo(print())
             .andExpect(status().isNoContent());
-    }
-
-    @Test
-    public void getServiceDeploymentInformation() throws Exception {
-        MicoApplication application = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoService service = new MicoService()
-            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
-
-        List<MicoLabel> labels = CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value"));
-        ImagePullPolicy imagePullPolicy = ImagePullPolicy.IF_NOT_PRESENT;
-        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
-            .setService(service)
-            .setReplicas(3)
-            .setLabels(labels)
-            .setImagePullPolicy(imagePullPolicy);
-
-        application.getServices().add(service);
-        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
-
-        given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(),
-            application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
-
-        mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
-            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(labels.get(0).getKey())))
-            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(labels.get(0).getValue())))
-            .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(imagePullPolicy.toString())))
-            .andReturn();
-    }
-
-    @Test
-    public void updateServiceDeploymentInformation() throws Exception {
-        MicoApplication application = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoApplication expectedApplication = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoService service = new MicoService()
-            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
-
-        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
-            .setId(ID_1)
-            .setService(service)
-            .setReplicas(3)
-            .setLabels(CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value")))
-            .setImagePullPolicy(ImagePullPolicy.IF_NOT_PRESENT);
-
-        MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
-            .setReplicas(5)
-            .setLabels(CollectionUtils.listOf(new MicoLabelRequestDTO().setKey("key-updated").setValue("value-updated")))
-            .setImagePullPolicy(ImagePullPolicy.NEVER)
-            .setTopics(CollectionUtils.listOf(
-                new MicoTopicRequestDTO().setName("input-topic").setRole(MicoTopicRole.Role.INPUT),
-                new MicoTopicRequestDTO().setName("output-topic").setRole(MicoTopicRole.Role.OUTPUT)));
-
-        application.getServices().add(service);
-        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
-        expectedApplication.getServices().add(service);
-        expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
-
-        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
-        given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
-        given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
-
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
-            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
-            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
-            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getKey())))
-            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getValue())))
-            .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(updatedServiceDeploymentInfoDTO.getImagePullPolicy().toString())))
-            .andExpect(jsonPath(SDI_TOPICS_PATH, hasSize(2)))
-            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].name", is(updatedServiceDeploymentInfoDTO.getTopics().get(0).getName())))
-            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].role", is(updatedServiceDeploymentInfoDTO.getTopics().get(0).getRole().toString())))
-            .andExpect(jsonPath(SDI_TOPICS_PATH + "[1].name", is(updatedServiceDeploymentInfoDTO.getTopics().get(1).getName())))
-            .andExpect(jsonPath(SDI_TOPICS_PATH + "[1].role", is(updatedServiceDeploymentInfoDTO.getTopics().get(1).getRole().toString())))
-            .andReturn();
-    }
-
-    @Test
-    public void updateServiceDeploymentInformationWithDuplicatedTopicRoles() throws Exception {
-        MicoApplication application = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoService service = new MicoService()
-            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
-
-        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
-            .setId(ID_1)
-            .setService(service);
-
-        MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
-            .setTopics(CollectionUtils.listOf(
-                new MicoTopicRequestDTO().setName("topic-1").setRole(MicoTopicRole.Role.INPUT),
-                new MicoTopicRequestDTO().setName("topic-2").setRole(MicoTopicRole.Role.INPUT)));
-
-        application.getServices().add(service);
-        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
-
-        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
-
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
-            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
-            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-            .andDo(print())
-            .andExpect(status().isUnprocessableEntity());
-    }
-
-    @Test
-    public void updateServiceDeploymentInformationReusesExistingTopics() throws Exception {
-        MicoApplication application = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoApplication expectedApplication = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoService service = new MicoService()
-            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
-
-        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
-            .setId(ID_1)
-            .setService(service);
-
-        MicoTopic existingTopic1 = new MicoTopic()
-            .setId(ID_2)
-            .setName("topic-name-1");
-
-        MicoTopic existingTopic2 = new MicoTopic()
-            .setId(ID_3)
-            .setName("topic-name-2");
-
-        String newTopicName = "new-topic";
-        MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
-            .setTopics(CollectionUtils.listOf(
-                new MicoTopicRequestDTO().setName(existingTopic1.getName()).setRole(MicoTopicRole.Role.INPUT),
-                new MicoTopicRequestDTO().setName(newTopicName).setRole(MicoTopicRole.Role.OUTPUT)));
-
-        application.getServices().add(service);
-        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
-        expectedApplication.getServices().add(service);
-        expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
-
-        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
-        given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
-        given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
-        given(micoTopicRepository.findByName(existingTopic1.getName())).willReturn(Optional.of(existingTopic1));
-        given(micoTopicRepository.findByName(existingTopic2.getName())).willReturn(Optional.of(existingTopic2));
-
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
-            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
-            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath(SDI_TOPICS_PATH, hasSize(2)))
-            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].name", is(serviceDeploymentInfo.getTopics().get(0).getTopic().getName())))
-            .andExpect(jsonPath(SDI_TOPICS_PATH + "[1].name", is(serviceDeploymentInfo.getTopics().get(1).getTopic().getName())))
-            .andReturn();
-
-        ArgumentCaptor<MicoServiceDeploymentInfo> sdiCaptor = ArgumentCaptor.forClass(MicoServiceDeploymentInfo.class);
-
-        verify(serviceDeploymentInfoRepository, atLeast(1)).save(sdiCaptor.capture());
-        MicoServiceDeploymentInfo actualSdi = sdiCaptor.getValue();
-        assertEquals(2, actualSdi.getTopics().size());
-        MicoTopicRole actualTopicRole1 = actualSdi.getTopics().get(0);
-        assertEquals("Existing topic was not reused!", existingTopic1.getId(), actualTopicRole1.getTopic().getId());
-        assertEquals(existingTopic1, actualTopicRole1.getTopic());
-        MicoTopicRole actualTopicRole2 = actualSdi.getTopics().get(1);
-        assertEquals("New topic was not saved.", newTopicName, actualTopicRole2.getTopic().getName());
     }
 
     @Test
@@ -1158,44 +976,6 @@ public class ApplicationResourceIntegrationTests {
             .andReturn();
 
         verify(applicationRepository, never()).deleteAll(micoApplicationListCaptor.capture());
-    }
-
-
-    @Test
-    public void invalidLabelsThrowAnException() throws Exception {
-        List<MicoLabel> labels = CollectionUtils.listOf(new MicoLabel().setKey("invalid-key!").setValue("value"));
-
-        MicoApplication application = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoApplication expectedApplication = new MicoApplication()
-            .setId(ID)
-            .setShortName(SHORT_NAME).setVersion(VERSION);
-
-        MicoService service = new MicoService()
-            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
-
-        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo().setService(service);
-
-        MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDTO =
-            (MicoServiceDeploymentInfoResponseDTO) new MicoServiceDeploymentInfoResponseDTO()
-                .setLabels(labels.stream().map(MicoLabelResponseDTO::new).collect(Collectors.toList()));
-
-        application.getServices().add(service);
-        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
-        expectedApplication.getServices().add(service);
-        expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
-
-        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion()))
-            .willReturn(Optional.of(application));
-
-        final ResultActions result = mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
-            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
-            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-            .andDo(print());
-
-        result.andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -1246,65 +1026,5 @@ public class ApplicationResourceIntegrationTests {
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isConflict());
-    }
-
-    @Test
-    public void testDefaultVariablesAddedToKafkaEnabledService() throws Exception {
-        MicoApplication micoApplication = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
-        MicoService service1 = new MicoService().setShortName(SERVICE_SHORT_NAME).setVersion(VERSION_1_0_1).setKafkaEnabled(true);
-
-        given(applicationRepository.findByShortNameAndVersion(micoApplication.getShortName(), micoApplication.getVersion()))
-            .willReturn(Optional.of(micoApplication));
-        given(serviceRepository.findByShortNameAndVersion(service1.getShortName(), service1.getVersion()))
-            .willReturn(Optional.of(service1));
-        given(micoKubernetesClient.isApplicationUndeployed(micoApplication)).willReturn(true);
-
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
-            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-            .andDo(print())
-            .andExpect(status().isNoContent());
-
-        ArgumentCaptor<MicoApplication> applicationCaptor = ArgumentCaptor.forClass(MicoApplication.class);
-        verify(applicationRepository, times(1)).save(applicationCaptor.capture());
-        MicoApplication savedApplication = applicationCaptor.getValue();
-        assertThat(savedApplication.getServiceDeploymentInfos(), hasSize(1));
-        MicoServiceDeploymentInfo actualServiceDeploymentInfo = savedApplication.getServiceDeploymentInfos().get(0);
-
-        LinkedList<MicoEnvironmentVariable> expectedMicoEnvironmentVariables = new LinkedList<>();
-        expectedMicoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
-        expectedMicoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
-        List<MicoEnvironmentVariable> actualEnvironmentVariables = actualServiceDeploymentInfo.getEnvironmentVariables();
-        assertThat(actualEnvironmentVariables, containsInAnyOrder(expectedMicoEnvironmentVariables.toArray()));
-
-        LinkedList<MicoTopicRole> expectedMicoTopics = new LinkedList<>();
-        expectedMicoTopics.addAll(kafkaConfig.getDefaultTopics(actualServiceDeploymentInfo));
-        List<MicoTopicRole> actualTopics = actualServiceDeploymentInfo.getTopics();
-        assertThat(actualTopics, containsInAnyOrder(expectedMicoTopics.toArray()));
-    }
-
-    @Test
-    public void testDefaultVariablesNotAddedToNormalService() throws Exception {
-        MicoApplication micoApplication = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
-        MicoService service1 = new MicoService().setShortName(SERVICE_SHORT_NAME).setVersion(VERSION_1_0_1);
-        //Kafka enabled is not set
-
-        given(applicationRepository.findByShortNameAndVersion(micoApplication.getShortName(), micoApplication.getVersion()))
-            .willReturn(Optional.of(micoApplication));
-        given(serviceRepository.findByShortNameAndVersion(service1.getShortName(), service1.getVersion()))
-            .willReturn(Optional.of(service1));
-        given(micoKubernetesClient.isApplicationUndeployed(micoApplication)).willReturn(true);
-
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
-            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
-            .andDo(print())
-            .andExpect(status().isNoContent());
-
-        ArgumentCaptor<MicoApplication> applicationCaptor = ArgumentCaptor.forClass(MicoApplication.class);
-        verify(applicationRepository, times(1)).save(applicationCaptor.capture());
-        MicoApplication savedApplication = applicationCaptor.getValue();
-        assertThat(savedApplication.getServiceDeploymentInfos(), hasSize(1));
-        List<MicoEnvironmentVariable> actualEnvironmentVariables = savedApplication.getServiceDeploymentInfos().get(0).getEnvironmentVariables();
-        assertThat(actualEnvironmentVariables, hasSize(0));
-
     }
 }

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceDeploymentInfoIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceDeploymentInfoIntegrationTests.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.ust.mico.core.dto.request.MicoLabelRequestDTO;
+import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
+import io.github.ust.mico.core.dto.request.MicoTopicRequestDTO;
+import io.github.ust.mico.core.dto.response.MicoLabelResponseDTO;
+import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
+import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo.ImagePullPolicy;
+import io.github.ust.mico.core.persistence.*;
+import io.github.ust.mico.core.service.MicoKubernetesClient;
+import io.github.ust.mico.core.service.MicoStatusService;
+import io.github.ust.mico.core.util.CollectionUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.github.ust.mico.core.TestConstants.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@EnableAutoConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+public class ServiceDeploymentInfoIntegrationTests {
+
+    private static final String BASE_PATH = "/applications";
+    private static final String PATH_DEPLOYMENT_INFORMATION = "deploymentInformation";
+
+    @MockBean
+    private MicoApplicationRepository applicationRepository;
+
+    @MockBean
+    private MicoServiceRepository serviceRepository;
+
+    @MockBean
+    private MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
+
+    @MockBean
+    private MicoLabelRepository micoLabelRepository;
+
+    @MockBean
+    private MicoTopicRepository micoTopicRepository;
+
+    @MockBean
+    private MicoEnvironmentVariableRepository micoEnvironmentVariableRepository;
+
+    @MockBean
+    private KubernetesDeploymentInfoRepository kubernetesDeploymentInfoRepository;
+
+    @MockBean
+    private MicoInterfaceConnectionRepository micoInterfaceConnectionRepository;
+
+    @MockBean
+    private MicoKubernetesClient micoKubernetesClient;
+
+    @MockBean
+    private MicoStatusService micoStatusService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    public void getServiceDeploymentInformation() throws Exception {
+        MicoApplication application = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoService service = new MicoService()
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+
+        List<MicoLabel> labels = CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value"));
+        ImagePullPolicy imagePullPolicy = ImagePullPolicy.IF_NOT_PRESENT;
+        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
+            .setService(service)
+            .setReplicas(3)
+            .setLabels(labels)
+            .setImagePullPolicy(imagePullPolicy);
+
+        application.getServices().add(service);
+        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
+
+        given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(),
+            application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+
+        mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(labels.get(0).getKey())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(labels.get(0).getValue())))
+            .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(imagePullPolicy.toString())))
+            .andReturn();
+    }
+
+    @Test
+    public void updateServiceDeploymentInformation() throws Exception {
+        MicoApplication application = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoApplication expectedApplication = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoService service = new MicoService()
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+
+        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
+            .setId(ID_1)
+            .setService(service)
+            .setReplicas(3)
+            .setLabels(CollectionUtils.listOf(new MicoLabel().setKey("key").setValue("value")))
+            .setImagePullPolicy(ImagePullPolicy.IF_NOT_PRESENT);
+
+        MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
+            .setReplicas(5)
+            .setLabels(CollectionUtils.listOf(new MicoLabelRequestDTO().setKey("key-updated").setValue("value-updated")))
+            .setImagePullPolicy(ImagePullPolicy.NEVER)
+            .setTopics(CollectionUtils.listOf(
+                new MicoTopicRequestDTO().setName("input-topic").setRole(MicoTopicRole.Role.INPUT),
+                new MicoTopicRequestDTO().setName("output-topic").setRole(MicoTopicRole.Role.OUTPUT)));
+
+        MicoTopic expectedTopicInput = new MicoTopic().setName("input-topic");
+        MicoTopic expectedTopicOutput = new MicoTopic().setName("output-topic");
+
+        application.getServices().add(service);
+        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
+        expectedApplication.getServices().add(service);
+        expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
+
+        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
+        given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+        given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
+        given(micoTopicRepository.findByName(anyString())).willReturn(Optional.empty());
+        given(micoTopicRepository.save(eq(expectedTopicInput))).willReturn(expectedTopicInput);
+        given(micoTopicRepository.save(eq(expectedTopicOutput))).willReturn(expectedTopicOutput);
+
+        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].key", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getKey())))
+            .andExpect(jsonPath(SDI_LABELS_PATH + "[0].value", is(updatedServiceDeploymentInfoDTO.getLabels().get(0).getValue())))
+            .andExpect(jsonPath(SDI_IMAGE_PULLPOLICY_PATH, is(updatedServiceDeploymentInfoDTO.getImagePullPolicy().toString())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH, hasSize(2)))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].name", is(updatedServiceDeploymentInfoDTO.getTopics().get(0).getName())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].role", is(updatedServiceDeploymentInfoDTO.getTopics().get(0).getRole().toString())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[1].name", is(updatedServiceDeploymentInfoDTO.getTopics().get(1).getName())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[1].role", is(updatedServiceDeploymentInfoDTO.getTopics().get(1).getRole().toString())))
+            .andReturn();
+    }
+
+    @Test
+    public void updateServiceDeploymentInformationWithDuplicatedTopicRoles() throws Exception {
+        MicoApplication application = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoService service = new MicoService()
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+
+        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
+            .setId(ID_1)
+            .setService(service);
+
+        MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
+            .setTopics(CollectionUtils.listOf(
+                new MicoTopicRequestDTO().setName("topic-1").setRole(MicoTopicRole.Role.INPUT),
+                new MicoTopicRequestDTO().setName("topic-2").setRole(MicoTopicRole.Role.INPUT)));
+
+        application.getServices().add(service);
+        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
+
+        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+
+        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    public void updateServiceDeploymentInformationReusesExistingTopics() throws Exception {
+        MicoApplication application = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoApplication expectedApplication = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoService service = new MicoService()
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+
+        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo()
+            .setId(ID_1)
+            .setService(service);
+
+        MicoTopic existingTopic1 = new MicoTopic()
+            .setId(ID_2)
+            .setName("topic-name-1");
+
+        MicoTopic existingTopic2 = new MicoTopic()
+            .setId(ID_3)
+            .setName("topic-name-2");
+
+        String newTopicName = "new-topic";
+        MicoServiceDeploymentInfoRequestDTO updatedServiceDeploymentInfoDTO = new MicoServiceDeploymentInfoRequestDTO()
+            .setTopics(CollectionUtils.listOf(
+                new MicoTopicRequestDTO().setName(existingTopic1.getName()).setRole(MicoTopicRole.Role.INPUT),
+                new MicoTopicRequestDTO().setName(newTopicName).setRole(MicoTopicRole.Role.OUTPUT)));
+        MicoTopic expectedTopicNew = new MicoTopic().setName(newTopicName);
+
+        application.getServices().add(service);
+        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
+        expectedApplication.getServices().add(service);
+        expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
+
+        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
+        given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+        given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
+        given(micoTopicRepository.findByName(existingTopic1.getName())).willReturn(Optional.of(existingTopic1));
+        given(micoTopicRepository.findByName(existingTopic2.getName())).willReturn(Optional.of(existingTopic2));
+        given(micoTopicRepository.save(eq(existingTopic1))).willReturn(existingTopic1);
+        given(micoTopicRepository.save(eq(expectedTopicNew))).willReturn(expectedTopicNew);
+
+        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(SDI_TOPICS_PATH, hasSize(2)))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[0].name", is(serviceDeploymentInfo.getTopics().get(0).getTopic().getName())))
+            .andExpect(jsonPath(SDI_TOPICS_PATH + "[1].name", is(serviceDeploymentInfo.getTopics().get(1).getTopic().getName())))
+            .andReturn();
+
+        ArgumentCaptor<MicoServiceDeploymentInfo> sdiCaptor = ArgumentCaptor.forClass(MicoServiceDeploymentInfo.class);
+
+        verify(serviceDeploymentInfoRepository, atLeast(1)).save(sdiCaptor.capture());
+        MicoServiceDeploymentInfo actualSdi = sdiCaptor.getValue();
+        assertEquals(2, actualSdi.getTopics().size());
+        MicoTopicRole actualTopicRole1 = actualSdi.getTopics().get(0);
+        assertEquals("Existing topic was not reused!", existingTopic1.getId(), actualTopicRole1.getTopic().getId());
+        assertEquals(existingTopic1, actualTopicRole1.getTopic());
+        MicoTopicRole actualTopicRole2 = actualSdi.getTopics().get(1);
+        assertEquals("New topic was not saved.", newTopicName, actualTopicRole2.getTopic().getName());
+    }
+
+    @Test
+    public void invalidLabelsThrowAnException() throws Exception {
+        List<MicoLabel> labels = CollectionUtils.listOf(new MicoLabel().setKey("invalid-key!").setValue("value"));
+
+        MicoApplication application = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoApplication expectedApplication = new MicoApplication()
+            .setId(ID)
+            .setShortName(SHORT_NAME).setVersion(VERSION);
+
+        MicoService service = new MicoService()
+            .setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+
+        MicoServiceDeploymentInfo serviceDeploymentInfo = new MicoServiceDeploymentInfo().setService(service);
+
+        MicoServiceDeploymentInfoResponseDTO updatedServiceDeploymentInfoDTO =
+            (MicoServiceDeploymentInfoResponseDTO) new MicoServiceDeploymentInfoResponseDTO()
+                .setLabels(labels.stream().map(MicoLabelResponseDTO::new).collect(Collectors.toList()));
+
+        application.getServices().add(service);
+        application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
+        expectedApplication.getServices().add(service);
+        expectedApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
+
+        given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion()))
+            .willReturn(Optional.of(application));
+
+        final ResultActions result = mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+            .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
+            .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
+            .andDo(print());
+
+        result.andExpect(status().isUnprocessableEntity());
+    }
+
+}


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Refactoring: Create own classes for entity `MicoServiceDeploymentInfo`:
- `ServiceDeploymentInfoResource`
- `MicoServiceDeploymentInfoBroker`
- `ServiceDeploymentInfoIntegrationTests`

Contains fix for Neo4j to finally saving all topics like expected. Basically the workaround is to delete all relationships to the existing topics of the particular `MicoServiceDeploymentInfo` node and recreate them. Works fine :)

- [ ] this PR contains breaking changes!

# Resolves / is related to

Relates to #761 
Closes #784 

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`ng serve --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
