### PR TITLE
Adds the KafkaFaasConnector service information to the application dto

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/KFConnectorDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/KFConnectorDeploymentInfoResponseDTO.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.dto.request.KFConnectorDeploymentInfoRequestDTO;
+import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.Extension;
@@ -45,6 +46,33 @@ import lombok.experimental.Accessors;
 public class KFConnectorDeploymentInfoResponseDTO extends KFConnectorDeploymentInfoRequestDTO {
 
     /**
+     * The short name of the associated KafkaFaasConnector {@link MicoService}.
+     */
+    @ApiModelProperty(required = true, extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Short Name"),
+            @ExtensionProperty(name = "x-order", value = "100"),
+            @ExtensionProperty(name = "description", value = "The short name of the KafkaFaasConnector MicoService.")
+        }
+    )})
+    private String shortName;
+
+    /**
+     * The version of the associated KafkaFaasConnector {@link MicoService}.
+     */
+    @ApiModelProperty(required = true, extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "Version"),
+            @ExtensionProperty(name = "x-order", value = "110"),
+            @ExtensionProperty(name = "description", value = "The version of the associated KafkaFaasConnector MicoService. " +
+                "Refers to GitHub release tag.")
+        }
+    )})
+    private String version;
+
+    /**
      * Information about the actual Kubernetes resources created by a deployment.
      * Contains details about the used Kubernetes {@link Deployment} and {@link Service Services}.
      * Is read only.
@@ -54,7 +82,7 @@ public class KFConnectorDeploymentInfoResponseDTO extends KFConnectorDeploymentI
         properties = {
             @ExtensionProperty(name = "title", value = "Kubernetes Deployment Information"),
             @ExtensionProperty(name = "readOnly", value = "true"),
-            @ExtensionProperty(name = "x-order", value = "100"),
+            @ExtensionProperty(name = "x-order", value = "200"),
             @ExtensionProperty(name = "description", value = "Information about the actual Kubernetes resources " +
                 "created by a deployment. Contains details about the used Kubernetes Deployment and Services.")
         }
@@ -75,6 +103,11 @@ public class KFConnectorDeploymentInfoResponseDTO extends KFConnectorDeploymentI
      */
     public KFConnectorDeploymentInfoResponseDTO(MicoServiceDeploymentInfo kfConnectorDeploymentInfo) {
         super(kfConnectorDeploymentInfo);
+
+        if (kfConnectorDeploymentInfo.getService() != null) {
+            setShortName(kfConnectorDeploymentInfo.getService().getShortName());
+            setVersion(kfConnectorDeploymentInfo.getService().getVersion());
+        }
 
         // Kubernetes deployment info could be null if not available
         if (kfConnectorDeploymentInfo.getKubernetesDeploymentInfo() != null) {

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoApplicationWithServicesResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoApplicationWithServicesResponseDTO.java
@@ -19,10 +19,6 @@
 
 package io.github.ust.mico.core.dto.response;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.dto.response.status.MicoApplicationDeploymentStatusResponseDTO;
 import io.github.ust.mico.core.model.MicoApplication;
@@ -30,12 +26,12 @@ import io.github.ust.mico.core.model.MicoApplicationDeploymentStatus;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.Extension;
 import io.swagger.annotations.ExtensionProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * DTO for a {@link MicoApplication} intended to use with responses only. Additionally includes all of services of the
@@ -62,6 +58,19 @@ public class MicoApplicationWithServicesResponseDTO extends MicoApplicationRespo
     )})
     private List<MicoServiceResponseDTO> services = new ArrayList<>();
 
+    /**
+     * All KafkaFaasConnector deployment information
+     * used by the application as {@link KFConnectorDeploymentInfoResponseDTO}.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "KafkaFaasConnectors"),
+            @ExtensionProperty(name = "x-order", value = "110"),
+            @ExtensionProperty(name = "description", value = "All KafkaFaasConnector deployment information used by the application.")
+        }
+    )})
+    private List<KFConnectorDeploymentInfoResponseDTO> kfConnectorDeploymentInfos = new ArrayList<>();
 
     // -------------------
     // -> Constructors ---
@@ -77,6 +86,9 @@ public class MicoApplicationWithServicesResponseDTO extends MicoApplicationRespo
         super(application);
         services = application.getServices().stream()
             .map(MicoServiceResponseDTO::new)
+            .collect(Collectors.toList());
+        kfConnectorDeploymentInfos = application.getKafkaFaasConnectorDeploymentInfos().stream()
+            .map(KFConnectorDeploymentInfoResponseDTO::new)
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Add KafkaFaasConnector service information to the application response DTO.

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [x] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
