### PR TITLE
Add optional parameter instanceId to be able to reuse existing instances

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -188,7 +188,7 @@ public class MicoApplicationBroker {
         String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion, Optional<String> instanceIdOptional)
         throws MicoApplicationNotFoundException, MicoServiceNotFoundException, MicoServiceAddedMoreThanOnceToMicoApplicationException,
         MicoApplicationIsNotUndeployedException, MicoTopicRoleUsedMultipleTimesException, MicoServiceDeploymentInformationNotFoundException,
-        KubernetesResourceException, MicoApplicationDoesNotIncludeMicoServiceException, KafkaFaasConnectorNotAllowedHereException {
+        KubernetesResourceException, MicoApplicationDoesNotIncludeMicoServiceException, KafkaFaasConnectorNotAllowedHereException, MicoServiceInstanceNotFoundException {
 
         // KafkaFaasConnector is not allowed here, because it should be handled differently.
         // See method `addKafkaFaasConnectorInstanceToMicoApplicationByVersion`
@@ -589,22 +589,22 @@ public class MicoApplicationBroker {
      * @param serviceVersion   the version of the {@link MicoService}
      * @param instanceId       the instance id of the {@link MicoServiceDeploymentInfo}
      * @return the {@link MicoServiceDeploymentInfo} corresponding to the provided {@code instanceId}
-     * @throws MicoServiceNotFoundException if the instance does not exist or the instance does not match the provided MicoService {@code shortName} or {@code version}
+     * @throws MicoServiceInstanceNotFoundException if the instance does not exist or the instance does not match the provided MicoService {@code shortName} or {@code version}
      */
     private MicoServiceDeploymentInfo getServiceDeploymentInfoByInstanceId(
-        String serviceShortName, String serviceVersion, String instanceId) throws MicoServiceNotFoundException {
+        String serviceShortName, String serviceVersion, String instanceId) throws MicoServiceInstanceNotFoundException {
 
         // Check if the instance exists and it is the right one for the requested service.
         Optional<MicoServiceDeploymentInfo> serviceDeploymentInfoOptional = serviceDeploymentInfoRepository.findByInstanceId(instanceId);
         if (!serviceDeploymentInfoOptional.isPresent()) {
             // Instance does not exist
-            throw new MicoServiceNotFoundException(serviceShortName, serviceVersion, instanceId);
+            throw new MicoServiceInstanceNotFoundException(serviceShortName, serviceVersion, instanceId);
         }
         MicoServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfoOptional.get();
         if (!serviceDeploymentInfo.getService().getShortName().equals(serviceShortName) ||
             !serviceDeploymentInfo.getService().getVersion().equals(serviceVersion)) {
             // Provided instance id is used for a different MicoService or a different version of it
-            throw new MicoServiceNotFoundException(serviceShortName, serviceVersion, instanceId);
+            throw new MicoServiceInstanceNotFoundException(serviceShortName, serviceVersion, instanceId);
         }
         return serviceDeploymentInfo;
     }

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -164,6 +164,26 @@ public class MicoApplicationBroker {
         return applicationRepository.findAllByUsedService(serviceShortName, serviceVersion);
     }
 
+    /**
+     * Adds a {@link MicoService} to a {@link MicoApplication}.
+     * If an instance id is provided, the existing {@link MicoServiceDeploymentInfo} will be reused.
+     *
+     * @param applicationShortName the short name of the {@link MicoApplication}
+     * @param applicationVersion   the version of the {@link MicoApplication}
+     * @param serviceShortName     the short name of the {@link MicoService}
+     * @param serviceVersion       the version of the {@link MicoService}
+     * @param instanceIdOptional   the optional instance if of the {@link MicoServiceDeploymentInfo}
+     * @return the {@link MicoServiceDeploymentInfo} that was created or reused
+     * @throws MicoApplicationNotFoundException                       if the {@link MicoApplication} does not exist
+     * @throws MicoServiceNotFoundException                           if the {@link MicoService} does not exist
+     * @throws MicoServiceAddedMoreThanOnceToMicoApplicationException if the {@link MicoService} is added more than once to the {@link MicoApplication}
+     * @throws MicoApplicationIsNotUndeployedException                if the {@link MicoApplication} is not undeployed
+     * @throws MicoTopicRoleUsedMultipleTimesException                if a role of a {@link MicoTopicRole} is used multiple times
+     * @throws MicoServiceDeploymentInformationNotFoundException      if the {@link MicoServiceDeploymentInfo} does not exist
+     * @throws KubernetesResourceException                            if there is an error with Kubernetes
+     * @throws MicoApplicationDoesNotIncludeMicoServiceException      if the {@link MicoApplication} does not include the {@link MicoService}, if it is expected
+     * @throws KafkaFaasConnectorNotAllowedHereException              if a KafkaFaasConnector is provided instead of a normal {@link MicoService}
+     */
     public MicoServiceDeploymentInfo addMicoServiceToMicoApplicationByShortNameAndVersion(
         String applicationShortName, String applicationVersion, String serviceShortName, String serviceVersion, Optional<String> instanceIdOptional)
         throws MicoApplicationNotFoundException, MicoServiceNotFoundException, MicoServiceAddedMoreThanOnceToMicoApplicationException,

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
@@ -31,6 +31,7 @@ import io.swagger.annotations.ExtensionProperty;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import javax.validation.constraints.NotNull;
 import java.util.stream.Collectors;
 
 /**
@@ -43,6 +44,20 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @Accessors(chain = true)
 public class MicoServiceDeploymentInfoResponseDTO extends MicoServiceDeploymentInfoRequestDTO {
+
+    /**
+     * Instance ID.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "InstanceId"),
+            @ExtensionProperty(name = "x-order", value = "1"),
+            @ExtensionProperty(name = "description", value = "ID of the instance.")
+        }
+    )})
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private String instanceId;
 
     /**
      * Information about the actual Kubernetes resources created by a deployment. Contains details about the used
@@ -74,6 +89,9 @@ public class MicoServiceDeploymentInfoResponseDTO extends MicoServiceDeploymentI
      */
     public MicoServiceDeploymentInfoResponseDTO(MicoServiceDeploymentInfo serviceDeploymentInfo) {
         super(serviceDeploymentInfo);
+
+        // Set instance ID.
+        setInstanceId(serviceDeploymentInfo.getInstanceId());
 
         // Labels need to be set explicitly to have a list of MicoLabelResponseDTOs
         // and not a list of MicoLabelRequestDTOs, since the list is declared

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
@@ -31,7 +31,6 @@ import io.swagger.annotations.ExtensionProperty;
 import lombok.*;
 import lombok.experimental.Accessors;
 
-import javax.validation.constraints.NotNull;
 import java.util.stream.Collectors;
 
 /**

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceInstanceNotFoundException.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceInstanceNotFoundException.java
@@ -1,0 +1,16 @@
+package io.github.ust.mico.core.exception;
+
+public class MicoServiceInstanceNotFoundException extends Exception {
+
+    private static final long serialVersionUID = -4136839099118490824L;
+
+    public MicoServiceInstanceNotFoundException(String shortName, String version, String instanceId) {
+        super("Instance of service with shortName '" + shortName + "', version '" + version +
+            "' and instanceId '" + instanceId + "' was not found!");
+    }
+
+    public MicoServiceInstanceNotFoundException() {
+        super("Instance of service was not found!");
+    }
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceNotFoundException.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceNotFoundException.java
@@ -4,10 +4,6 @@ public class MicoServiceNotFoundException extends Exception {
 
     private static final long serialVersionUID = -935780471998542258L;
 
-    public MicoServiceNotFoundException(String shortName, String version, String instanceId) {
-        super("Service '" + shortName + "' '" + version + "' in instance '" + instanceId + "' was not found!");
-    }
-
     public MicoServiceNotFoundException(String shortName, String version) {
         super("Service '" + shortName + "' '" + version + "' was not found!");
     }

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceNotFoundException.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceNotFoundException.java
@@ -4,6 +4,10 @@ public class MicoServiceNotFoundException extends Exception {
 
     private static final long serialVersionUID = -935780471998542258L;
 
+    public MicoServiceNotFoundException(String shortName, String version, String instanceId) {
+        super("Service '" + shortName + "' '" + version + "' in instance '" + instanceId + "' was not found!");
+    }
+
     public MicoServiceNotFoundException(String shortName, String version) {
         super("Service '" + shortName + "' '" + version + "' was not found!");
     }

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -73,9 +73,9 @@ public class MicoServiceDeploymentInfo {
 
     /**
      * The instance id of this deployment.
-     * It will be generated immediately after the creation of this {@code MicoServiceDeploymentInfo}.
-     * Therefore it can be considered as write once.
-     * It is required to be able to have multiple independent deployments of the same MICO service.
+     * It must be generated immediately after the creation of this {@code MicoServiceDeploymentInfo}.
+     * It should be handled as write once.
+     * The instance id is required to be able to have multiple independent deployments of the same MICO service.
      * Especially for KafkaFaasConnectors this is a must have.
      */
     private String instanceId;

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -73,8 +73,9 @@ public class MicoServiceDeploymentInfo {
 
     /**
      * The instance id of this deployment.
-     * It is used to be able to have multiple independent deployments
-     * of the same MICO service.
+     * It will be generated immediately after the creation of this {@code MicoServiceDeploymentInfo}.
+     * Therefore it can be considered as write once.
+     * It is required to be able to have multiple independent deployments of the same MICO service.
      * Especially for KafkaFaasConnectors this is a must have.
      */
     private String instanceId;

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -43,6 +43,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -221,6 +222,12 @@ public class ApplicationResource {
         return ResponseEntity.ok(new Resource<>(new MicoServiceDeploymentInfoResponseDTO(serviceDeploymentInfo)));
     }
 
+    /**
+     * Currently we don't support multiple instance deployment for normal MICO services.
+     * Covered by MICO#743.
+     * Therefore this API endpoint is not required at the moment.
+     */
+    @ApiIgnore
     @ApiOperation(value = "Reuses an existing service deployment information instance and adds it to the application.")
     @PostMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_SERVICES + "/{" + PATH_VARIABLE_SERVICE_SHORT_NAME + "}/{" + PATH_VARIABLE_SERVICE_VERSION + "}/{" + PATH_VARIABLE_INSTANCE_ID + "}")
     public ResponseEntity<Resource<MicoServiceDeploymentInfoResponseDTO>> addServiceToApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String applicationShortName,

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -210,7 +210,7 @@ public class ApplicationResource {
         try {
             serviceDeploymentInfo = broker.addMicoServiceToMicoApplicationByShortNameAndVersion(
                 applicationShortName, applicationVersion, serviceShortName, serviceVersion, Optional.empty());
-        } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException e) {
+        } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException | MicoServiceInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoServiceAddedMoreThanOnceToMicoApplicationException | MicoApplicationIsNotUndeployedException | MicoApplicationDoesNotIncludeMicoServiceException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
@@ -232,7 +232,7 @@ public class ApplicationResource {
         try {
             serviceDeploymentInfo = broker.addMicoServiceToMicoApplicationByShortNameAndVersion(
                 applicationShortName, applicationVersion, serviceShortName, serviceVersion, Optional.ofNullable(instanceId));
-        } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException e) {
+        } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException | MicoServiceInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoServiceAddedMoreThanOnceToMicoApplicationException | MicoApplicationIsNotUndeployedException | MicoApplicationDoesNotIncludeMicoServiceException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Part of #743 _Multiple Instance Deployment_.
Also makes the implementation of #817 (part of epic #750) easier because an `instanceId` is required to be able to deploy and undeploy specific instances of *MicoServices*.
This PR covers not _Multiple Instance Deployment_ as a whole, it only introduces the `instanceId` to all *MicoServiceDeploymentInfo* entities to ensure, that it is always given.
-> Multiple Instances of a normal *MicoService* are not supported! Only multiple instances of a KafkaFaasConnector will be supported with the final implementation of the epic #750.

There should be a possible to reuse existing MicoService instances.
Therefore this PR adds an optional `instanceId` to the API endpoint method `addServiceToApplication`:
`POST /application/<shortName>/<version>/services/<serviceShortName>/<serviceVersion>/<instanceId>`

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
