### PR TITLE
Feature/#826 optional version

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -1,6 +1,7 @@
 package io.github.ust.mico.core.broker;
 
 import io.github.ust.mico.core.configuration.KafkaFaasConnectorConfig;
+import io.github.ust.mico.core.dto.request.KFConnectorDeploymentInfoRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoServiceDeploymentInfoRequestDTO;
 import io.github.ust.mico.core.dto.response.status.MicoApplicationDeploymentStatusResponseDTO;
 import io.github.ust.mico.core.dto.response.status.MicoApplicationStatusResponseDTO;
@@ -54,6 +55,12 @@ public class MicoApplicationBroker {
 
     @Autowired
     private MicoStatusService micoStatusService;
+
+    @Autowired
+    private KafkaFaasConnectorDeploymentInfoBroker kafkaFaasConnectorDeploymentInfoBroker;
+
+    @Autowired
+    private MicoServiceDeploymentInfoBroker serviceDeploymentInfoBroker;
 
     public MicoApplication getMicoApplicationByShortNameAndVersion(String shortName, String version) throws MicoApplicationNotFoundException {
         Optional<MicoApplication> micoApplicationOptional = applicationRepository.findByShortNameAndVersion(shortName, version);
@@ -323,7 +330,7 @@ public class MicoApplicationBroker {
      */
     public MicoServiceDeploymentInfo addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
         String applicationShortName, String applicationVersion, String kfConnectorVersion)
-        throws MicoApplicationNotFoundException, MicoApplicationIsNotUndeployedException, KafkaFaasConnectorVersionNotFoundException {
+        throws MicoApplicationNotFoundException, MicoApplicationIsNotUndeployedException, KafkaFaasConnectorVersionNotFoundException, KafkaFaasConnectorInstanceNotFoundException {
 
         // Retrieve application and service from database (checks whether they exist)
         MicoApplication micoApplication = getMicoApplicationByShortNameAndVersion(applicationShortName, applicationVersion);
@@ -347,9 +354,8 @@ public class MicoApplicationBroker {
 
         // TODO: Set default deployment information (covered in epic mico#750)
         // Set default deployment information (environment variables, topics)
-        //serviceDeploymentInfoBroker.setDefaultDeploymentInformationForKafkaEnabledService(sdi);
-        //serviceDeploymentInfoBroker.updateKafkaFaasConnectorDeploymentInformation(applicationShortName, applicationVersion, instanceId,
-        //    new KFConnectorDeploymentInfoRequestDTO(sdi));
+        serviceDeploymentInfoBroker.setDefaultDeploymentInformationForKafkaEnabledService(sdi);
+        kafkaFaasConnectorDeploymentInfoBroker.updateKafkaFaasConnectorDeploymentInformation(instanceId, new KFConnectorDeploymentInfoRequestDTO(sdi));
         return sdi;
     }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceBroker.java
@@ -273,6 +273,11 @@ public class MicoServiceBroker {
         return micoKubernetesClient.getYaml(getServiceFromDatabase(shortName, version));
     }
 
+    /**
+     * Returns the latest version of the KafkaFaaSConnector (according to the database)
+     * @return the latest version of the KafkaFaaSConnector
+     * @throws KafkaFaasConnectorLatestVersionNotFound
+     */
     public String getLatestKFConnectorVersion() throws KafkaFaasConnectorLatestVersionNotFound {
         List<String> kfConnectorVersions = serviceRepository.findByShortName(kafkaFaasConnectorConfig.getServiceName()).stream()
                 .map(kfConnector -> kfConnector.getVersion()).sorted().collect(Collectors.toList());

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceBroker.java
@@ -1,10 +1,13 @@
 package io.github.ust.mico.core.broker;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Iterables;
+import io.github.ust.mico.core.configuration.KafkaFaasConnectorConfig;
 import io.github.ust.mico.core.model.MicoApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -38,6 +41,9 @@ public class MicoServiceBroker {
 
     @Autowired
     private MicoStatusService micoStatusService;
+
+    @Autowired
+    private KafkaFaasConnectorConfig kafkaFaasConnectorConfig;
 
     public List<MicoService> getAllServicesAsList() {
         return serviceRepository.findAll(2);
@@ -265,5 +271,14 @@ public class MicoServiceBroker {
      */
     public String getServiceYamlByShortNameAndVersion(String shortName, String version) throws MicoServiceNotFoundException, JsonProcessingException {
         return micoKubernetesClient.getYaml(getServiceFromDatabase(shortName, version));
+    }
+
+    public String getLatestKFConnectorVersion() throws KafkaFaasConnectorLatestVersionNotFound {
+        List<String> kfConnectorVersions = serviceRepository.findByShortName(kafkaFaasConnectorConfig.getServiceName()).stream()
+                .map(kfConnector -> kfConnector.getVersion()).sorted().collect(Collectors.toList());
+        if(kfConnectorVersions.isEmpty()) {
+            throw new KafkaFaasConnectorLatestVersionNotFound();
+        }
+        return Iterables.getLast(kfConnectorVersions);
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/KafkaFaasConnectorLatestVersionNotFound.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/KafkaFaasConnectorLatestVersionNotFound.java
@@ -1,0 +1,7 @@
+package io.github.ust.mico.core.exception;
+
+public class KafkaFaasConnectorLatestVersionNotFound extends Exception {
+    public KafkaFaasConnectorLatestVersionNotFound() {
+        super("Could not find the latest version of the KafkaFaaSConnector");
+    }
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -281,8 +281,8 @@ public class ApplicationResource {
                 kfConnectorVersion = serviceBroker.getLatestKFConnectorVersion();
             kafkaFaasConnectorSDI = applicationBroker.addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
                 applicationShortName, applicationVersion, kfConnectorVersion);
-                | KafkaFaasConnectorLatestVersionNotFound e) {
-        } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException | KafkaFaasConnectorInstanceNotFoundException e) {
+        } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException
+                | KafkaFaasConnectorInstanceNotFoundException | KafkaFaasConnectorLatestVersionNotFound e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationIsNotUndeployedException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -20,6 +20,7 @@
 package io.github.ust.mico.core.resource;
 
 import io.github.ust.mico.core.broker.MicoApplicationBroker;
+import io.github.ust.mico.core.broker.MicoServiceBroker;
 import io.github.ust.mico.core.dto.request.MicoApplicationRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
 import io.github.ust.mico.core.dto.response.KFConnectorDeploymentInfoResponseDTO;
@@ -75,11 +76,14 @@ public class ApplicationResource {
     static final String PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID = "kafkaFaasConnectorInstanceId";
 
     @Autowired
-    private MicoApplicationBroker broker;
+    private MicoApplicationBroker applicationBroker;
+
+    @Autowired
+    private MicoServiceBroker serviceBroker;
 
     @GetMapping()
     public ResponseEntity<Resources<Resource<MicoApplicationWithServicesResponseDTO>>> getAllApplications() {
-        List<MicoApplication> applications = broker.getMicoApplications();
+        List<MicoApplication> applications = applicationBroker.getMicoApplications();
 
         return ResponseEntity.ok(
             new Resources<>(getApplicationWithServicesResponseDTOResourceList(applications),
@@ -88,7 +92,7 @@ public class ApplicationResource {
 
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}")
     public ResponseEntity<Resources<Resource<MicoApplicationWithServicesResponseDTO>>> getApplicationsByShortName(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName) {
-        List<MicoApplication> applications = broker.getMicoApplicationsByShortName(shortName);
+        List<MicoApplication> applications = applicationBroker.getMicoApplicationsByShortName(shortName);
 
         return ResponseEntity.ok(
             new Resources<>(getApplicationWithServicesResponseDTOResourceList(applications),
@@ -100,7 +104,7 @@ public class ApplicationResource {
                                                                                                                 @PathVariable(PATH_VARIABLE_VERSION) String version) {
         MicoApplication application;
         try {
-            application = broker.getMicoApplicationByShortNameAndVersion(shortName, version);
+            application = applicationBroker.getMicoApplicationByShortNameAndVersion(shortName, version);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
@@ -113,7 +117,7 @@ public class ApplicationResource {
     public ResponseEntity<Resource<MicoApplicationWithServicesResponseDTO>> createApplication(@Valid @RequestBody MicoApplicationRequestDTO applicationDto) {
         MicoApplication application;
         try {
-            application = broker.createMicoApplication(MicoApplication.valueOf(applicationDto));
+            application = applicationBroker.createMicoApplication(MicoApplication.valueOf(applicationDto));
         } catch (MicoApplicationAlreadyExistsException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
@@ -123,7 +127,7 @@ public class ApplicationResource {
         return ResponseEntity
             .created(linkTo(methodOn(ApplicationResource.class)
                 .getApplicationByShortNameAndVersion(application.getShortName(), application.getVersion())).toUri())
-            .body(new Resource<>(dto, broker.getLinksOfMicoApplication(application)));
+            .body(new Resource<>(dto, applicationBroker.getLinksOfMicoApplication(application)));
     }
 
     @PutMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}")
@@ -132,7 +136,7 @@ public class ApplicationResource {
                                                                                               @Valid @RequestBody MicoApplicationRequestDTO applicationRequestDto) {
         MicoApplication application;
         try {
-            application = broker.updateMicoApplication(shortName, version, MicoApplication.valueOf(applicationRequestDto));
+            application = applicationBroker.updateMicoApplication(shortName, version, MicoApplication.valueOf(applicationRequestDto));
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (ShortNameOfMicoApplicationDoesNotMatchException | VersionOfMicoApplicationDoesNotMatchException | MicoApplicationIsNotUndeployedException e) {
@@ -149,7 +153,7 @@ public class ApplicationResource {
                                                                                                @Valid @RequestBody MicoVersionRequestDTO newVersionDto) {
         MicoApplication application;
         try {
-            application = broker.copyAndUpgradeMicoApplicationByShortNameAndVersion(shortName, version, newVersionDto.getVersion());
+            application = applicationBroker.copyAndUpgradeMicoApplicationByShortNameAndVersion(shortName, version, newVersionDto.getVersion());
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationAlreadyExistsException e) {
@@ -163,7 +167,7 @@ public class ApplicationResource {
     public ResponseEntity<Void> deleteApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
                                                   @PathVariable(PATH_VARIABLE_VERSION) String version) {
         try {
-            broker.deleteMicoApplicationByShortNameAndVersion(shortName, version);
+            applicationBroker.deleteMicoApplicationByShortNameAndVersion(shortName, version);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationIsNotUndeployedException e) {
@@ -176,7 +180,7 @@ public class ApplicationResource {
     @DeleteMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}")
     public ResponseEntity<Void> deleteAllVersionsOfApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName) {
         try {
-            broker.deleteMicoApplicationsByShortName(shortName);
+            applicationBroker.deleteMicoApplicationsByShortName(shortName);
         } catch (MicoApplicationIsNotUndeployedException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
@@ -189,7 +193,7 @@ public class ApplicationResource {
                                                                                                 @PathVariable(PATH_VARIABLE_VERSION) String version) {
         List<MicoService> micoServices;
         try {
-            micoServices = broker.getMicoServicesOfMicoApplicationByShortNameAndVersion(shortName, version);
+            micoServices = applicationBroker.getMicoServicesOfMicoApplicationByShortNameAndVersion(shortName, version);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
@@ -209,7 +213,7 @@ public class ApplicationResource {
                                                                                                   @PathVariable(PATH_VARIABLE_SERVICE_VERSION) String serviceVersion) {
         MicoServiceDeploymentInfo serviceDeploymentInfo;
         try {
-            serviceDeploymentInfo = broker.addMicoServiceToMicoApplicationByShortNameAndVersion(
+            serviceDeploymentInfo = applicationBroker.addMicoServiceToMicoApplicationByShortNameAndVersion(
                 applicationShortName, applicationVersion, serviceShortName, serviceVersion, Optional.empty());
         } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException | MicoServiceInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
@@ -237,7 +241,7 @@ public class ApplicationResource {
                                                                                                   @PathVariable(PATH_VARIABLE_INSTANCE_ID) String instanceId) {
         MicoServiceDeploymentInfo serviceDeploymentInfo;
         try {
-            serviceDeploymentInfo = broker.addMicoServiceToMicoApplicationByShortNameAndVersion(
+            serviceDeploymentInfo = applicationBroker.addMicoServiceToMicoApplicationByShortNameAndVersion(
                 applicationShortName, applicationVersion, serviceShortName, serviceVersion, Optional.ofNullable(instanceId));
         } catch (MicoApplicationNotFoundException | MicoServiceNotFoundException | MicoServiceDeploymentInformationNotFoundException | KubernetesResourceException | MicoServiceInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
@@ -255,7 +259,7 @@ public class ApplicationResource {
                                                              @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                              @PathVariable(PATH_VARIABLE_SERVICE_SHORT_NAME) String serviceShortName) {
         try {
-            broker.removeMicoServiceFromMicoApplicationByShortNameAndVersion(shortName, version, serviceShortName);
+            applicationBroker.removeMicoServiceFromMicoApplicationByShortNameAndVersion(shortName, version, serviceShortName);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationDoesNotIncludeMicoServiceException | MicoApplicationIsNotUndeployedException e) {
@@ -270,10 +274,12 @@ public class ApplicationResource {
     @PostMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECTOR)
     public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> addKafkaFaasConnectorInstanceToApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String applicationShortName,
                                                                                                                      @PathVariable(PATH_VARIABLE_VERSION) String applicationVersion,
-                                                                                                                     @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION) String kfConnectorVersion) {
+                                                                                                                     @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required=false) String kfConnectorVersion) throws KafkaFaasConnectorLatestVersionNotFound {
         MicoServiceDeploymentInfo kafkaFaasConnectorSDI;
+        if(kfConnectorVersion == null)
+            kfConnectorVersion = serviceBroker.getLatestKFConnectorVersion();
         try {
-            kafkaFaasConnectorSDI = broker.addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
+            kafkaFaasConnectorSDI = applicationBroker.addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
                 applicationShortName, applicationVersion, kfConnectorVersion);
         } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException | KafkaFaasConnectorInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
@@ -289,10 +295,11 @@ public class ApplicationResource {
     public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> updateKafkaFaasConnectorInstanceOfApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String applicationShortName,
                                                                                                                         @PathVariable(PATH_VARIABLE_VERSION) String applicationVersion,
                                                                                                                         @PathVariable(PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID) String instanceId,
-                                                                                                                        @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION) String kfConnectorVersion) {
+                                                                                                                        @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required=false) String kfConnectorVersion) {
+
         MicoServiceDeploymentInfo kafkaFaasConnectorSDI;
         try {
-            kafkaFaasConnectorSDI = broker.updateKafkaFaasConnectorInstanceOfMicoApplicationByVersionAndInstanceId(
+            kafkaFaasConnectorSDI = applicationBroker.updateKafkaFaasConnectorInstanceOfMicoApplicationByVersionAndInstanceId(
                 applicationShortName, applicationVersion, kfConnectorVersion, instanceId);
         } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException | KafkaFaasConnectorInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
@@ -307,7 +314,7 @@ public class ApplicationResource {
     public ResponseEntity<Void> deleteKafkaFaasConnectorInstancesFromApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
                                                                                  @PathVariable(PATH_VARIABLE_VERSION) String version) {
         try {
-            broker.removeAllKafkaFaasConnectorInstancesFromMicoApplication(shortName, version);
+            applicationBroker.removeAllKafkaFaasConnectorInstancesFromMicoApplication(shortName, version);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationIsNotUndeployedException e) {
@@ -322,7 +329,7 @@ public class ApplicationResource {
                                                                                 @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                                                 @PathVariable(PATH_VARIABLE_INSTANCE_ID) String instanceId) {
         try {
-            broker.removeKafkaFaasConnectorInstanceFromMicoApplicationByInstanceId(shortName, version, instanceId);
+            applicationBroker.removeKafkaFaasConnectorInstanceFromMicoApplicationByInstanceId(shortName, version, instanceId);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationDoesNotIncludeKFConnectorInstanceException | MicoApplicationIsNotUndeployedException | KafkaFaasConnectorInstanceNotFoundException e) {
@@ -337,7 +344,7 @@ public class ApplicationResource {
                                                                                                                @PathVariable(PATH_VARIABLE_VERSION) String version) {
         MicoApplicationDeploymentStatus applicationDeploymentStatus;
         try {
-            applicationDeploymentStatus = broker.getApplicationDeploymentStatus(shortName, version);
+            applicationDeploymentStatus = applicationBroker.getApplicationDeploymentStatus(shortName, version);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
@@ -349,7 +356,7 @@ public class ApplicationResource {
                                                                                              @PathVariable(PATH_VARIABLE_VERSION) String version) {
         MicoApplicationStatusResponseDTO applicationStatus;
         try {
-            applicationStatus = broker.getApplicationStatus(shortName, version);
+            applicationStatus = applicationBroker.getApplicationStatus(shortName, version);
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
@@ -364,12 +371,12 @@ public class ApplicationResource {
         MicoApplicationWithServicesResponseDTO dto = new MicoApplicationWithServicesResponseDTO(application);
         try {
             dto.setDeploymentStatus(new MicoApplicationDeploymentStatusResponseDTO(
-                broker.getApplicationDeploymentStatus(application.getShortName(), application.getVersion())));
+                applicationBroker.getApplicationDeploymentStatus(application.getShortName(), application.getVersion())));
         } catch (MicoApplicationNotFoundException e) {
             // Application was already checked -> it's safe to not throw an exception.
             // Don't throw an exception because it would make the code way more complex.
             log.error(e.getMessage());
         }
-        return new Resource<>(dto, broker.getLinksOfMicoApplication(application));
+        return new Resource<>(dto, applicationBroker.getLinksOfMicoApplication(application));
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -275,7 +275,7 @@ public class ApplicationResource {
         try {
             kafkaFaasConnectorSDI = broker.addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
                 applicationShortName, applicationVersion, kfConnectorVersion);
-        } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException e) {
+        } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException | KafkaFaasConnectorInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationIsNotUndeployedException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -274,13 +274,14 @@ public class ApplicationResource {
     @PostMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECTOR)
     public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> addKafkaFaasConnectorInstanceToApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String applicationShortName,
                                                                                                                      @PathVariable(PATH_VARIABLE_VERSION) String applicationVersion,
-                                                                                                                     @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required=false) String kfConnectorVersion) throws KafkaFaasConnectorLatestVersionNotFound {
+                                                                                                                     @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required=false) String kfConnectorVersion) {
         MicoServiceDeploymentInfo kafkaFaasConnectorSDI;
-        if(kfConnectorVersion == null)
-            kfConnectorVersion = serviceBroker.getLatestKFConnectorVersion();
         try {
+            if(kfConnectorVersion == null)
+                kfConnectorVersion = serviceBroker.getLatestKFConnectorVersion();
             kafkaFaasConnectorSDI = applicationBroker.addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
                 applicationShortName, applicationVersion, kfConnectorVersion);
+                | KafkaFaasConnectorLatestVersionNotFound e) {
         } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException | KafkaFaasConnectorInstanceNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationIsNotUndeployedException e) {

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
@@ -239,6 +239,27 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
     }
 
     @Test
+    public void addKafkaFaasConnectorInstanceOfApplicationWithoutSpecifyingVersion() throws Exception {
+        MicoApplication application = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
+        applicationRepository.save(application);
+
+        String kafkaFaasConnectorServiceName = kafkaFaasConnectorConfig.getServiceName();
+        MicoService kfConnectorService1 = new MicoService().setShortName(kafkaFaasConnectorServiceName).setVersion(SERVICE_VERSION_1).setKafkaEnabled(true);
+        MicoService kfConnectorService2 = new MicoService().setShortName(kafkaFaasConnectorServiceName).setVersion(SERVICE_VERSION_2).setKafkaEnabled(true);
+        serviceRepository.save(kfConnectorService1);
+        serviceRepository.save(kfConnectorService2);
+
+        given(micoKubernetesClient.isApplicationUndeployed(application)).willReturn(true);
+
+        mvc.perform(post(PATH_APPLICATIONS + "/" + SHORT_NAME + "/" + VERSION + "/" + PATH_KAFKA_FAAS_CONNECTOR))
+                .andDo(print())
+                .andExpect(status().isOk());
+        Optional<MicoApplication> result = applicationRepository.findByShortNameAndVersion(application.getShortName(), application.getVersion());
+        assertThat(result.get().getKafkaFaasConnectorDeploymentInfos().size(), is(1));
+        assertThat(result.get().getKafkaFaasConnectorDeploymentInfos().get(0).getService().getVersion(), is(kfConnectorService2.getVersion()));
+    }
+
+    @Test
     public void updateKafkaFaasConnectorInstanceOfApplicationShouldBeIdempotent() throws Exception {
         MicoApplication application = new MicoApplication().setShortName(SHORT_NAME).setVersion(VERSION);
         applicationRepository.save(application);

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
@@ -244,8 +244,8 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         applicationRepository.save(application);
 
         String kafkaFaasConnectorServiceName = kafkaFaasConnectorConfig.getServiceName();
-        MicoService kfConnectorService1 = new MicoService().setShortName(kafkaFaasConnectorServiceName).setVersion(SERVICE_VERSION_1).setKafkaEnabled(true);
-        MicoService kfConnectorService2 = new MicoService().setShortName(kafkaFaasConnectorServiceName).setVersion(SERVICE_VERSION_2).setKafkaEnabled(true);
+        MicoService kfConnectorService1 = new MicoService().setShortName(kafkaFaasConnectorServiceName).setVersion(VERSION_1_0_1).setKafkaEnabled(true);
+        MicoService kfConnectorService2 = new MicoService().setShortName(kafkaFaasConnectorServiceName).setVersion(VERSION_1_0_2).setKafkaEnabled(true);
         serviceRepository.save(kfConnectorService1);
         serviceRepository.save(kfConnectorService2);
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -82,8 +82,6 @@ class TestConstants {
     static final String SERVICE_SHORT_NAME_1 = "service-short-name-1";
 
     static final String SERVICE_VERSION = "1.0.0";
-    static final String SERVICE_VERSION_1 = "1.0.1";
-    static final String SERVICE_VERSION_2 = "1.0.2";
 
     static final String SERVICE_INTERFACE_NAME = "service-interface-name";
     static final String SERVICE_INTERFACE_NAME_1 = "service-interface-name-1";

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -82,6 +82,8 @@ class TestConstants {
     static final String SERVICE_SHORT_NAME_1 = "service-short-name-1";
 
     static final String SERVICE_VERSION = "1.0.0";
+    static final String SERVICE_VERSION_1 = "1.0.1";
+    static final String SERVICE_VERSION_2 = "1.0.2";
 
     static final String SERVICE_INTERFACE_NAME = "service-interface-name";
     static final String SERVICE_INTERFACE_NAME_1 = "service-interface-name-1";


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

For the following request 
```POST /applications/<shortName>/<version>/kafka-faas-connector/```
The query parameter `version` becomes optional. 

If `version` is not specified, the latest version is used. 
Otherwise the value of `version` is used

- [ ] this PR contains breaking changes!

# Resolves / is related to

Closes #826

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [x] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
