### PR TITLE
Fix/mico#829 put kf connector self link

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -87,8 +87,10 @@ public class KafkaFaasConnectorDeploymentInfoResource {
     }
 
     @PutMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECTOR + "/{" + PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID + "}")
-    public ResponseEntity<Resource<KFConnectorDeploymentInfoRequestDTO>> updateKafkaFaasConnectorDeploymentInfo(@PathVariable(PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID) String instanceId,
-                                                                                                                @Valid @RequestBody KFConnectorDeploymentInfoRequestDTO kfConnectorDeploymentInfoRequestDTO) {
+    public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> updateKafkaFaasConnectorDeploymentInfo(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                                 @PathVariable(PATH_VARIABLE_VERSION) String version,
+                                                                                                                 @PathVariable(PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID) String instanceId,
+                                                                                                                 @Valid @RequestBody KFConnectorDeploymentInfoRequestDTO kfConnectorDeploymentInfoRequestDTO) {
         if (!kfConnectorDeploymentInfoRequestDTO.getInstanceId().equals(instanceId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                 "InstanceId in the request body does not match the request parameter");
@@ -102,9 +104,8 @@ public class KafkaFaasConnectorDeploymentInfoResource {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
         // Convert to service deployment info DTO and return it
-
-        KFConnectorDeploymentInfoResponseDTO updatedKFConnectorDeploymentInfoResponseDto = new KFConnectorDeploymentInfoResponseDTO(updatedServiceDeploymentInfo);
-        return ResponseEntity.ok(new Resource<>(updatedKFConnectorDeploymentInfoResponseDto));
+        Resource<KFConnectorDeploymentInfoResponseDTO> responseDTOResource = getKfConnectorDeploymentInfoResponseDTOResource(shortName, version, updatedServiceDeploymentInfo);
+        return ResponseEntity.ok(responseDTOResource);
     }
 
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/KafkaFaasConnectorDeploymentInfoResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/KafkaFaasConnectorDeploymentInfoResourceEndToEndTests.java
@@ -48,6 +48,7 @@ import static io.github.ust.mico.core.JsonPathBuilder.ROOT;
 import static io.github.ust.mico.core.TestConstants.*;
 import static io.github.ust.mico.core.resource.ApplicationResource.PATH_APPLICATIONS;
 import static io.github.ust.mico.core.resource.ApplicationResource.PATH_KAFKA_FAAS_CONNECTOR;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -169,6 +170,7 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
         // create the deployment info, that shall be updated
         MicoServiceDeploymentInfo deploymentInfo = new MicoServiceDeploymentInfo()
             .setInstanceId(INSTANCE_ID);
+        deploymentInfo.setService(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION));
         deploymentInfoRepository.save(deploymentInfo);
 
         // create the request for updating the deployment info
@@ -205,6 +207,7 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
                 new MicoTopicRole()
                     .setServiceDeploymentInfo(deploymentInfo).setTopic(new MicoTopic()
                     .setName(OUTPUT_TOPIC)).setRole(MicoTopicRole.Role.OUTPUT)));
+        deploymentInfo.setService(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION));
         deploymentInfoRepository.save(deploymentInfo);
 
         // create the request for updating the deployment info
@@ -241,6 +244,7 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
                 new MicoTopicRole()
                     .setServiceDeploymentInfo(deploymentInfo).setTopic(new MicoTopic()
                     .setName(OUTPUT_TOPIC)).setRole(MicoTopicRole.Role.OUTPUT)));
+        deploymentInfo.setService(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION));
         deploymentInfoRepository.save(deploymentInfo);
 
         // create the request for updating the deployment info
@@ -274,6 +278,7 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
                 new MicoTopicRole()
                     .setServiceDeploymentInfo(deploymentInfo).setTopic(new MicoTopic()
                     .setName(OUTPUT_TOPIC)).setRole(MicoTopicRole.Role.OUTPUT)));
+        deploymentInfo.setService(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION));
         deploymentInfoRepository.save(deploymentInfo);
 
         // create the request for updating the deployment info
@@ -319,6 +324,7 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
                 new MicoTopicRole().setServiceDeploymentInfo(deploymentInfo2).setTopic(inputTopic2).setRole(MicoTopicRole.Role.INPUT),
                 new MicoTopicRole().setServiceDeploymentInfo(deploymentInfo2).setTopic(outputTopic).setRole(MicoTopicRole.Role.OUTPUT)));
         MicoServiceDeploymentInfo savedDeploymentInfo2 = deploymentInfoRepository.save(deploymentInfo2);
+        deploymentInfo2.setService(new MicoService().setShortName(SHORT_NAME).setVersion(VERSION));
         deploymentInfoRepository.save(savedDeploymentInfo2);
 
         Iterable<MicoTopic> topicsAll = topicRepository.findAll();
@@ -351,7 +357,10 @@ public class KafkaFaasConnectorDeploymentInfoResourceEndToEndTests extends Neo4j
             .content(mapper.writeValueAsBytes(kfConnectorDeploymentInfoRequestDTO))
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))
             .andDo(print())
-            .andExpect(status().isOk());
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(JsonPathBuilder.buildPath(JsonPathBuilder.ROOT, JsonPathBuilder.LINKS, "application", JsonPathBuilder.HREF), endsWith("/applications/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JsonPathBuilder.buildPath(JsonPathBuilder.ROOT, JsonPathBuilder.LINKS, "kafkaFaasConnector", JsonPathBuilder.HREF), endsWith("/services/" + SHORT_NAME + "/" + VERSION)))
+            .andExpect(jsonPath(JsonPathBuilder.buildPath(JsonPathBuilder.ROOT, JsonPathBuilder.LINKS_SELF_HREF), endsWith("/applications/" + SHORT_NAME + "/" + VERSION + "/kafka-faas-connector/" + kfConnectorDeploymentInfoRequestDTO.getInstanceId())));
     }
 
 


### PR DESCRIPTION
# Description

`PUT /applications/{micoApplicationShortName}/{micoApplicationVersion}/kafka-faas-connector/{InstanceID}` now contains a self link and returns an instance of KFConnectorDeploymentInfoResponseDTO instead of KFConnectorDeploymentInfoRequestDTO

- [X] this PR contains breaking changes!

# Resolves / is related to

Closes #829

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [X] API
    - [X] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [X] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [X] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
