### PR TITLE
Fix PUT endpoint so that properties are not required anymore

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -289,6 +289,11 @@ public class MicoServiceDeploymentInfoBroker {
      */
     MicoServiceDeploymentInfo createOrReuseOpenFaaSFunctionsInDatabase(MicoServiceDeploymentInfo serviceDeploymentInfo) {
         OpenFaaSFunction openFaaSFunction = serviceDeploymentInfo.getOpenFaaSFunction();
+        if (openFaaSFunction == null) {
+            // There is no OpenFaaS function -> nothing to do.
+            return serviceDeploymentInfo;
+        }
+
         Optional<OpenFaaSFunction> existingOpenFaaSFunctionOptional = openFaaSFunctionRepository.findByName(openFaaSFunction.getName());
         if (existingOpenFaaSFunctionOptional.isPresent()) {
             // OpenFaasFunction node with same name already exists -> Reuse it

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/KFConnectorDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/KFConnectorDeploymentInfoRequestDTO.java
@@ -71,7 +71,6 @@ public class KFConnectorDeploymentInfoRequestDTO {
             @ExtensionProperty(name = "description", value = "Name of the input topic.")
         }
     )})
-    @NotNull
     private String inputTopicName;
 
     /**
@@ -85,7 +84,6 @@ public class KFConnectorDeploymentInfoRequestDTO {
             @ExtensionProperty(name = "description", value = "Name of the output topic.")
         }
     )})
-    @NotNull
     private String outputTopicName;
 
     /**


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

PUT endpoint for updating KafkaFaasConnector instances don't require following properties anymore:
- `inputTopicName`
- `outputTopicName`
- `openFaaSFunctionName`

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [x] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
