### PR TITLE
Fix find methods for getting service deployment information

### DIFF
--- a/docs/mico-core/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.rst
+++ b/docs/mico-core/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.rst
@@ -26,6 +26,19 @@ MicoServiceDeploymentInfoBroker
 
 Methods
 -------
+getExistingServiceDeploymentInfo
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. java:method:: public MicoServiceDeploymentInfo getExistingServiceDeploymentInfo(MicoApplication micoApplication, MicoService micoService) throws IllegalStateException
+   :outertype: MicoServiceDeploymentInfoBroker
+
+   Retrieves the \ :java:ref:`MicoServiceDeploymentInfo`\  that is used for the deployment of the requested {link MicoService} as part of a \ :java:ref:`MicoApplication`\ . There must not be zero or more than one service deployment information stored. If that's the case, an \ :java:ref:`IllegalStateException`\  will be thrown.
+
+   :param micoApplication: the \ :java:ref:`MicoApplication`\
+   :param micoService: the \ :java:ref:`MicoService`\
+   :throws IllegalStateException: if there is no or more than one service deployment information stored
+   :return: the one and only existing \ :java:ref:`MicoServiceDeploymentInfo`\
+
 getMicoServiceDeploymentInformation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/mico-core/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.rst
+++ b/docs/mico-core/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.rst
@@ -97,7 +97,7 @@ findAllByService
 findByApplicationAndService
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. java:method:: @Query  Optional<MicoServiceDeploymentInfo> findByApplicationAndService(String applicationShortName, String applicationVersion, String serviceShortName)
+.. java:method:: @Query  List<MicoServiceDeploymentInfo> findByApplicationAndService(String applicationShortName, String applicationVersion, String serviceShortName)
    :outertype: MicoServiceDeploymentInfoRepository
 
    Retrieves the deployment information for a particular application and service. Also works with a KafkaFaasConnector instance.
@@ -110,7 +110,7 @@ findByApplicationAndService
 findByApplicationAndService
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. java:method:: @Query  Optional<MicoServiceDeploymentInfo> findByApplicationAndService(String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion)
+.. java:method:: @Query  List<MicoServiceDeploymentInfo> findByApplicationAndService(String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion)
    :outertype: MicoServiceDeploymentInfoRepository
 
    Retrieves the deployment information for a particular application and service. Also works with a KafkaFaasConnector instance.

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
@@ -33,6 +33,9 @@ public class DeploymentBroker {
     private MicoApplicationBroker micoApplicationBroker;
 
     @Autowired
+    private MicoServiceDeploymentInfoBroker micoServiceDeploymentInfoBroker;
+
+    @Autowired
     private BackgroundJobBroker backgroundJobBroker;
 
     @Autowired
@@ -79,15 +82,7 @@ public class DeploymentBroker {
                 .setStatus(MicoServiceBackgroundJob.Status.RUNNING);
             backgroundJobBroker.saveJob(job);
 
-            List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository
-                .findByApplicationAndService(micoApplication.getShortName(), micoApplication.getVersion(),
-                    micoService.getShortName(), micoService.getVersion());
-            if(serviceDeploymentInfos.isEmpty()) {
-                throw new IllegalStateException("Service deployment information for service '" + micoService.getShortName()
-                    + "' in application '" + micoApplication.getShortName() + "' '" + micoApplication.getVersion()
-                    + "' could not be found.");
-            }
-            MicoServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfos.get(0);
+            MicoServiceDeploymentInfo serviceDeploymentInfo = micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication, micoService);
 
             log.info("Start build of MicoService '{}' '{}'.", micoService.getShortName(), micoService.getVersion());
             CompletableFuture<MicoServiceDeploymentInfo> buildJob = CompletableFuture.supplyAsync(() -> buildMicoService(serviceDeploymentInfo))

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
@@ -79,13 +79,15 @@ public class DeploymentBroker {
                 .setStatus(MicoServiceBackgroundJob.Status.RUNNING);
             backgroundJobBroker.saveJob(job);
 
-            Optional<MicoServiceDeploymentInfo> serviceDeploymentInfoOptional = serviceDeploymentInfoRepository
+            List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository
                 .findByApplicationAndService(micoApplication.getShortName(), micoApplication.getVersion(),
                     micoService.getShortName(), micoService.getVersion());
-            MicoServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfoOptional.orElseThrow(() ->
-                new IllegalStateException("Service deployment information for service '" + micoService.getShortName()
+            if(serviceDeploymentInfos.isEmpty()) {
+                throw new IllegalStateException("Service deployment information for service '" + micoService.getShortName()
                     + "' in application '" + micoApplication.getShortName() + "' '" + micoApplication.getVersion()
-                    + "' could not be found."));
+                    + "' could not be found.");
+            }
+            MicoServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfos.get(0);
 
             log.info("Start build of MicoService '{}' '{}'.", micoService.getShortName(), micoService.getVersion());
             CompletableFuture<MicoServiceDeploymentInfo> buildJob = CompletableFuture.supplyAsync(() -> buildMicoService(serviceDeploymentInfo))

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -37,6 +37,9 @@ public class MicoApplicationBroker {
     private MicoServiceBroker micoServiceBroker;
 
     @Autowired
+    private MicoServiceDeploymentInfoBroker micoServiceDeploymentInfoBroker;
+
+    @Autowired
     private MicoApplicationRepository applicationRepository;
 
     @Autowired
@@ -279,12 +282,7 @@ public class MicoApplicationBroker {
             }
         }
 
-        List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository.findByApplicationAndService(
-            applicationShortName, applicationVersion, serviceShortName, serviceVersion);
-        if(serviceDeploymentInfos.isEmpty()) {
-            throw new IllegalStateException("Previously stored service deployment information not found.");
-        }
-        return serviceDeploymentInfos.get(0);
+        return micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication, micoService);
     }
 
     public MicoApplication removeMicoServiceFromMicoApplicationByShortNameAndVersion(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException, MicoApplicationIsNotUndeployedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -279,10 +279,12 @@ public class MicoApplicationBroker {
             }
         }
 
-        Optional<MicoServiceDeploymentInfo> sdiOptional = serviceDeploymentInfoRepository.findByApplicationAndService(
+        List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository.findByApplicationAndService(
             applicationShortName, applicationVersion, serviceShortName, serviceVersion);
-        sdiOptional.orElseThrow(() -> new IllegalStateException("Previously stored service deployment information not found."));
-        return sdiOptional.get();
+        if(serviceDeploymentInfos.isEmpty()) {
+            throw new IllegalStateException("Previously stored service deployment information not found.");
+        }
+        return serviceDeploymentInfos.get(0);
     }
 
     public MicoApplication removeMicoServiceFromMicoApplicationByShortNameAndVersion(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException, MicoApplicationIsNotUndeployedException {

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -82,12 +82,11 @@ public class MicoServiceDeploymentInfoBroker {
     public MicoServiceDeploymentInfo getMicoServiceDeploymentInformation(String applicationShortName, String applicationVersion, String serviceShortName) throws MicoServiceDeploymentInformationNotFoundException, MicoApplicationNotFoundException, MicoApplicationDoesNotIncludeMicoServiceException {
         applicationBroker.getMicoApplicationForMicoService(applicationShortName, applicationVersion, serviceShortName);
 
-        Optional<MicoServiceDeploymentInfo> micoServiceDeploymentInfoOptional = serviceDeploymentInfoRepository.findByApplicationAndService(applicationShortName, applicationVersion, serviceShortName);
-        if (micoServiceDeploymentInfoOptional.isPresent()) {
-            return micoServiceDeploymentInfoOptional.get();
-        } else {
+        List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository.findByApplicationAndService(applicationShortName, applicationVersion, serviceShortName);
+        if (serviceDeploymentInfos.isEmpty()) {
             throw new MicoServiceDeploymentInformationNotFoundException(applicationShortName, applicationVersion, serviceShortName);
         }
+        return serviceDeploymentInfos.get(0);
     }
 
     /**

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -90,6 +90,37 @@ public class MicoServiceDeploymentInfoBroker {
     }
 
     /**
+     * Retrieves the {@link MicoServiceDeploymentInfo} that is used for the deployment
+     * of the requested {link MicoService} as part of a {@link MicoApplication}.
+     * There must not be zero or more than one service deployment information stored.
+     * If that's the case, an {@link IllegalStateException} will be thrown.
+     *
+     * @param micoApplication the {@link MicoApplication}
+     * @param micoService     the {@link MicoService}
+     * @return the one and only existing {@link MicoServiceDeploymentInfo}
+     * @throws IllegalStateException if there is no or more than one service deployment information stored
+     */
+    public MicoServiceDeploymentInfo getExistingServiceDeploymentInfo(MicoApplication micoApplication, MicoService micoService) throws IllegalStateException {
+        List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository
+            .findByApplicationAndService(micoApplication.getShortName(), micoApplication.getVersion(),
+                micoService.getShortName(), micoService.getVersion());
+        if (serviceDeploymentInfos.isEmpty()) {
+            String errorMessage = "Previously stored service deployment information for service '" + micoService.getShortName() + "' '" +
+                micoService.getVersion() + "' used by application '" + micoApplication.getShortName() + "' '" + micoApplication.getVersion() + "' not found.";
+            log.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
+        if (serviceDeploymentInfos.size() > 1) {
+            String errorMessage = "There are " + serviceDeploymentInfos.size() + " service deployment information stored for service '" +
+                micoService.getShortName() + "' '" + micoService.getVersion() + "' used by application '" + micoApplication.getShortName() + "' '" +
+                micoApplication.getVersion() + "'. However, there must be only one.";
+            log.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
+        return serviceDeploymentInfos.get(0);
+    }
+
+    /**
      * Updates an existing {@link MicoServiceDeploymentInfo} in the database
      * based on the values of a {@link MicoServiceDeploymentInfoRequestDTO} object.
      *

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
@@ -106,7 +106,7 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
         + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
         + "AND s.shortName = {serviceShortName} "
         + "RETURN (sdi:MicoServiceDeploymentInfo)-[:FOR|:HAS*0..1]->(), (s)-[:PROVIDES*2]->()")
-    Optional<MicoServiceDeploymentInfo> findByApplicationAndService(
+    List<MicoServiceDeploymentInfo> findByApplicationAndService(
         @Param("applicationShortName") String applicationShortName,
         @Param("applicationVersion") String applicationVersion,
         @Param("serviceShortName") String serviceShortName);
@@ -125,7 +125,7 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
         + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
         + "AND s.shortName = {serviceShortName} AND s.version = {serviceVersion} "
         + "RETURN (sdi:MicoServiceDeploymentInfo)-[:FOR|:HAS*0..1]->(), (s)-[:PROVIDES*2]->()")
-    Optional<MicoServiceDeploymentInfo> findByApplicationAndService(
+    List<MicoServiceDeploymentInfo> findByApplicationAndService(
         @Param("applicationShortName") String applicationShortName,
         @Param("applicationVersion") String applicationVersion,
         @Param("serviceShortName") String serviceShortName,

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -890,7 +890,7 @@ public class ApplicationResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
         given(serviceRepository.findAllByApplication(SHORT_NAME, VERSION)).willReturn(CollectionUtils.listOf(service));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME, SERVICE_VERSION))
-            .willReturn(Optional.of(serviceDeploymentInfo));
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
         given(micoServiceDeploymentInfoBroker.updateMicoServiceDeploymentInformation(
             eq(SHORT_NAME), eq(VERSION), eq(SERVICE_SHORT_NAME), any(MicoServiceDeploymentInfoRequestDTO.class))).willReturn(serviceDeploymentInfo);
@@ -922,7 +922,7 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME))
-            .willReturn(Optional.of(application.getServiceDeploymentInfos().get(0)));
+            .willReturn(application.getServiceDeploymentInfos());
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
 
         mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
@@ -992,7 +992,7 @@ public class ApplicationResourceIntegrationTests {
             .willReturn(Optional.of(serviceNew));
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
         given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME, VERSION_1_0_2))
-            .willReturn(Optional.of(serviceDeploymentInfoNew));
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfoNew));
 
         mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_2)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -889,8 +889,8 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceRepository.findByShortNameAndVersion(SERVICE_SHORT_NAME, SERVICE_VERSION)).willReturn(Optional.of(service));
         given(serviceRepository.findAllByApplication(SHORT_NAME, VERSION)).willReturn(CollectionUtils.listOf(service));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME, SERVICE_VERSION))
-            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
+        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(application, service))
+            .willReturn(serviceDeploymentInfo);
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
         given(micoServiceDeploymentInfoBroker.updateMicoServiceDeploymentInformation(
             eq(SHORT_NAME), eq(VERSION), eq(SERVICE_SHORT_NAME), any(MicoServiceDeploymentInfoRequestDTO.class))).willReturn(serviceDeploymentInfo);
@@ -991,8 +991,8 @@ public class ApplicationResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(serviceNew.getShortName(), serviceNew.getVersion()))
             .willReturn(Optional.of(serviceNew));
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(SHORT_NAME, VERSION, SERVICE_SHORT_NAME, VERSION_1_0_2))
-            .willReturn(CollectionUtils.listOf(serviceDeploymentInfoNew));
+        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(application, serviceNew))
+            .willReturn(serviceDeploymentInfoNew);
 
         mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_2)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))

--- a/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceTests.java
@@ -238,7 +238,7 @@ public class DeploymentResourceTests {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceDeploymentInfoRepository
             .findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName(), service.getVersion()))
-            .willReturn(Optional.of(new MicoServiceDeploymentInfo().setService(service)));
+            .willReturn(CollectionUtils.listOf(new MicoServiceDeploymentInfo().setService(service)));
         given(serviceRepository.save(any(MicoService.class))).willReturn(service);
         given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class)))
             .willReturn(new MicoServiceDeploymentInfo()

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.github.ust.mico.core.TestConstants.*;
 import io.github.ust.mico.core.broker.BackgroundJobBroker;
-import io.github.ust.mico.core.broker.MicoServiceDeploymentInfoBroker;
 import io.github.ust.mico.core.configuration.MicoKubernetesBuildBotConfig;
 import io.github.ust.mico.core.configuration.MicoKubernetesConfig;
 import io.github.ust.mico.core.exception.KubernetesResourceException;
@@ -105,9 +104,6 @@ public class MicoKubernetesClientTests {
     @MockBean
     private KubernetesDeploymentInfoRepository kubernetesDeploymentInfoRepository;
 
-    @MockBean
-    private MicoServiceDeploymentInfoBroker micoServiceDeploymentInfoBroker;
-
     private MicoKubernetesClient micoKubernetesClient;
 
     private static final String testNamespace = "test-namespace";
@@ -120,7 +116,7 @@ public class MicoKubernetesClientTests {
         given(micoKubernetesBuildBotConfig.isBuildCleanUpByUndeploy()).willReturn(true);
 
         micoKubernetesClient = new MicoKubernetesClient(micoKubernetesConfig, micoKubernetesBuildBotConfig,
-            mockServer.getClient(), imageBuilder, micoServiceDeploymentInfoBroker, backgroundJobBroker, applicationRepository,
+            mockServer.getClient(), imageBuilder, backgroundJobBroker, applicationRepository,
             serviceDeploymentInfoRepository, kubernetesDeploymentInfoRepository);
 
         mockServer.getClient().namespaces().create(new NamespaceBuilder().withNewMetadata().withName(testNamespace).endMetadata().build());
@@ -618,12 +614,15 @@ public class MicoKubernetesClientTests {
             .setServices(CollectionUtils.listOf(micoService))
             .setServiceDeploymentInfos(CollectionUtils.listOf(serviceDeploymentInfo3));
 
-        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication1, micoService))
-            .willReturn(serviceDeploymentInfo1);
-        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication2, micoService))
-            .willReturn(serviceDeploymentInfo2);
-        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication3, micoService))
-            .willReturn(serviceDeploymentInfo3);
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(
+            micoApplication1.getShortName(), micoApplication1.getVersion(), micoService.getShortName(), micoService.getVersion()))
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(
+            micoApplication2.getShortName(), micoApplication2.getVersion(), micoService.getShortName(), micoService.getVersion()))
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo2));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(
+            micoApplication3.getShortName(), micoApplication3.getVersion(), micoService.getShortName(), micoService.getVersion()))
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo3));
         given(serviceDeploymentInfoRepository.findAllByApplication(micoApplication1.getShortName(), micoApplication1.getVersion()))
             .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));
         given(serviceDeploymentInfoRepository.findAllByApplication(micoApplication2.getShortName(), micoApplication2.getVersion()))
@@ -725,8 +724,8 @@ public class MicoKubernetesClientTests {
             given(serviceDeploymentInfoRepository.findByApplicationAndService(
                 micoApplication.getShortName(), micoApplication.getVersion(), micoService.getShortName(), micoService.getVersion()))
                 .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
-            given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication, micoService))
-                .willReturn(serviceDeploymentInfo);
+            given(serviceDeploymentInfoRepository.findAllByService(micoService.getShortName(), micoService.getVersion()))
+                .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
             given(applicationRepository.findAllByUsedService(micoService.getShortName(), micoService.getVersion()))
                 .willReturn(CollectionUtils.listOf(micoApplication));
         }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -618,13 +618,13 @@ public class MicoKubernetesClientTests {
             .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1, serviceDeploymentInfo2, serviceDeploymentInfo3));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(
             micoApplication1.getShortName(), micoApplication1.getVersion(), micoService.getShortName(), micoService.getVersion()))
-            .willReturn(Optional.of(serviceDeploymentInfo1));
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(
             micoApplication2.getShortName(), micoApplication2.getVersion(), micoService.getShortName(), micoService.getVersion()))
-            .willReturn(Optional.of(serviceDeploymentInfo2));
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo2));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(
             micoApplication3.getShortName(), micoApplication3.getVersion(), micoService.getShortName(), micoService.getVersion()))
-            .willReturn(Optional.of(serviceDeploymentInfo3));
+            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo3));
         given(serviceDeploymentInfoRepository.findAllByApplication(micoApplication1.getShortName(), micoApplication1.getVersion()))
             .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));
         given(serviceDeploymentInfoRepository.findAllByApplication(micoApplication2.getShortName(), micoApplication2.getVersion()))
@@ -727,7 +727,7 @@ public class MicoKubernetesClientTests {
                 .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
             given(serviceDeploymentInfoRepository.findByApplicationAndService(
                 micoApplication.getShortName(), micoApplication.getVersion(), micoService.getShortName(), micoService.getVersion()))
-                .willReturn(Optional.of(serviceDeploymentInfo));
+                .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
             given(applicationRepository.findAllByUsedService(micoService.getShortName(), micoService.getVersion()))
                 .willReturn(CollectionUtils.listOf(micoApplication));
         }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.github.ust.mico.core.TestConstants.*;
 import io.github.ust.mico.core.broker.BackgroundJobBroker;
+import io.github.ust.mico.core.broker.MicoServiceDeploymentInfoBroker;
 import io.github.ust.mico.core.configuration.MicoKubernetesBuildBotConfig;
 import io.github.ust.mico.core.configuration.MicoKubernetesConfig;
 import io.github.ust.mico.core.exception.KubernetesResourceException;
@@ -104,6 +105,9 @@ public class MicoKubernetesClientTests {
     @MockBean
     private KubernetesDeploymentInfoRepository kubernetesDeploymentInfoRepository;
 
+    @MockBean
+    private MicoServiceDeploymentInfoBroker micoServiceDeploymentInfoBroker;
+
     private MicoKubernetesClient micoKubernetesClient;
 
     private static final String testNamespace = "test-namespace";
@@ -116,7 +120,7 @@ public class MicoKubernetesClientTests {
         given(micoKubernetesBuildBotConfig.isBuildCleanUpByUndeploy()).willReturn(true);
 
         micoKubernetesClient = new MicoKubernetesClient(micoKubernetesConfig, micoKubernetesBuildBotConfig,
-            mockServer.getClient(), imageBuilder, backgroundJobBroker, applicationRepository,
+            mockServer.getClient(), imageBuilder, micoServiceDeploymentInfoBroker, backgroundJobBroker, applicationRepository,
             serviceDeploymentInfoRepository, kubernetesDeploymentInfoRepository);
 
         mockServer.getClient().namespaces().create(new NamespaceBuilder().withNewMetadata().withName(testNamespace).endMetadata().build());
@@ -614,17 +618,12 @@ public class MicoKubernetesClientTests {
             .setServices(CollectionUtils.listOf(micoService))
             .setServiceDeploymentInfos(CollectionUtils.listOf(serviceDeploymentInfo3));
 
-        given(serviceDeploymentInfoRepository.findAllByService(micoService.getShortName(), micoService.getVersion()))
-            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1, serviceDeploymentInfo2, serviceDeploymentInfo3));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(
-            micoApplication1.getShortName(), micoApplication1.getVersion(), micoService.getShortName(), micoService.getVersion()))
-            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(
-            micoApplication2.getShortName(), micoApplication2.getVersion(), micoService.getShortName(), micoService.getVersion()))
-            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo2));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(
-            micoApplication3.getShortName(), micoApplication3.getVersion(), micoService.getShortName(), micoService.getVersion()))
-            .willReturn(CollectionUtils.listOf(serviceDeploymentInfo3));
+        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication1, micoService))
+            .willReturn(serviceDeploymentInfo1);
+        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication2, micoService))
+            .willReturn(serviceDeploymentInfo2);
+        given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication3, micoService))
+            .willReturn(serviceDeploymentInfo3);
         given(serviceDeploymentInfoRepository.findAllByApplication(micoApplication1.getShortName(), micoApplication1.getVersion()))
             .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));
         given(serviceDeploymentInfoRepository.findAllByApplication(micoApplication2.getShortName(), micoApplication2.getVersion()))
@@ -723,11 +722,11 @@ public class MicoKubernetesClientTests {
                 );
             micoApplication.getServiceDeploymentInfos().add(serviceDeploymentInfo);
 
-            given(serviceDeploymentInfoRepository.findAllByService(micoService.getShortName(), micoService.getVersion()))
-                .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
             given(serviceDeploymentInfoRepository.findByApplicationAndService(
                 micoApplication.getShortName(), micoApplication.getVersion(), micoService.getShortName(), micoService.getVersion()))
                 .willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
+            given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(micoApplication, micoService))
+                .willReturn(serviceDeploymentInfo);
             given(applicationRepository.findAllByUsedService(micoService.getShortName(), micoService.getVersion()))
                 .willReturn(CollectionUtils.listOf(micoApplication));
         }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoServiceDeploymentInfoRepositoryTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoServiceDeploymentInfoRepositoryTests.java
@@ -147,20 +147,20 @@ public class MicoServiceDeploymentInfoRepositoryTests extends MicoRepositoryTest
         applicationRepository.save(a2);
 
         // Application #0 includes no service
-        assertFalse(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName()).isPresent());
-        assertFalse(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s1.getShortName()).isPresent());
+        assertTrue(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName()).isEmpty());
+        assertTrue(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s1.getShortName()).isEmpty());
         // Application #1 only includes service #1
-        assertFalse(serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s0.getShortName()).isPresent());
-        Optional<MicoServiceDeploymentInfo> deploymentInfoOptionalA1S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s1.getShortName());
-        assertTrue(deploymentInfoOptionalA1S1.isPresent());
-        assertEquals(a1.getServiceDeploymentInfos().get(0), deploymentInfoOptionalA1S1.get());
+        assertTrue(serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s0.getShortName()).isEmpty());
+        List<MicoServiceDeploymentInfo> deploymentInfosA1S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s1.getShortName());
+        assertEquals(1, deploymentInfosA1S1.size());
+        assertEquals(a1.getServiceDeploymentInfos().get(0), deploymentInfosA1S1.get(0));
         // Application #2 includes services #0 and #1
-        Optional<MicoServiceDeploymentInfo> deploymentInfoOptionalA2S0 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s0.getShortName());
-        assertTrue(deploymentInfoOptionalA2S0.isPresent());
-        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s0), deploymentInfoOptionalA2S0.get());
-        Optional<MicoServiceDeploymentInfo> deploymentInfoOptionalA2S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s1.getShortName());
-        assertTrue(deploymentInfoOptionalA2S1.isPresent());
-        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s1), deploymentInfoOptionalA2S1.get());
+        List<MicoServiceDeploymentInfo> deploymentInfosA2S0 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s0.getShortName());
+        assertEquals(1, deploymentInfosA2S0.size());
+        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s0), deploymentInfosA2S0.get(0));
+        List<MicoServiceDeploymentInfo> deploymentInfosA2S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s1.getShortName());
+        assertEquals(1, deploymentInfosA2S1.size());
+        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s1), deploymentInfosA2S1.get(0));
     }
 
     @Commit
@@ -187,20 +187,20 @@ public class MicoServiceDeploymentInfoRepositoryTests extends MicoRepositoryTest
         applicationRepository.save(a2);
 
         // Application #0 includes no service
-        assertFalse(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName(), s0.getVersion()).isPresent());
-        assertFalse(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s1.getShortName(), s1.getVersion()).isPresent());
+        assertTrue(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName(), s0.getVersion()).isEmpty());
+        assertTrue(serviceDeploymentInfoRepository.findByApplicationAndService(a0.getShortName(), a0.getVersion(), s1.getShortName(), s1.getVersion()).isEmpty());
         // Application #1 only includes service #1
-        assertFalse(serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s0.getShortName(), s0.getVersion()).isPresent());
-        Optional<MicoServiceDeploymentInfo> deploymentInfoOptionalA1S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s1.getShortName(), s1.getVersion());
-        assertTrue(deploymentInfoOptionalA1S1.isPresent());
-        assertEquals(a1.getServiceDeploymentInfos().get(0), deploymentInfoOptionalA1S1.get());
+        assertTrue(serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s0.getShortName(), s0.getVersion()).isEmpty());
+        List<MicoServiceDeploymentInfo> deploymentInfosA1S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a1.getShortName(), a1.getVersion(), s1.getShortName(), s1.getVersion());
+        assertEquals(1, deploymentInfosA1S1.size());
+        assertEquals(a1.getServiceDeploymentInfos().get(0), deploymentInfosA1S1.get(0));
         // Application #2 includes services #0 and #1
-        Optional<MicoServiceDeploymentInfo> deploymentInfoOptionalA2S0 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s0.getShortName(), s0.getVersion());
-        assertTrue(deploymentInfoOptionalA2S0.isPresent());
-        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s0), deploymentInfoOptionalA2S0.get());
-        Optional<MicoServiceDeploymentInfo> deploymentInfoOptionalA2S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s1.getShortName(), s1.getVersion());
-        assertTrue(deploymentInfoOptionalA2S1.isPresent());
-        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s1), deploymentInfoOptionalA2S1.get());
+        List<MicoServiceDeploymentInfo> deploymentInfosA2S0 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s0.getShortName(), s0.getVersion());
+        assertEquals(1, deploymentInfosA2S0.size());
+        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s0), deploymentInfosA2S0.get(0));
+        List<MicoServiceDeploymentInfo> deploymentInfosA2S1 = serviceDeploymentInfoRepository.findByApplicationAndService(a2.getShortName(), a2.getVersion(), s1.getShortName(), s1.getVersion());
+        assertEquals(1, deploymentInfosA2S1.size());
+        assertEquals(matchMicoServiceDeploymentInfoByService(a2.getServiceDeploymentInfos(), s1), deploymentInfosA2S1.get(0));
     }
 
     @Commit
@@ -362,9 +362,11 @@ public class MicoServiceDeploymentInfoRepositoryTests extends MicoRepositoryTest
         sdi0.getTopics().add(tr0);
         applicationRepository.save(a0);
 
-        MicoServiceDeploymentInfo storedSdi = serviceDeploymentInfoRepository
-            .findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName()).get();
-        List<MicoTopicRole> topicRoles = storedSdi.getTopics();
+        List<MicoServiceDeploymentInfo> storedSDIs = serviceDeploymentInfoRepository
+            .findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName());
+        assertEquals(1, storedSDIs.size());
+        MicoServiceDeploymentInfo storedSDI = storedSDIs.get(0);
+        List<MicoTopicRole> topicRoles = storedSDI.getTopics();
 
         assertEquals(1, topicRoles.size());
         assertEquals(MicoTopicRole.Role.INPUT, topicRoles.get(0).getRole());
@@ -372,13 +374,15 @@ public class MicoServiceDeploymentInfoRepositoryTests extends MicoRepositoryTest
         assertEquals(t0.getName(), topicRoles.get(0).getTopic().getName());
 
         // Update topic
-        storedSdi.getTopics().get(0).getTopic().setName("topic0-updated");
-        storedSdi.getTopics().get(0).setRole(MicoTopicRole.Role.OUTPUT);
-        MicoServiceDeploymentInfo updatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(storedSdi);
+        storedSDI.getTopics().get(0).getTopic().setName("topic0-updated");
+        storedSDI.getTopics().get(0).setRole(MicoTopicRole.Role.OUTPUT);
+        MicoServiceDeploymentInfo updatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(storedSDI);
 
-        MicoServiceDeploymentInfo updatedSdi = serviceDeploymentInfoRepository
-            .findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName()).get();
-        List<MicoTopicRole> updatedTopicRoles = updatedSdi.getTopics();
+        List<MicoServiceDeploymentInfo> updatedSDIs = serviceDeploymentInfoRepository
+            .findByApplicationAndService(a0.getShortName(), a0.getVersion(), s0.getShortName());
+        assertEquals(1, updatedSDIs.size());
+        MicoServiceDeploymentInfo updatedSDI = updatedSDIs.get(0);
+        List<MicoTopicRole> updatedTopicRoles = updatedSDI.getTopics();
 
         assertEquals(1, updatedTopicRoles.size());
         assertEquals(MicoTopicRole.Role.OUTPUT, updatedTopicRoles.get(0).getRole());

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceDeploymentInfoIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceDeploymentInfoIntegrationTests.java
@@ -131,7 +131,7 @@ public class ServiceDeploymentInfoIntegrationTests {
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(),
-            application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+            application.getVersion(), service.getShortName())).willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
 
         mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
             .andDo(print())
@@ -181,7 +181,7 @@ public class ServiceDeploymentInfoIntegrationTests {
 
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
         given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
         given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
         given(micoTopicRepository.findByName(anyString())).willReturn(Optional.empty());
         given(micoTopicRepository.save(eq(expectedTopicInput))).willReturn(expectedTopicInput);
@@ -226,7 +226,7 @@ public class ServiceDeploymentInfoIntegrationTests {
         application.getServiceDeploymentInfos().add(serviceDeploymentInfo);
 
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
 
         mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
@@ -274,7 +274,7 @@ public class ServiceDeploymentInfoIntegrationTests {
 
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
         given(applicationRepository.save(eq(expectedApplication))).willReturn(expectedApplication);
-        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(Optional.of(serviceDeploymentInfo));
+        given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
         given(serviceDeploymentInfoRepository.save(any(MicoServiceDeploymentInfo.class))).willReturn(serviceDeploymentInfo.applyValuesFrom(updatedServiceDeploymentInfoDTO));
         given(micoTopicRepository.findByName(existingTopic1.getName())).willReturn(Optional.of(existingTopic1));
         given(micoTopicRepository.findByName(existingTopic2.getName())).willReturn(Optional.of(existingTopic2));


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Because of the changes introduced with #790 it's now possible that there are multiple service deployment information for the same service short name and version within an application.
Therefore the find methods in the repository have to be modified, so that a list is returned instead of an `Optional`.

- [ ] this PR contains breaking changes!


# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- x ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [x] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
