### PR TITLE
Refactor endpoints to delete KafkaFaasConnector instances

### DIFF
--- a/docs/mico-core/java/io/github/ust/mico/core/broker/MicoApplicationBroker.rst
+++ b/docs/mico-core/java/io/github/ust/mico/core/broker/MicoApplicationBroker.rst
@@ -18,6 +18,8 @@
 
 .. java:import:: io.github.ust.mico.core.service MicoStatusService
 
+.. java:import:: io.github.ust.mico.core.util CollectionUtils
+
 .. java:import:: io.github.ust.mico.core.util UIDUtils
 
 .. java:import:: lombok.extern.slf4j Slf4j

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -470,23 +470,6 @@ public class MicoApplicationBroker {
     }
 
     /**
-     * Retrieves the KafkaFaasConnector {@link MicoService} with the requested version from the database.
-     *
-     * @param kfConnectorVersion the version of the KafkaFaasConnector
-     * @return the KafkaFaasConnector {@link MicoService}
-     * @throws KafkaFaasConnectorVersionNotFoundException if the version of the KafkaFaasConnector does not exist in MICO
-     */
-    private MicoService getKafkaFaasConnectorServiceByVersion(String kfConnectorVersion) throws KafkaFaasConnectorVersionNotFoundException {
-        MicoService kfConnectorWithRequestedVersion;
-        try {
-            kfConnectorWithRequestedVersion = micoServiceBroker.getServiceFromDatabase(kafkaFaasConnectorConfig.getServiceName(), kfConnectorVersion);
-        } catch (MicoServiceNotFoundException e) {
-            throw new KafkaFaasConnectorVersionNotFoundException(kfConnectorVersion);
-        }
-        return kfConnectorWithRequestedVersion;
-    }
-
-    /**
      * Deletes a KafkaFaasConnector deployment information from the application.
      *
      * @param application           the {@link MicoApplication}

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -87,6 +87,10 @@ class TestConstants {
 
     static final String OWNER = "owner";
 
+    static final String INSTANCE_ID = "instance-id";
+    static final String INSTANCE_ID_1 = "instance-id-1";
+    static final String INSTANCE_ID_2 = "instance-id-2";
+
     /*
      * For tests in ApplicationResourceIntegrationTests, one service is added to the list of MicoServiceStatusDTOs in MicoApplicationStatusDTO.
      * All paths are build on the path for the status of this service.


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Refactor and improve implementation of deleting KafkaFaasConnector instances from an application.
Add tests.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Relates to #793

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [x] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
