### PR TITLE
Add Kubernetes deployment info to reponse DTO

### DIFF
--- a/docs/mico-core/java/io/github/ust/mico/core/dto/response/KFConnectorDeploymentInfoResponseDTO.rst
+++ b/docs/mico-core/java/io/github/ust/mico/core/dto/response/KFConnectorDeploymentInfoResponseDTO.rst
@@ -1,6 +1,20 @@
+.. java:import:: com.fasterxml.jackson.annotation JsonProperty
+
+.. java:import:: io.fabric8.kubernetes.api.model Service
+
+.. java:import:: io.fabric8.kubernetes.api.model.apps Deployment
+
+.. java:import:: io.github.ust.mico.core.configuration.extension CustomOpenApiExtentionsPlugin
+
 .. java:import:: io.github.ust.mico.core.dto.request KFConnectorDeploymentInfoRequestDTO
 
 .. java:import:: io.github.ust.mico.core.model MicoServiceDeploymentInfo
+
+.. java:import:: io.swagger.annotations ApiModelProperty
+
+.. java:import:: io.swagger.annotations Extension
+
+.. java:import:: io.swagger.annotations ExtensionProperty
 
 .. java:import:: lombok Data
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/KFConnectorDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/KFConnectorDeploymentInfoResponseDTO.java
@@ -19,8 +19,15 @@
 
 package io.github.ust.mico.core.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.dto.request.KFConnectorDeploymentInfoRequestDTO;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -37,6 +44,25 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class KFConnectorDeploymentInfoResponseDTO extends KFConnectorDeploymentInfoRequestDTO {
 
+    /**
+     * Information about the actual Kubernetes resources created by a deployment.
+     * Contains details about the used Kubernetes {@link Deployment} and {@link Service Services}.
+     * Is read only.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Kubernetes Deployment Information"),
+            @ExtensionProperty(name = "readOnly", value = "true"),
+            @ExtensionProperty(name = "x-order", value = "100"),
+            @ExtensionProperty(name = "description", value = "Information about the actual Kubernetes resources " +
+                "created by a deployment. Contains details about the used Kubernetes Deployment and Services.")
+        }
+    )})
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private KubernetesDeploymentInfoResponseDTO kubernetesDeploymentInfo;
+
+
     // -------------------
     // -> Constructors ---
     // -------------------
@@ -49,5 +75,11 @@ public class KFConnectorDeploymentInfoResponseDTO extends KFConnectorDeploymentI
      */
     public KFConnectorDeploymentInfoResponseDTO(MicoServiceDeploymentInfo kfConnectorDeploymentInfo) {
         super(kfConnectorDeploymentInfo);
+
+        // Kubernetes deployment info could be null if not available
+        if (kfConnectorDeploymentInfo.getKubernetesDeploymentInfo() != null) {
+            setKubernetesDeploymentInfo(new KubernetesDeploymentInfoResponseDTO(
+                kfConnectorDeploymentInfo.getKubernetesDeploymentInfo()));
+        }
     }
 }


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Add Kubernetes deployment info to response DTO of the KafkaFaasConnector.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Closes #800.

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [x] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
