### PR TITLE
Add missing self-links to POST kfconnectorDeploymentInfo

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ApplicationResource.java
@@ -274,21 +274,21 @@ public class ApplicationResource {
     @PostMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECTOR)
     public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> addKafkaFaasConnectorInstanceToApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String applicationShortName,
                                                                                                                      @PathVariable(PATH_VARIABLE_VERSION) String applicationVersion,
-                                                                                                                     @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required=false) String kfConnectorVersion) {
+                                                                                                                     @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required = false) String kfConnectorVersion) {
         MicoServiceDeploymentInfo kafkaFaasConnectorSDI;
         try {
-            if(kfConnectorVersion == null)
+            if (kfConnectorVersion == null)
                 kfConnectorVersion = serviceBroker.getLatestKFConnectorVersion();
             kafkaFaasConnectorSDI = applicationBroker.addKafkaFaasConnectorInstanceToMicoApplicationByVersion(
                 applicationShortName, applicationVersion, kfConnectorVersion);
         } catch (MicoApplicationNotFoundException | KafkaFaasConnectorVersionNotFoundException
-                | KafkaFaasConnectorInstanceNotFoundException | KafkaFaasConnectorLatestVersionNotFound e) {
+            | KafkaFaasConnectorInstanceNotFoundException | KafkaFaasConnectorLatestVersionNotFound e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (MicoApplicationIsNotUndeployedException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
 
-        return ResponseEntity.ok(new Resource<>(new KFConnectorDeploymentInfoResponseDTO(kafkaFaasConnectorSDI)));
+        return ResponseEntity.ok(KafkaFaasConnectorDeploymentInfoResource.getKfConnectorDeploymentInfoResponseDTOResource(applicationShortName, applicationVersion, kafkaFaasConnectorSDI));
     }
 
     @ApiOperation(value = "Updates an existing KafkaFaasConnector deployment information instance with a new version.")
@@ -296,7 +296,7 @@ public class ApplicationResource {
     public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> updateKafkaFaasConnectorInstanceOfApplication(@PathVariable(PATH_VARIABLE_SHORT_NAME) String applicationShortName,
                                                                                                                         @PathVariable(PATH_VARIABLE_VERSION) String applicationVersion,
                                                                                                                         @PathVariable(PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID) String instanceId,
-                                                                                                                        @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required=false) String kfConnectorVersion) {
+                                                                                                                        @RequestParam(name = PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_VERSION, required = false) String kfConnectorVersion) {
 
         MicoServiceDeploymentInfo kafkaFaasConnectorSDI;
         try {
@@ -308,7 +308,7 @@ public class ApplicationResource {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
 
-        return ResponseEntity.ok(new Resource<>(new KFConnectorDeploymentInfoResponseDTO(kafkaFaasConnectorSDI)));
+        return ResponseEntity.ok(KafkaFaasConnectorDeploymentInfoResource.getKfConnectorDeploymentInfoResponseDTOResource(applicationShortName, applicationVersion, kafkaFaasConnectorSDI));
     }
 
     @DeleteMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/" + PATH_KAFKA_FAAS_CONNECTOR)

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -136,7 +136,7 @@ public class KafkaFaasConnectorDeploymentInfoResource {
      * @param micoServiceDeploymentInfo the {@link MicoServiceDeploymentInfo}
      * @return The resource containing the {@link KFConnectorDeploymentInfoResponseDTO}.
      */
-    private Resource<KFConnectorDeploymentInfoResponseDTO> getKfConnectorDeploymentInfoResponseDTOResource(
+    protected static Resource<KFConnectorDeploymentInfoResponseDTO> getKfConnectorDeploymentInfoResponseDTOResource(
         String applicationShortName, String applicationVersion, MicoServiceDeploymentInfo micoServiceDeploymentInfo) {
 
         KFConnectorDeploymentInfoResponseDTO kfConnectorDeploymentInfoResponseDTO = new KFConnectorDeploymentInfoResponseDTO(micoServiceDeploymentInfo);


### PR DESCRIPTION
# Description

Adds the missing self links to POST kfconnectorDeploymentInfo

# Resolves / is related to

Closes #837

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [X] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [X] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [X] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
