### PR TITLE
Add validity checks for kf connectors in grapheditor

### DIFF
--- a/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph-constants.ts
+++ b/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph-constants.ts
@@ -116,6 +116,18 @@ export const STYLE_TEMPLATE = {
         .text.clickable:hover {
             text-decoration: underline dashed;
         }
+        .node .warning-label {
+            display: none;
+        }
+        .node.error .warning-label {
+            display: initial;
+        }
+        .warning-background {
+            fill: white;
+        }
+        .warning-foreground {
+            fill: red;
+        }
         .node:not(.application):not(.selected).hovered {
             fill: #dfdfdf;
         }
@@ -208,6 +220,11 @@ export const KAFKA_FAAS_CONNECTOR_NODE_TEMPLATE = {
     <g>
         <text class="text instance-id small" data-content="data.instanceId" width="24" x="0" y="10"></text>
         <title data-content="data.instanceId"></title>
+    </g>
+    <g class="warning-label" transform="scale(0.4) translate(55,-35)">
+        <circle class="warning-background" cx="12" cy="12" r="11.5"></circle>
+        <path class="warning-foreground" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path>
+        <title data-content="error"></title>
     </g>`
 };
 

--- a/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph.component.ts
+++ b/mico-admin/src/app/graphs/app-dependency-graph/app-dependency-graph.component.ts
@@ -109,6 +109,19 @@ export class AppDependencyGraphComponent implements OnInit, OnChanges, OnDestroy
                     return true;
                 }
             }
+            if (className === 'error') {
+                if (node.type === 'kafka-faas-connector') {
+                    if (node.data.inputTopicName == null || node.data.inputTopicName === '') {
+                        // node has no input
+                        return true;
+                    }
+                    if ((node.data.outputTopicName == null || node.data.outputTopicName === '') &&
+                        (node.data.openFaaSFunctionName == null || node.data.openFaaSFunctionName === '')) {
+                        // node has no possible output
+                        return true;
+                    }
+                }
+            }
             return false;
         };
         graph.setEdgeClass = (className, edge) => {
@@ -1261,6 +1274,14 @@ export class AppDependencyGraphComponent implements OnInit, OnChanges, OnDestroy
                     outputTopicName: connector.outputTopicName,
                     openFaaSFunctionName: connector.openFaaSFunctionName,
                 };
+            }
+            existing.error = '';
+            if (connector.inputTopicName == null || connector.inputTopicName === '') {
+                existing.error = 'No input topic specified!\n';
+            }
+            if ((connector.outputTopicName == null || connector.outputTopicName === '') &&
+                (connector.openFaaSFunctionName == null || connector.openFaaSFunctionName === '')) {
+                existing.error += 'Either a FaaS function or an output topic need to be specified!';
             }
             if (connector.openFaaSFunctionName != null && connector.openFaaSFunctionName !== '') {
                 existing.title = connector.openFaaSFunctionName;


### PR DESCRIPTION
# Description

Show if kafka faas connector is ready for deployment directly in the grapheditor.
(input topic and one of output topic or faas function have to be set)

- [ ] this PR contains breaking changes!

# Resolves / is related to

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [x] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [ ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
