### PR TITLE
Fix Neo4j queries to delete only exclusively used properties

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
@@ -19,16 +19,15 @@
 
 package io.github.ust.mico.core.persistence;
 
-import java.util.List;
-import java.util.Optional;
-
+import io.github.ust.mico.core.model.MicoApplication;
+import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.query.Param;
 
-import io.github.ust.mico.core.model.MicoApplication;
-import io.github.ust.mico.core.model.MicoService;
-import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
+import java.util.List;
+import java.util.Optional;
 
 public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<MicoServiceDeploymentInfo, Long> {
 
@@ -135,30 +134,33 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * Deletes all deployment information for all versions of an application including the ones for the KafkaFaasConnectors.
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
-     * relationship will be deleted, too.
+     * relationship will be deleted too, if they are used exclusively by this deployment information.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
      */
     @Query("MATCH (a:MicoApplication)-[:PROVIDES|:PROVIDES_KF_CONNECTOR]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
         + "WHERE a.shortName = {applicationShortName} "
-        + "WITH a, sdi OPTIONAL MATCH (sdi)-[:HAS]->(additionalProperty) "
-        + "WHERE a.shortName = {applicationShortName} "
-        + "DETACH DELETE sdi, additionalProperty")
+        + "WITH a, sdi "
+        + "OPTIONAL MATCH (sdi)-[:HAS]->(allRelatedNodes) "
+        + "WHERE size((allRelatedNodes)--()) = 1 "
+        + "DETACH DELETE sdi, allRelatedNodes")
     void deleteAllByApplication(@Param("applicationShortName") String applicationShortName);
 
     /**
      * Deletes all deployment information for a particular application including the ones for the KafkaFaasConnectors.
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
-     * relationship will be deleted, too.
+     * relationship will be deleted too, if they are used exclusively by this deployment information.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
      * @param applicationVersion   the version of the {@link MicoApplication}.
      */
     @Query("MATCH (a:MicoApplication)-[:PROVIDES|:PROVIDES_KF_CONNECTOR]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
         + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
-        + "WITH a, sdi OPTIONAL MATCH (sdi)-[:HAS]->(additionalProperty) "
-        + "DETACH DELETE sdi, additionalProperty")
+        + "WITH a, sdi "
+        + "OPTIONAL MATCH (sdi)-[:HAS]->(allRelatedNodes) "
+        + "WHERE size((allRelatedNodes)--()) = 1 "
+        + "DETACH DELETE sdi, allRelatedNodes")
     void deleteAllByApplication(
         @Param("applicationShortName") String applicationShortName,
         @Param("applicationVersion") String applicationVersion);
@@ -167,7 +169,7 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * Deletes the deployment information for a particular application and service.
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
-     * relationship will be deleted, too.
+     * relationship will be deleted too, if they are used exclusively by this deployment information.
      * Also works with a KafkaFaasConnector instance.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
@@ -177,8 +179,10 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
     @Query("MATCH (a:MicoApplication)-[:PROVIDES|:PROVIDES_KF_CONNECTOR]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
         + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
         + "AND s.shortName = {serviceShortName} "
-        + "WITH a, sdi, s OPTIONAL MATCH (sdi)-[:HAS]->(additionalProperty) "
-        + "DETACH DELETE sdi, additionalProperty")
+        + "WITH a, sdi, s "
+        + "OPTIONAL MATCH (sdi)-[:HAS]->(allRelatedNodes) "
+        + "WHERE size((allRelatedNodes)--()) = 1 "
+        + "DETACH DELETE sdi, allRelatedNodes")
     void deleteByApplicationAndService(
         @Param("applicationShortName") String applicationShortName,
         @Param("applicationVersion") String applicationVersion,
@@ -188,7 +192,7 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * Deletes the deployment information for a particular application and service.
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
-     * relationship will be deleted, too.
+     * relationship will be deleted too, if they are used exclusively by this deployment information.
      * Also works with a KafkaFaasConnector instance.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
@@ -199,8 +203,10 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
     @Query("MATCH (a:MicoApplication)-[:PROVIDES|:PROVIDES_KF_CONNECTOR]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
         + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
         + "AND s.shortName = {serviceShortName} AND s.version = {serviceVersion} "
-        + "WITH a, sdi, s OPTIONAL MATCH (sdi)-[:HAS]->(additionalProperty) "
-        + "DETACH DELETE sdi, additionalProperty")
+        + "WITH a, sdi, s"
+        + "OPTIONAL MATCH (sdi)-[:HAS]->(allRelatedNodes) "
+        + "WHERE size((allRelatedNodes)--()) = 1 "
+        + "DETACH DELETE sdi, allRelatedNodes")
     void deleteByApplicationAndService(
         @Param("applicationShortName") String applicationShortName,
         @Param("applicationVersion") String applicationVersion,

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
@@ -135,6 +135,11 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
      * relationship will be deleted too, if they are used exclusively by this deployment information.
+     * Exclusively means that there must only be one single edge connected to the particular property
+     * ({@code relatedNode}, see {@code size} operator in {@code WHERE} clause).
+     * If that's the case, it's possible to delete this related node safely.
+     * <p>
+     * Also works with a KafkaFaasConnector instance.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
      */
@@ -151,6 +156,11 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
      * relationship will be deleted too, if they are used exclusively by this deployment information.
+     * Exclusively means that there must only be one single edge connected to the particular property
+     * ({@code relatedNode}, see {@code size} operator in {@code WHERE} clause).
+     * If that's the case, it's possible to delete this related node safely.
+     * <p>
+     * Also works with a KafkaFaasConnector instance.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
      * @param applicationVersion   the version of the {@link MicoApplication}.
@@ -170,6 +180,10 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
      * relationship will be deleted too, if they are used exclusively by this deployment information.
+     * Exclusively means that there must only be one single edge connected to the particular property
+     * ({@code relatedNode}, see {@code size} operator in {@code WHERE} clause).
+     * If that's the case, it's possible to delete this related node safely.
+     * <p>
      * Also works with a KafkaFaasConnector instance.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.
@@ -193,6 +207,10 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
      * All additional properties of a {@link MicoServiceDeploymentInfo} that
      * are stored as a separate node entity and connected to it via a {@code [:HAS]}
      * relationship will be deleted too, if they are used exclusively by this deployment information.
+     * Exclusively means that there must only be one single edge connected to the particular property
+     * ({@code relatedNode}, see {@code size} operator in {@code WHERE} clause).
+     * If that's the case, it's possible to delete this related node safely.
+     * <p>
      * Also works with a KafkaFaasConnector instance.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}.

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoServiceDeploymentInfoRepository.java
@@ -203,7 +203,7 @@ public interface MicoServiceDeploymentInfoRepository extends Neo4jRepository<Mic
     @Query("MATCH (a:MicoApplication)-[:PROVIDES|:PROVIDES_KF_CONNECTOR]->(sdi:MicoServiceDeploymentInfo)-[:FOR]->(s:MicoService) "
         + "WHERE a.shortName = {applicationShortName} AND a.version = {applicationVersion} "
         + "AND s.shortName = {serviceShortName} AND s.version = {serviceVersion} "
-        + "WITH a, sdi, s"
+        + "WITH a, sdi, s "
         + "OPTIONAL MATCH (sdi)-[:HAS]->(allRelatedNodes) "
         + "WHERE size((allRelatedNodes)--()) = 1 "
         + "DETACH DELETE sdi, allRelatedNodes")

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
@@ -124,6 +124,73 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
     }
 
     @Test
+    public void deleteServiceFromApplication() throws Exception {
+        MicoApplication application1 = new MicoApplication().setShortName(SHORT_NAME_1).setVersion(VERSION);
+        MicoApplication application2 = new MicoApplication().setShortName(SHORT_NAME_2).setVersion(VERSION);
+        MicoService service = new MicoService().setShortName(SERVICE_SHORT_NAME).setVersion(SERVICE_VERSION);
+        serviceRepository.save(service);
+
+        MicoTopic micoTopic = new MicoTopic().setName("topic-name");
+        MicoServiceDeploymentInfo sdi1 = new MicoServiceDeploymentInfo()
+            .setService(service)
+            .setInstanceId(INSTANCE_ID_1);
+        MicoTopicRole topicRole1 = new MicoTopicRole()
+            .setServiceDeploymentInfo(sdi1)
+            .setRole(MicoTopicRole.Role.INPUT)
+            .setTopic(micoTopic);
+        sdi1.getTopics().add(topicRole1);
+        MicoServiceDeploymentInfo savedSDI1 = serviceDeploymentInfoRepository.save(sdi1);
+        // Save it twice to ensure topic is created correctly
+        savedSDI1 = serviceDeploymentInfoRepository.save(savedSDI1);
+
+        MicoServiceDeploymentInfo sdi2 = new MicoServiceDeploymentInfo()
+            .setService(service)
+            .setInstanceId(INSTANCE_ID_2);
+        MicoTopicRole topicRole2 = new MicoTopicRole()
+            .setServiceDeploymentInfo(sdi2)
+            .setRole(MicoTopicRole.Role.INPUT)
+            .setTopic(micoTopic);
+        sdi2.getTopics().add(topicRole2);
+        MicoServiceDeploymentInfo savedSDI2 = serviceDeploymentInfoRepository.save(sdi2);
+        // Save it twice to ensure topic is created correctly
+        savedSDI2 = serviceDeploymentInfoRepository.save(savedSDI2);
+
+        application1.getServices().add(service);
+        application1.getServiceDeploymentInfos().add(savedSDI1);
+        applicationRepository.save(application1);
+
+        application2.getServices().add(service);
+        application2.getServiceDeploymentInfos().add(savedSDI2);
+        applicationRepository.save(application2);
+
+        given(micoKubernetesClient.isApplicationUndeployed(application1)).willReturn(true);
+        given(micoKubernetesClient.isApplicationUndeployed(application2)).willReturn(true);
+
+        mvc.perform(delete(PATH_APPLICATIONS + "/" + SHORT_NAME_2 + "/" + VERSION + "/" + PATH_SERVICES + "/" + SERVICE_SHORT_NAME))
+            .andDo(print())
+            .andExpect(status().isNoContent());
+
+        Optional<MicoService> resultingService = serviceRepository.findByShortNameAndVersion(service.getShortName(), service.getVersion());
+        assertTrue(resultingService.isPresent());
+        assertThat(resultingService.get(), is(service));
+
+        Optional<MicoApplication> resultingApplication2 = applicationRepository.findByShortNameAndVersion(application2.getShortName(), application2.getVersion());
+        assertTrue(resultingApplication2.isPresent());
+        assertThat(resultingApplication2.get().getServices().size(), is(0));
+        assertThat(resultingApplication2.get().getServiceDeploymentInfos().size(), is(0));
+
+        Optional<MicoApplication> resultingApplication1 = applicationRepository.findByShortNameAndVersion(application1.getShortName(), application1.getVersion());
+        assertTrue(resultingApplication1.isPresent());
+        assertThat(resultingApplication1.get().getServices().size(), is(1));
+        assertThat(resultingApplication1.get().getServices().get(0), is(service));
+        assertThat(resultingApplication1.get().getServiceDeploymentInfos().size(), is(1));
+        assertThat(resultingApplication1.get().getServiceDeploymentInfos().get(0).getService(), is(service));
+        assertThat(resultingApplication1.get().getServiceDeploymentInfos().get(0).getTopics().size(), is(1));
+        assertThat(resultingApplication1.get().getServiceDeploymentInfos().get(0).getTopics().get(0), is(topicRole1));
+        assertThat(resultingApplication1.get().getServiceDeploymentInfos().get(0), is(sdi1));
+    }
+
+    @Test
     public void addKafkaFaasConnectorInstanceOfApplication() throws Exception {
         MicoApplication application = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
         applicationRepository.save(application);


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

If a service was deleted from an application it also deletes all related properties like topics.
However if a topic is also used by another service deployment information it must not be deleted from the database.
This PR fixes this problem by only deleting related properties if they are used exclusively by the particular service deployment information.

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
