### PR TITLE
Add endpoints for KafkaFaasConnector deployment information

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.broker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class KafkaFaasConnectorDeploymentInfoBroker {
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
@@ -19,11 +19,27 @@
 
 package io.github.ust.mico.core.broker;
 
+import io.github.ust.mico.core.exception.MicoApplicationNotFoundException;
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
 public class KafkaFaasConnectorDeploymentInfoBroker {
+
+    @Autowired
+    private MicoApplicationBroker applicationBroker;
+
+    public List<MicoServiceDeploymentInfo> getKafkaFaasConnectorDeploymentInformation(String micoApplicationShortName, String micoApplicationVersion) throws MicoApplicationNotFoundException {
+        MicoApplication micoApplication = applicationBroker.getMicoApplicationByShortNameAndVersion(micoApplicationShortName, micoApplicationVersion);
+        List<MicoServiceDeploymentInfo> micoServiceDeploymentInfos = micoApplication.getKafkaFaasConnectorDeploymentInfos();
+        log.debug("There are {} kafkaFaasConnectorDeploymentInformation for MicoApplication '{}' in version '{}' ", micoServiceDeploymentInfos.size(), micoApplicationShortName, micoApplicationVersion);
+        return micoApplication.getKafkaFaasConnectorDeploymentInfos();
+    }
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
@@ -36,14 +36,17 @@ public class KafkaFaasConnectorDeploymentInfoBroker {
     private MicoApplicationBroker applicationBroker;
 
     /**
-     * Fetches a list of {@link MicoServiceDeploymentInfo} of all kafkaFaasConnector instances associated  with the specified micoApplication.
+     * Fetches a list of {@link MicoServiceDeploymentInfo MicoServiceDeploymentInfos} of all KafkaFaasConnector instances
+     * associated with the specified {@link MicoApplication}.
      *
      * @param micoApplicationShortName the shortName of the micoApplication
      * @param micoApplicationVersion   the version of the micoApplication
-     * @return
+     * @return the list of {@link MicoServiceDeploymentInfo MicoServiceDeploymentInfos}
      * @throws MicoApplicationNotFoundException if there is no such micoApplication
      */
-    public List<MicoServiceDeploymentInfo> getKafkaFaasConnectorDeploymentInformation(String micoApplicationShortName, String micoApplicationVersion) throws MicoApplicationNotFoundException {
+    public List<MicoServiceDeploymentInfo> getKafkaFaasConnectorDeploymentInformation(
+        String micoApplicationShortName, String micoApplicationVersion) throws MicoApplicationNotFoundException {
+
         MicoApplication micoApplication = applicationBroker.getMicoApplicationByShortNameAndVersion(micoApplicationShortName, micoApplicationVersion);
         List<MicoServiceDeploymentInfo> micoServiceDeploymentInfos = micoApplication.getKafkaFaasConnectorDeploymentInfos();
         log.debug("There are {} KafkaFaasConnector deployment information for MicoApplication '{}' in version '{}'.",

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
@@ -35,6 +35,14 @@ public class KafkaFaasConnectorDeploymentInfoBroker {
     @Autowired
     private MicoApplicationBroker applicationBroker;
 
+    /**
+     * Fetches a list of {@link MicoServiceDeploymentInfo} of all kafkaFaasConnector instances associated  with the specified micoApplication.
+     *
+     * @param micoApplicationShortName the shortName of the micoApplication
+     * @param micoApplicationVersion   the version of the micoApplication
+     * @return
+     * @throws MicoApplicationNotFoundException if there is no such micoApplication
+     */
     public List<MicoServiceDeploymentInfo> getKafkaFaasConnectorDeploymentInformation(String micoApplicationShortName, String micoApplicationVersion) throws MicoApplicationNotFoundException {
         MicoApplication micoApplication = applicationBroker.getMicoApplicationByShortNameAndVersion(micoApplicationShortName, micoApplicationVersion);
         List<MicoServiceDeploymentInfo> micoServiceDeploymentInfos = micoApplication.getKafkaFaasConnectorDeploymentInfos();

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -53,7 +53,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/applications", produces = MediaTypes.HAL_JSON_VALUE)
+@RequestMapping(value = ApplicationResource.PATH_APPLICATIONS, produces = MediaTypes.HAL_JSON_VALUE)
 public class ApplicationResource {
 
     private static final String PATH_SERVICES = "services";
@@ -69,6 +69,7 @@ public class ApplicationResource {
     private static final String PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION = "kafkaFaasConnectorVersion";
     private static final String PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID = "kafkaFaasConnectorInstanceId";
     private static final String PATH_VARIABLE_INSTANCE_ID = "instanceId";
+    public static final String PATH_APPLICATIONS = "/applications";
 
     @Autowired
     private MicoApplicationBroker broker;

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -62,8 +62,8 @@ public class ApplicationResource {
     private static final String PATH_STATUS = "status";
     private static final String PATH_KAFKA_FAAS_CONNECTOR = "kafka-faas-connector";
 
-    private static final String PATH_VARIABLE_SHORT_NAME = "micoApplicationShortName";
-    private static final String PATH_VARIABLE_VERSION = "micoApplicationVersion";
+    public static final String PATH_VARIABLE_SHORT_NAME = "micoApplicationShortName";
+    public static final String PATH_VARIABLE_VERSION = "micoApplicationVersion";
     private static final String PATH_VARIABLE_SERVICE_SHORT_NAME = "micoServiceShortName";
     private static final String PATH_VARIABLE_SERVICE_VERSION = "micoServiceVersion";
     private static final String PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION = "kafkaFaasConnectorVersion";

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/DeploymentResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/DeploymentResource.java
@@ -19,7 +19,10 @@
 
 package io.github.ust.mico.core.resource;
 
+import io.github.ust.mico.core.broker.DeploymentBroker;
+import io.github.ust.mico.core.dto.response.MicoApplicationJobStatusResponseDTO;
 import io.github.ust.mico.core.exception.*;
+import io.github.ust.mico.core.model.MicoApplicationJobStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
@@ -31,12 +34,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.github.ust.mico.core.broker.DeploymentBroker;
-import io.github.ust.mico.core.dto.response.MicoApplicationJobStatusResponseDTO;
-import io.github.ust.mico.core.model.MicoApplicationJobStatus;
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 
 @RestController
-@RequestMapping(value = "/applications/{shortName}/{version}", produces = MediaTypes.HAL_JSON_VALUE)
+@RequestMapping(value = PATH_APPLICATIONS + "/{shortName}/{version}", produces = MediaTypes.HAL_JSON_VALUE)
 public class DeploymentResource {
     private static final String PATH_VARIABLE_SHORT_NAME = "shortName";
     private static final String PATH_VARIABLE_VERSION = "version";

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core.resource;
+
+import io.github.ust.mico.core.broker.KafkaFaasConnectorDeploymentInfoBroker;
+import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_VARIABLE_SHORT_NAME;
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_VARIABLE_VERSION;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/applications", produces = MediaTypes.HAL_JSON_VALUE)
+public class KafkaFaasConnectorDeploymentInfoResource {
+
+    private static final String PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION = "kafkaFaasConnectorDeploymentInformation";
+
+    @Autowired
+    private KafkaFaasConnectorDeploymentInfoBroker kafkaFaasConnectorDeploymentInfoBroker;
+
+    @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION)
+    public ResponseEntity<Resource<MicoServiceDeploymentInfoResponseDTO>> getKafkaFaasConnectorDeploymentInformation(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                                     @PathVariable(PATH_VARIABLE_VERSION) String version) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -22,6 +22,7 @@ package io.github.ust.mico.core.resource;
 import io.github.ust.mico.core.broker.KafkaFaasConnectorDeploymentInfoBroker;
 import io.github.ust.mico.core.dto.response.KFConnectorDeploymentInfoResponseDTO;
 import io.github.ust.mico.core.exception.MicoApplicationNotFoundException;
+import io.github.ust.mico.core.model.MicoApplication;
 import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +56,6 @@ public class KafkaFaasConnectorDeploymentInfoResource {
     @Autowired
     private KafkaFaasConnectorDeploymentInfoBroker kafkaFaasConnectorDeploymentInfoBroker;
 
-
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECTOR_DEPLOYMENT_INFORMATION)
     public ResponseEntity<Resources<Resource<KFConnectorDeploymentInfoResponseDTO>>> getKafkaFaasConnectorDeploymentInformation(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
                                                                                                                                 @PathVariable(PATH_VARIABLE_VERSION) String version) {
@@ -71,35 +71,39 @@ public class KafkaFaasConnectorDeploymentInfoResource {
     }
 
     /**
-     * Warps a list of {@link MicoServiceDeploymentInfo} into a list of {@link KFConnectorDeploymentInfoResponseDTO} resources.
+     * Wraps a list of {@link MicoServiceDeploymentInfo MicoServiceDeploymentInfos} into a list of {@link KFConnectorDeploymentInfoResponseDTO} resources.
      *
-     * @param shortName
-     * @param version
-     * @param micoServiceDeploymentInfos
-     * @return A list of resources. Each item in the list contains a {@link KFConnectorDeploymentInfoResponseDTO}.
+     * @param applicationShortName       the short name of the {@link MicoApplication}
+     * @param applicationVersion         the version of the {@link MicoApplication}
+     * @param micoServiceDeploymentInfos the {@link MicoServiceDeploymentInfo MicoServiceDeploymentInfos}
+     * @return A list of resources containing the {@link KFConnectorDeploymentInfoResponseDTO KFConnectorDeploymentInfoResponseDTOs}.
      */
-    private List<Resource<KFConnectorDeploymentInfoResponseDTO>> getKfConnectorDeploymentInfoResponseDTOResources(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName, @PathVariable(PATH_VARIABLE_VERSION) String version, List<MicoServiceDeploymentInfo> micoServiceDeploymentInfos) {
+    private List<Resource<KFConnectorDeploymentInfoResponseDTO>> getKfConnectorDeploymentInfoResponseDTOResources(
+        String applicationShortName, String applicationVersion, List<MicoServiceDeploymentInfo> micoServiceDeploymentInfos) {
+
         LinkedList<Resource<KFConnectorDeploymentInfoResponseDTO>> micoServiceDeploymentInfoResources = new LinkedList<>();
         for (MicoServiceDeploymentInfo micoServiceDeploymentInfo : micoServiceDeploymentInfos) {
-            Resource<KFConnectorDeploymentInfoResponseDTO> micoServiceDeploymentInfoResource = getKfConnectorDeploymentInfoResponseDTOResource(shortName, version, micoServiceDeploymentInfo);
+            Resource<KFConnectorDeploymentInfoResponseDTO> micoServiceDeploymentInfoResource = getKfConnectorDeploymentInfoResponseDTOResource(applicationShortName, applicationVersion, micoServiceDeploymentInfo);
             micoServiceDeploymentInfoResources.add(micoServiceDeploymentInfoResource);
         }
         return micoServiceDeploymentInfoResources;
     }
 
     /**
-     * Warps a {@link KFConnectorDeploymentInfoResponseDTO} into a HATOAS resource with a link to the application and a self-link.
+     * Wraps a {@link KFConnectorDeploymentInfoResponseDTO} into a HATEOAS resource with a link to the application and a self-link.
      *
-     * @param shortName
-     * @param version
-     * @param micoServiceDeploymentInfo
-     * @return
+     * @param applicationShortName      the short name of the {@link MicoApplication}
+     * @param applicationVersion        the version of the {@link MicoApplication}
+     * @param micoServiceDeploymentInfo the {@link MicoServiceDeploymentInfo}
+     * @return The resource containing the {@link KFConnectorDeploymentInfoResponseDTO}.
      */
-    private Resource<KFConnectorDeploymentInfoResponseDTO> getKfConnectorDeploymentInfoResponseDTOResource(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName, @PathVariable(PATH_VARIABLE_VERSION) String version, MicoServiceDeploymentInfo micoServiceDeploymentInfo) {
+    private Resource<KFConnectorDeploymentInfoResponseDTO> getKfConnectorDeploymentInfoResponseDTOResource(
+        String applicationShortName, String applicationVersion, MicoServiceDeploymentInfo micoServiceDeploymentInfo) {
+
         KFConnectorDeploymentInfoResponseDTO kfConnectorDeploymentInfoResponseDTO = new KFConnectorDeploymentInfoResponseDTO(micoServiceDeploymentInfo);
         MicoService micoService = micoServiceDeploymentInfo.getService();
         LinkedList<Link> links = new LinkedList<>();
-        links.add(linkTo(methodOn(ApplicationResource.class).getApplicationByShortNameAndVersion(shortName, version)).withRel("application"));
+        links.add(linkTo(methodOn(ApplicationResource.class).getApplicationByShortNameAndVersion(applicationShortName, applicationVersion)).withRel("application"));
         links.add(linkTo(methodOn(ServiceResource.class).getServiceByShortNameAndVersion(micoService.getShortName(), micoService.getVersion())).withRel("kafkaFaasConnector"));
         return new Resource<>(kfConnectorDeploymentInfoResponseDTO, links);
     }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -41,17 +41,16 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.LinkedList;
 import java.util.List;
 
-import static io.github.ust.mico.core.resource.ApplicationResource.PATH_VARIABLE_SHORT_NAME;
-import static io.github.ust.mico.core.resource.ApplicationResource.PATH_VARIABLE_VERSION;
+import static io.github.ust.mico.core.resource.ApplicationResource.*;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/applications", produces = MediaTypes.HAL_JSON_VALUE)
+@RequestMapping(value = PATH_APPLICATIONS, produces = MediaTypes.HAL_JSON_VALUE)
 public class KafkaFaasConnectorDeploymentInfoResource {
 
-    private static final String PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION = "kafkaFaasConnectorDeploymentInformation";
+    public static final String PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION = "kafkaFaasConnectorDeploymentInformation";
 
     @Autowired
     private KafkaFaasConnectorDeploymentInfoBroker kafkaFaasConnectorDeploymentInfoBroker;

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -21,18 +21,30 @@ package io.github.ust.mico.core.resource;
 
 import io.github.ust.mico.core.broker.KafkaFaasConnectorDeploymentInfoBroker;
 import io.github.ust.mico.core.dto.response.MicoServiceDeploymentInfoResponseDTO;
+import io.github.ust.mico.core.exception.MicoApplicationNotFoundException;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedList;
+import java.util.List;
 
 import static io.github.ust.mico.core.resource.ApplicationResource.PATH_VARIABLE_SHORT_NAME;
 import static io.github.ust.mico.core.resource.ApplicationResource.PATH_VARIABLE_VERSION;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @Slf4j
 @RestController
@@ -45,9 +57,28 @@ public class KafkaFaasConnectorDeploymentInfoResource {
     private KafkaFaasConnectorDeploymentInfoBroker kafkaFaasConnectorDeploymentInfoBroker;
 
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION)
-    public ResponseEntity<Resource<MicoServiceDeploymentInfoResponseDTO>> getKafkaFaasConnectorDeploymentInformation(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
-                                                                                                                     @PathVariable(PATH_VARIABLE_VERSION) String version) {
-        throw new UnsupportedOperationException();
+    public ResponseEntity<Resources<Resource<MicoServiceDeploymentInfoResponseDTO>>> getKafkaFaasConnectorDeploymentInformation(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                                                @PathVariable(PATH_VARIABLE_VERSION) String version) {
+        log.debug("Request to getKafkaFaasConnectorDeploymentInformation with the micoApplicationShortname '{}' and version '{}'.", shortName, version);
+        List<MicoServiceDeploymentInfo> micoServiceDeploymentInfos;
+        try {
+            micoServiceDeploymentInfos = kafkaFaasConnectorDeploymentInfoBroker.getKafkaFaasConnectorDeploymentInformation(shortName, version);
+        } catch (MicoApplicationNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+        // Convert to service deployment info DTOs and return it
+        LinkedList<Resource<MicoServiceDeploymentInfoResponseDTO>> micoServiceDeploymentInfoResources = new LinkedList<>();
+        for (MicoServiceDeploymentInfo micoServiceDeploymentInfo : micoServiceDeploymentInfos) {
+            MicoServiceDeploymentInfoResponseDTO serviceDeploymentInfoResponseDto = new MicoServiceDeploymentInfoResponseDTO(micoServiceDeploymentInfo);
+            MicoService micoService = micoServiceDeploymentInfo.getService();
+            LinkedList<Link> links = new LinkedList<>();
+            links.add(linkTo(methodOn(ApplicationResource.class).getApplicationByShortNameAndVersion(shortName, version)).withRel("application"));
+            links.add(linkTo(methodOn(ServiceResource.class).getServiceByShortNameAndVersion(micoService.getShortName(), micoService.getVersion())).withRel("kafkaFaasConnector"));
+            Resource<MicoServiceDeploymentInfoResponseDTO> micoServiceDeploymentInfoResource = new Resource<>(serviceDeploymentInfoResponseDto, links);
+            micoServiceDeploymentInfoResources.add(micoServiceDeploymentInfoResource);
+        }
+        return ResponseEntity.ok(new Resources<>(micoServiceDeploymentInfoResources, linkTo(methodOn(KafkaFaasConnectorDeploymentInfoResource.class).getKafkaFaasConnectorDeploymentInformation(shortName, version)).withSelfRel()));
     }
+
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceDeploymentInfoResource.java
@@ -35,12 +35,13 @@ import org.springframework.web.server.ResponseStatusException;
 
 import javax.validation.Valid;
 
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/applications", produces = MediaTypes.HAL_JSON_VALUE)
+@RequestMapping(value = PATH_APPLICATIONS, produces = MediaTypes.HAL_JSON_VALUE)
 public class ServiceDeploymentInfoResource {
 
     private static final String PATH_DEPLOYMENT_INFORMATION = "deploymentInformation";

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -62,7 +63,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("local")
 public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
 
-    private static final String BASE_PATH = "/applications";
     private static final String PATH_SERVICES = "services";
     private static final String PATH_KAFKA_FAAS_CONNECTOR = "kafka-faas-connector";
 
@@ -100,7 +100,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
 
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -111,7 +111,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         assertThat(result.get().getServiceDeploymentInfos().size(), is(1));
         assertThat(result.get().getServiceDeploymentInfos().get(0).getService(), is(service));
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -134,7 +134,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
 
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -157,7 +157,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
 
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -167,7 +167,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         assertThat(result.get().getKafkaFaasConnectorDeploymentInfos().get(0).getService(), is(kfConnectorService));
         String instanceId = result.get().getKafkaFaasConnectorDeploymentInfos().get(0).getInstanceId();
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION + "/" + instanceId))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION + "/" + instanceId))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -177,7 +177,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         assertThat(result2.get().getKafkaFaasConnectorDeploymentInfos().get(0).getService(), is(kfConnectorService));
         assertThat(result2.get().getKafkaFaasConnectorDeploymentInfos().get(0).getInstanceId(), is(instanceId));
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION + "/" + instanceId))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION + "/" + instanceId))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -214,7 +214,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         assertTrue(appBefore.isPresent());
         assertThat(appBefore.get().getKafkaFaasConnectorDeploymentInfos().size(), is(2));
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR))
             .andDo(print())
             .andExpect(status().isNoContent());
 
@@ -252,7 +252,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         assertTrue(appBefore.isPresent());
         assertThat(appBefore.get().getKafkaFaasConnectorDeploymentInfos().size(), is(2));
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isNoContent());
 
@@ -290,7 +290,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         assertTrue(appBefore.isPresent());
         assertThat(appBefore.get().getKafkaFaasConnectorDeploymentInfos().size(), is(2));
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION + "/" + INSTANCE_ID_1))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR + "/" + SERVICE_VERSION + "/" + INSTANCE_ID_1))
             .andDo(print())
             .andExpect(status().isNoContent());
 
@@ -313,7 +313,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
 
         given(micoKubernetesClient.isApplicationUndeployed(micoApplication)).willReturn(true);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isOk());
@@ -350,7 +350,7 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
 
         given(micoKubernetesClient.isApplicationUndeployed(micoApplication)).willReturn(true);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isOk());

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -151,7 +151,7 @@ public class ApplicationResourceIntegrationTests {
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[1].version", is(VERSION)))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].shortName", is(SHORT_NAME_1)))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].version", is(VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "self.href", is("http://localhost/" + PATH_APPLICATIONS)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "self.href", is("http://localhost" + PATH_APPLICATIONS)))
             .andReturn();
     }
 
@@ -168,7 +168,7 @@ public class ApplicationResourceIntegrationTests {
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].shortName", is(SHORT_NAME)))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].version", is(VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/+ " + PATH_APPLICATIONS + "/" + SHORT_NAME)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost" + PATH_APPLICATIONS + "/" + SHORT_NAME)))
             .andReturn();
     }
 
@@ -185,8 +185,8 @@ public class ApplicationResourceIntegrationTests {
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
             .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
             .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/" + PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/" + PATH_APPLICATIONS)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost" + PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost" + PATH_APPLICATIONS)))
             .andReturn();
     }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -53,6 +53,7 @@ import static io.github.ust.mico.core.JsonPathBuilder.*;
 import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
 import static io.github.ust.mico.core.TestConstants.VERSION;
 import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
@@ -82,7 +83,6 @@ public class ApplicationResourceIntegrationTests {
     private static final String VALUE_PATH = buildPath(ROOT, "value");
     private static final String MESSAGES_PATH = buildPath(ROOT, "messages");
     private static final String JSON_PATH_LINKS_SECTION = "$._links.";
-    private static final String BASE_PATH = "/applications";
     private static final String PATH_SERVICES = "services";
     private static final String PATH_PROMOTE = "promote";
     private static final String PATH_DEPLOYMENT_STATUS = "deploymentStatus";
@@ -140,7 +140,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(any(MicoApplication.class))).willReturn(
             MicoApplicationDeploymentStatus.undeployed("MicoApplication is currently not deployed."));
 
-        mvc.perform(get(BASE_PATH).accept(MediaTypes.HAL_JSON_UTF8_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS).accept(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
@@ -151,7 +151,7 @@ public class ApplicationResourceIntegrationTests {
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[1].version", is(VERSION)))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].shortName", is(SHORT_NAME_1)))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[2].version", is(VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "self.href", is("http://localhost/applications")))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "self.href", is("http://localhost/" + PATH_APPLICATIONS)))
             .andReturn();
     }
 
@@ -162,13 +162,13 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(any(MicoApplication.class))).willReturn(
             MicoApplicationDeploymentStatus.undeployed("MicoApplication is currently not deployed."));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].shortName", is(SHORT_NAME)))
             .andExpect(jsonPath(APPLICATION_WITH_SERVICES_DTO_LIST_PATH + "[0].version", is(VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/+ " + PATH_APPLICATIONS + "/" + SHORT_NAME)))
             .andReturn();
     }
 
@@ -179,14 +179,14 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(any(MicoApplication.class))).willReturn(
             MicoApplicationDeploymentStatus.undeployed("MicoApplication is currently not deployed."));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
             .andExpect(jsonPath(SHORT_NAME_PATH, is(SHORT_NAME)))
             .andExpect(jsonPath(VERSION_PATH, is(VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME + "/" + VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/applications")))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/" + PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/" + PATH_APPLICATIONS)))
             .andReturn();
     }
 
@@ -213,7 +213,7 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
         given(micoKubernetesClient.getApplicationDeploymentStatus(application)).willReturn(expectedApplicationDeploymentStatus);
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
@@ -227,8 +227,8 @@ public class ApplicationResourceIntegrationTests {
             .andExpect(jsonPath(DEPLOYMENT_STATUS_PATH + ".value", is(expectedApplicationDeploymentStatus.getValue().toString())))
             .andExpect(jsonPath(DEPLOYMENT_STATUS_PATH + ".messages[0].type", is(expectedApplicationDeploymentStatus.getMessages().get(0).getType().toString())))
             .andExpect(jsonPath(DEPLOYMENT_STATUS_PATH + ".messages[0].content", is(expectedApplicationDeploymentStatus.getMessages().get(0).getContent())))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost/applications/" + SHORT_NAME + "/" + VERSION)))
-            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost/applications")))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + SELF_HREF, is("http://localhost" + PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JSON_PATH_LINKS_SECTION + "applications.href", is("http://localhost" + PATH_APPLICATIONS)))
             .andReturn();
     }
 
@@ -240,7 +240,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(any(MicoApplication.class))).willReturn(
             MicoApplicationDeploymentStatus.undeployed("MicoApplication is currently not deployed."));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/").accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andReturn();
@@ -255,7 +255,7 @@ public class ApplicationResourceIntegrationTests {
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(application);
 
-        mvc.perform(post(BASE_PATH)
+        mvc.perform(post(PATH_APPLICATIONS)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -290,7 +290,7 @@ public class ApplicationResourceIntegrationTests {
             .setShortName(SHORT_NAME).setVersion(VERSION)
             .setName(NAME).setDescription(DESCRIPTION);
 
-        mvc.perform(post(BASE_PATH)
+        mvc.perform(post(PATH_APPLICATIONS)
             .content(mapper.writeValueAsBytes(newApplicationDto))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -319,7 +319,7 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(eq(application.getShortName()),
             eq(application.getVersion()))).willReturn(Optional.of(application));
 
-        mvc.perform(post(BASE_PATH)
+        mvc.perform(post(PATH_APPLICATIONS)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -333,7 +333,7 @@ public class ApplicationResourceIntegrationTests {
             .setShortName(SHORT_NAME).setVersion(VERSION)
             .setName(null).setDescription(DESCRIPTION);
 
-        mvc.perform(post(BASE_PATH)
+        mvc.perform(post(PATH_APPLICATIONS)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(application)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -355,7 +355,7 @@ public class ApplicationResourceIntegrationTests {
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(expectedApplication);
 
-        mvc.perform(post(BASE_PATH)
+        mvc.perform(post(PATH_APPLICATIONS)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(newApplication)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -381,7 +381,7 @@ public class ApplicationResourceIntegrationTests {
 
         given(applicationRepository.save(any(MicoApplication.class))).willReturn(expectedApplication);
 
-        mvc.perform(post(BASE_PATH)
+        mvc.perform(post(PATH_APPLICATIONS)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(newApplication)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -415,7 +415,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(existingApplication)).willReturn(
             MicoApplicationDeploymentStatus.undeployed("MicoApplication is currently not deployed."));
 
-        mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
+        mvc.perform(put(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -457,7 +457,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.isApplicationUndeployed(any(MicoApplication.class))).willReturn(true);
         given(micoKubernetesClient.getApplicationDeploymentStatus(existingApplication)).willReturn(expectedApplicationDeploymentStatus);
 
-        mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
+        mvc.perform(put(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -538,7 +538,7 @@ public class ApplicationResourceIntegrationTests {
 
         ArgumentCaptor<MicoApplication> applicationArgumentCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_PROMOTE)
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_PROMOTE)
             .content(mapper.writeValueAsBytes(new MicoVersionRequestDTO(newVersion)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -580,7 +580,7 @@ public class ApplicationResourceIntegrationTests {
 
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 
-        mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
+        mvc.perform(put(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -611,7 +611,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(application)).willReturn(
             MicoApplicationDeploymentStatus.undeployed("MicoApplication is currently not deployed."));
 
-        mvc.perform(put(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION)
+        mvc.perform(put(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION)
             .content(mapper.writeValueAsBytes(new MicoApplicationRequestDTO(updatedApplication)))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -635,7 +635,7 @@ public class ApplicationResourceIntegrationTests {
 
         ArgumentCaptor<MicoApplication> appCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isNoContent())
             .andReturn();
@@ -657,7 +657,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(application))
             .willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED, new ArrayList<>()));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(VALUE_PATH, is(MicoApplicationDeploymentStatus.Value.DEPLOYED.toString())))
@@ -676,7 +676,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(application))
             .willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.UNDEPLOYED, new ArrayList<>()));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(VALUE_PATH, is(MicoApplicationDeploymentStatus.Value.UNDEPLOYED.toString())))
@@ -696,7 +696,7 @@ public class ApplicationResourceIntegrationTests {
             .willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.PENDING,
                 CollectionUtils.listOf(MicoMessage.info("The deployment of MicoApplication is scheduled to be started."))));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(VALUE_PATH, is(MicoApplicationDeploymentStatus.Value.PENDING.toString())))
@@ -718,7 +718,7 @@ public class ApplicationResourceIntegrationTests {
                     MicoMessage.error("The deployment of MicoService 1 failed."),
                     MicoMessage.error("The deployment of MicoService 2 failed."))));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(VALUE_PATH, is(MicoApplicationDeploymentStatus.Value.INCOMPLETE.toString())))
@@ -738,7 +738,7 @@ public class ApplicationResourceIntegrationTests {
             .willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.UNKNOWN,
                 CollectionUtils.listOf(MicoMessage.warning("Unexpected number of clowns appeared."))));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_DEPLOYMENT_STATUS).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(VALUE_PATH, is(MicoApplicationDeploymentStatus.Value.UNKNOWN.toString())))
@@ -843,7 +843,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.getApplicationDeploymentStatus(any(MicoApplication.class)))
             .willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED, new ArrayList<>()));
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_STATUS))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_STATUS))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(SERVICE_INFORMATION_NAME, is(NAME)))
@@ -897,7 +897,7 @@ public class ApplicationResourceIntegrationTests {
 
         ArgumentCaptor<MicoApplication> micoApplicationCaptor = ArgumentCaptor.forClass(MicoApplication.class);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + SERVICE_VERSION))
             .andDo(print())
             .andExpect(status().isOk());
 
@@ -925,7 +925,7 @@ public class ApplicationResourceIntegrationTests {
             .willReturn(application.getServiceDeploymentInfos());
         given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/services/" + SERVICE_SHORT_NAME))
             .andDo(print())
             .andExpect(status().isNoContent());
     }
@@ -941,7 +941,7 @@ public class ApplicationResourceIntegrationTests {
         given(applicationRepository.findByShortName(SHORT_NAME_2)).willReturn(CollectionUtils.listOf(otherApplication));
         given(micoKubernetesClient.isApplicationUndeployed(any(MicoApplication.class))).willReturn(true);
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME))
             .andDo(print())
             .andExpect(status().isNoContent())
             .andReturn();
@@ -965,7 +965,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoKubernetesClient.isApplicationUndeployed(micoApplicationV2)).willReturn(false);
         given(micoKubernetesClient.isApplicationUndeployed(micoApplicationV3)).willReturn(true);
 
-        mvc.perform(delete(BASE_PATH + "/" + SHORT_NAME))
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME))
             .andDo(print())
             .andExpect(status().isConflict())
             .andExpect(status().reason("Application 'short-name' '1.0.1' is currently not undeployed!"))
@@ -994,7 +994,7 @@ public class ApplicationResourceIntegrationTests {
         given(micoServiceDeploymentInfoBroker.getExistingServiceDeploymentInfo(application, serviceNew))
             .willReturn(serviceDeploymentInfoNew);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_2)
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_2)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isOk());
@@ -1022,7 +1022,7 @@ public class ApplicationResourceIntegrationTests {
         given(serviceRepository.findByShortNameAndVersion(service1.getShortName(), service1.getVersion()))
             .willReturn(Optional.of(service1));
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME + "/" + VERSION_1_0_1)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
             .andExpect(status().isConflict());

--- a/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceIntegrationTests.java
@@ -42,6 +42,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.concurrent.CompletableFuture;
 
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -59,8 +60,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("dev")
 public class DeploymentResourceIntegrationTests extends Neo4jTestClass {
-
-    private static final String BASE_PATH = "/applications";
 
     @ClassRule
     public static RuleChain rules = RuleChain.outerRule(EmbeddedRedisServer.runningAt(6379).suppressExceptions());
@@ -128,7 +127,7 @@ public class DeploymentResourceIntegrationTests extends Neo4jTestClass {
         String applicationShortName = application.getShortName();
         String applicationVersion = application.getVersion();
 
-        mvc.perform(post(BASE_PATH + "/" + applicationShortName + "/" + applicationVersion + "/deploy"))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + applicationShortName + "/" + applicationVersion + "/deploy"))
             .andDo(print())
             .andExpect(status().isAccepted());
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceTests.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,7 +83,6 @@ public class DeploymentResourceTests {
     @ClassRule
     public static RuleChain rules = RuleChain.outerRule(EmbeddedRedisServer.runningAt(6379).suppressExceptions());
 
-    private static final String BASE_PATH = "/applications";
     private static final String DEPLOYMENT_NAME = "deployment-name";
     private static final String SERVICE_NAME = "service-name";
     private static final String NAMESPACE_NAME = "namespace-name";
@@ -142,7 +142,7 @@ public class DeploymentResourceTests {
 
         setupDeploymentResources(application, service);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
             .andDo(print())
             .andExpect(status().isAccepted());
 
@@ -197,7 +197,7 @@ public class DeploymentResourceTests {
         MicoApplication application = getTestApplication();
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
             .andDo(print())
             .andExpect(status().isUnprocessableEntity())
             .andExpect(status().reason(Matchers.containsString("services")));
@@ -212,7 +212,7 @@ public class DeploymentResourceTests {
         application.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo().setService(service));
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(application));
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
             .andDo(print())
             .andExpect(status().isUnprocessableEntity())
             .andExpect(status().reason(Matchers.containsString("interfaces")));
@@ -229,7 +229,7 @@ public class DeploymentResourceTests {
 
         setupDeploymentResources(application, service);
 
-        mvc.perform(post(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/deploy"))
             .andDo(print())
             .andExpect(status().isAccepted());
     }

--- a/mico-core/src/test/java/io/github/ust/mico/core/KafkaFaasConnectorDeploymentInfoResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/KafkaFaasConnectorDeploymentInfoResourceEndToEndTests.java
@@ -89,6 +89,30 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
             .andExpect(jsonPath(DEPLOYMENT_INFO_RESPONSE_DTO_LIST_JSON_PATH, hasSize(1)));
     }
 
+    @Test
+    public void getKafkaFaasConnectorDeploymentInfoMoreElements() throws Exception {
+        MicoApplication application = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
+        MicoService kafkaFaasConnectorMicoService = getKafkaFaasConnectorMicoService();
+        micoServiceRepository.save(kafkaFaasConnectorMicoService);
+        int count = 3;
+        for (int i = 0; i < count; i++) {
+            addKafkaFaasConnectorToApplication(application, kafkaFaasConnectorMicoService);
+        }
+        applicationRepository.save(application);
+
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(DEPLOYMENT_INFO_RESPONSE_DTO_LIST_JSON_PATH, hasSize(count)));
+    }
+
+    @Test
+    public void getKafkaFaasConnectorDeploymentInfoNoApplication() throws Exception {
+        mvc.perform(get(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECOTR_DEPLOYMENT_INFORMATION))
+            .andDo(print())
+            .andExpect(status().isNotFound());
+    }
+
     private void addKafkaFaasConnectorToApplication(MicoApplication application, MicoService kafkaFaasConnectorMicoService) {
         String instanceId = UIDUtils.uidFor(kafkaFaasConnectorMicoService);
         MicoServiceDeploymentInfo sdi = new MicoServiceDeploymentInfo()

--- a/mico-core/src/test/java/io/github/ust/mico/core/KafkaFaasConnectorDeploymentInfoResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/KafkaFaasConnectorDeploymentInfoResourceEndToEndTests.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.core;
+
+import io.github.ust.mico.core.persistence.MicoApplicationRepository;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@EnableAutoConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4jTestClass {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    MicoApplicationRepository applicationRepository;
+    
+}

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceDeploymentInfoIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceDeploymentInfoIntegrationTests.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.github.ust.mico.core.TestConstants.*;
+import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -70,7 +71,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("local")
 public class ServiceDeploymentInfoIntegrationTests {
 
-    private static final String BASE_PATH = "/applications";
     private static final String PATH_DEPLOYMENT_INFORMATION = "deploymentInformation";
 
     @MockBean
@@ -133,7 +133,7 @@ public class ServiceDeploymentInfoIntegrationTests {
         given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(),
             application.getVersion(), service.getShortName())).willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
 
-        mvc.perform(get(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
+        mvc.perform(get(PATH_APPLICATIONS + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName()))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(SDI_REPLICAS_PATH, is(serviceDeploymentInfo.getReplicas())))
@@ -187,7 +187,7 @@ public class ServiceDeploymentInfoIntegrationTests {
         given(micoTopicRepository.save(eq(expectedTopicInput))).willReturn(expectedTopicInput);
         given(micoTopicRepository.save(eq(expectedTopicOutput))).willReturn(expectedTopicOutput);
 
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+        mvc.perform(put(PATH_APPLICATIONS + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -228,7 +228,7 @@ public class ServiceDeploymentInfoIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion())).willReturn(Optional.of(application));
         given(serviceDeploymentInfoRepository.findByApplicationAndService(application.getShortName(), application.getVersion(), service.getShortName())).willReturn(CollectionUtils.listOf(serviceDeploymentInfo));
 
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+        mvc.perform(put(PATH_APPLICATIONS + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -281,7 +281,7 @@ public class ServiceDeploymentInfoIntegrationTests {
         given(micoTopicRepository.save(eq(existingTopic1))).willReturn(existingTopic1);
         given(micoTopicRepository.save(eq(expectedTopicNew))).willReturn(expectedTopicNew);
 
-        mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+        mvc.perform(put(PATH_APPLICATIONS + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
@@ -332,7 +332,7 @@ public class ServiceDeploymentInfoIntegrationTests {
         given(applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion()))
             .willReturn(Optional.of(application));
 
-        final ResultActions result = mvc.perform(put(BASE_PATH + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
+        final ResultActions result = mvc.perform(put(PATH_APPLICATIONS + "/" + application.getShortName() + "/" + application.getVersion() + "/" + PATH_DEPLOYMENT_INFORMATION + "/" + service.getShortName())
             .content(mapper.writeValueAsBytes(updatedServiceDeploymentInfoDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print());


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Adds the following endpoints:
 - GET `/applications/<short-name>/<version>/kafkaFaasConnectorDeploymentInformation/`

- [ ] this PR contains breaking changes!

# Resolves / is related to

Relates to #750
Relates to #798

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [x] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
