### PR TITLE
Add topics to app dependency graph

### DIFF
--- a/mico-admin/package-lock.json
+++ b/mico-admin/package-lock.json
@@ -86,6 +86,7 @@
           "dev": true,
           "requires": {
             "ajv": "6.6.2",
+            "chokidar": "2.0.4",
             "fast-json-stable-stringify": "2.0.0",
             "rxjs": "6.3.3",
             "source-map": "0.7.3"
@@ -101,6 +102,27 @@
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
+          }
+        },
+        "chokidar": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.2.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.5"
           }
         },
         "opn": {
@@ -186,6 +208,7 @@
           "dev": true,
           "requires": {
             "ajv": "6.6.2",
+            "chokidar": "2.0.4",
             "fast-json-stable-stringify": "2.0.0",
             "rxjs": "6.3.3",
             "source-map": "0.7.3"
@@ -201,6 +224,27 @@
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
+          }
+        },
+        "chokidar": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.2.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.5"
           }
         }
       }
@@ -428,12 +472,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -448,17 +494,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -575,7 +624,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -587,6 +637,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -601,6 +652,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -608,12 +660,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -632,6 +686,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -712,7 +767,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -724,6 +780,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -845,6 +902,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1243,6 +1301,7 @@
           "dev": true,
           "requires": {
             "ajv": "6.6.2",
+            "chokidar": "2.0.4",
             "fast-json-stable-stringify": "2.0.0",
             "rxjs": "6.3.3",
             "source-map": "0.7.3"
@@ -1258,6 +1317,27 @@
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
+          }
+        },
+        "chokidar": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.2.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.5"
           }
         },
         "webpack-sources": {
@@ -1595,23 +1675,32 @@
       }
     },
     "@ustutt/grapheditor-webcomponent": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ustutt/grapheditor-webcomponent/-/grapheditor-webcomponent-0.1.2.tgz",
-      "integrity": "sha512-NQOtVH/J40yISYqxvOv+cmDSOuuGNUA0hqAHU7jb6tb8hji41XUQXMLVBy4DhTfxMEkEGd2IrVqeXpeWS5mUSg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ustutt/grapheditor-webcomponent/-/grapheditor-webcomponent-0.1.3.tgz",
+      "integrity": "sha512-T5N7EWv6z6yRzAiR9mCYuH9bJO4MWj3jN/1dqZhBQXab8thLGMyTOKH1X7Wm8bsV3FJOApLDU0Cxfnf3QPkNZg==",
       "requires": {
-        "d3-drag": "^1.2.3",
-        "d3-scale": "^3.0.0",
+        "d3-drag": "^1.2.4",
+        "d3-scale": "^3.0.1",
         "d3-selection": "^1.4.0",
         "d3-shape": "^1.3.5",
-        "d3-zoom": "^1.7.3"
+        "d3-zoom": "^1.8.3"
       },
       "dependencies": {
-        "d3-scale": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.0.0.tgz",
-          "integrity": "sha512-ktic5HBFlAZj2CN8CCl/p/JyY8bMQluN7+fA6ICE6yyoMOnSQAZ1Bb8/5LcNpNKMBMJge+5Vv4pWJhARYlQYFw==",
+        "d3-drag": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.4.tgz",
+          "integrity": "sha512-ICPurDETFAelF1CTHdIyiUM4PsyZLaM+7oIBhmyP+cuVjze5vDZ8V//LdOFjg0jGnFIZD/Sfmk0r95PSiu78rw==",
           "requires": {
-            "d3-array": "^1.2.0 || 2",
+            "d3-dispatch": "1",
+            "d3-selection": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.0.1.tgz",
+          "integrity": "sha512-f+OsXyd0claf6ufjI52zBHyOnm6mmfFvYiGUU8UB2VumZpqCcxds5iWN1rcOACIHgw9MntTFLXmi4LBRmY4DwQ==",
+          "requires": {
+            "d3-array": "1.2.0 - 2",
             "d3-format": "1",
             "d3-interpolate": "1",
             "d3-time": "1",
@@ -1624,6 +1713,18 @@
           "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
           "requires": {
             "d3-path": "1"
+          }
+        },
+        "d3-zoom": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
+          "integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
+          "requires": {
+            "d3-dispatch": "1",
+            "d3-drag": "1",
+            "d3-interpolate": "1",
+            "d3-selection": "1",
+            "d3-transition": "1"
           }
         }
       }

--- a/mico-admin/package.json
+++ b/mico-admin/package.json
@@ -25,7 +25,7 @@
     "@types/c3": "^0.7.0",
     "c3": "^0.7.1",
     "core-js": "^2.5.7",
-    "@ustutt/grapheditor-webcomponent": "^0.1.2",
+    "@ustutt/grapheditor-webcomponent": "^0.1.3",
     "hammerjs": "^2.0.8",
     "ng-pick-datetime": "^7.0.0",
     "rxjs": "~6.3.3",

--- a/mico-admin/src/app/app.module.ts
+++ b/mico-admin/src/app/app.module.ts
@@ -99,6 +99,7 @@ import { DeploymentInformationDialogComponent } from './dialogs/deployment-infor
 import { AppDetailPublicIpComponent } from './app-detail-public-ip/app-detail-public-ip.component';
 import { ServiceDetailKubeconfigComponent } from './service-detail-kubeconfig/service-detail-kubeconfig.component';
 import { GraphAddEnvironmentVariableComponent } from './dialogs/graph-add-environment-variable/graph-add-environment-variable.component';
+import { GraphAddKafkaTopicComponent } from './dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component';
 
 @NgModule({
     declarations: [
@@ -140,7 +141,8 @@ import { GraphAddEnvironmentVariableComponent } from './dialogs/graph-add-enviro
         DeploymentInformationDialogComponent,
         AppDetailPublicIpComponent,
         ServiceDetailKubeconfigComponent,
-        GraphAddEnvironmentVariableComponent
+        GraphAddEnvironmentVariableComponent,
+        GraphAddKafkaTopicComponent,
     ],
     entryComponents: [
         // dialogs
@@ -154,6 +156,7 @@ import { GraphAddEnvironmentVariableComponent } from './dialogs/graph-add-enviro
         CreateNextVersionComponent,
         DeploymentInformationDialogComponent,
         GraphAddEnvironmentVariableComponent,
+        GraphAddKafkaTopicComponent,
     ],
     imports: [
         BrowserModule,

--- a/mico-admin/src/app/dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component.html
+++ b/mico-admin/src/app/dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component.html
@@ -1,0 +1,28 @@
+<h2 mat-dialog-title>Add Kafka-Topic</h2>
+<mat-dialog-content style="min-width: 48rem">
+
+    Add
+
+    <mat-form-field>
+        <input matInput placeholder="kafka topic" [(ngModel)]="topic" [pattern]="'[a-zA-Z0-9\\._\\-]+'">
+    </mat-form-field>
+
+    as
+
+    <mat-form-field>
+        <mat-label>role</mat-label>
+        <mat-select [(ngModel)]="role">
+            <mat-option *ngFor="let role of possibleRoles" [value]="role">
+                {{role.toLowerCase()}}
+            </mat-option>
+        </mat-select>
+    </mat-form-field>
+
+    to <b>{{serviceShortName}}</b>.
+
+</mat-dialog-content>
+<mat-dialog-actions>
+    <button mat-button mat-dialog-close>Cancel</button>
+    <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
+    <button mat-button [mat-dialog-close]="response()" [disabled]="!isValid()">Ok</button>
+</mat-dialog-actions>

--- a/mico-admin/src/app/dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component.spec.ts
+++ b/mico-admin/src/app/dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GraphAddKafkaTopicComponent } from './graph-add-kafka-topic.component';
+
+describe('GraphAddKafkaTopicComponent', () => {
+  let component: GraphAddKafkaTopicComponent;
+  let fixture: ComponentFixture<GraphAddKafkaTopicComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GraphAddKafkaTopicComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GraphAddKafkaTopicComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/mico-admin/src/app/dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component.ts
+++ b/mico-admin/src/app/dialogs/graph-add-kafka-topic/graph-add-kafka-topic.component.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+    selector: 'mico-graph-add-kafka-topic',
+    templateUrl: './graph-add-kafka-topic.component.html',
+    styleUrls: ['./graph-add-kafka-topic.component.css']
+})
+export class GraphAddKafkaTopicComponent {
+
+
+    constructor(public dialogRef: MatDialogRef<GraphAddKafkaTopicComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: any,
+    ) {
+        this.serviceShortName = data.serviceShortName;
+        this.possibleRoles = ['INPUT', 'OUTPUT'].filter(r => !data.existingRoles.some(existing => existing === r));
+        if (this.possibleRoles.length === 2) {
+            this.role = this.possibleRoles[1];
+        } else if (this.possibleRoles.length === 1) {
+            this.role = this.possibleRoles[0];
+        }
+    }
+
+    serviceShortName;
+    possibleRoles;
+
+    topic;
+    role;
+
+    isValid() {
+        if (this.topic == null || this.topic === '') {
+            return false;
+        }
+        return /^[a-zA-Z0-9\._\-]+$/.test(this.topic);
+    }
+
+    /**
+     * return method of the dialog
+     */
+    response() {
+        if (!this.isValid()) {
+            // invalid topic!
+            return '';
+        }
+
+        return {
+            kafkaTopicName: this.topic,
+            role: this.role,
+        };
+    }
+
+}

--- a/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph-constants.ts
+++ b/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph-constants.ts
@@ -105,10 +105,16 @@ export const STYLE_TEMPLATE = {
             text-decoration: underline;
         }
         .node:not(.application):not(.selected).hovered {
-            fill: #efefef;
+            fill: #dfdfdf;
         }
         .node.application.hovered {
             fill: #0099ff;
+        }
+        .node .foreground {
+            fill: #dfdfdf;
+        }
+        .node:not(.selected).hovered .foreground {
+            fill: #efefef;
         }
         .hovered:not(.service-interface) .link-handle {
             display: initial;
@@ -159,6 +165,15 @@ export const SERVICE_INTERFACE_NODE_TEMPLATE = {
     innerHTML: `<circle r=20></circle>
         <text class="text interface-name" data-content="title" data-click="title" width="34" text-anchor="middle" x="0" y="0"></text>
         <text class="text protocol" data-content="protocol" data-click="title" width="30" text-anchor="middle" x="0" y="10">PPP</text>`
+};
+
+export const KAFKA_TOPIC_NODE_TEMPLATE = {
+    id: 'kafka-topic',
+    innerHTML: `<polygon points="-29,0 -28,-6 28,-6 29,0 28,6 -28,6" data-link-handles="corners"></polygon>
+    <ellipse class="background" cx="25" cy="0" rx="4" ry="9"/>
+    <rect class="background" x="-25" y="-9" width="50" height="18"></rect>
+    <ellipse class="foreground" cx="-25" cy="0" rx="4" ry="9"/>
+    <text class="text title" data-content="title" data-click="title" width="42" text-anchor="middle" x="2" y="3"></text>`
 };
 
 export const SERVICE_NODE_TEMPLATE = {

--- a/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph-constants.ts
+++ b/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph-constants.ts
@@ -149,6 +149,12 @@ export const STYLE_TEMPLATE = {
         }
         .highlight-incoming .marker {
             fill: green;
+        }
+        .highlight-outgoing .text {
+            fill: red;
+        }
+        .highlight-incoming .text {
+            fill: green;
         }`
 };
 

--- a/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph.component.ts
+++ b/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph.component.ts
@@ -315,7 +315,7 @@ export class AppDependencyGraphComponent implements OnInit, OnChanges, OnDestroy
                 // kafka enabled nodes can target kafka topics
                 const depl = this.deploymentInformations.get(edge.source.toString());
                 if (!depl.topics.some(t => t.role === 'OUTPUT')) {
-                    // only nodes that don't have both output topic set
+                    // only nodes that don't have an output topic set
                     this.kafkaTopicNodes.forEach(e => edge.validTargets.add(e));
                 }
             }


### PR DESCRIPTION
# Description

Add topics to application grapheditor. Only input and output topics will be shown to avoid clutter.

- [x] show topics in grapheditor based on deployment interaction
- [x] define edge dragging behaviour for topic edges
- [x] add dialogs for removing, changing and adding topic connections

- [ ] this PR contains breaking changes!

# Resolves / is related to

#780 

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [x] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [ ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
