### PR TITLE
Fix kafka group id semantic

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -328,6 +328,10 @@ public class MicoServiceDeploymentInfoBroker {
             micoService.getShortName(), micoService.getVersion());
         List<MicoEnvironmentVariable> micoEnvironmentVariables = micoServiceDeploymentInfo.getEnvironmentVariables();
         micoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
+        // set a unique group id for each service instance
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable()
+            .setName(MicoEnvironmentVariable.DefaultNames.KAFKA_GROUP_ID.name())
+            .setValue(micoServiceDeploymentInfo.getInstanceId()));
         micoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
         List<MicoTopicRole> topics = micoServiceDeploymentInfo.getTopics();
         topics.addAll(kafkaConfig.getDefaultTopics(micoServiceDeploymentInfo));

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/KafkaConfig.java
@@ -50,8 +50,9 @@ public class KafkaConfig {
     private String bootstrapServers;
 
     /**
-     * The group id is a string that uniquely identifies the group
-     * of consumer processes to which this consumer belongs.
+     * The group id used by mico core when directly connecting to kafka.
+     * <p>
+     * Currently unused.
      */
     @NotBlank
     private String groupId;
@@ -74,7 +75,6 @@ public class KafkaConfig {
     public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForKafka() {
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
         micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultNames.KAFKA_BOOTSTRAP_SERVERS.name()).setValue(bootstrapServers));
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(DefaultNames.KAFKA_GROUP_ID.name()).setValue(groupId));
         return micoEnvironmentVariables;
     }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceEndToEndTests.java
@@ -402,6 +402,9 @@ public class ApplicationResourceEndToEndTests extends Neo4jTestClass {
         LinkedList<MicoEnvironmentVariable> expectedMicoEnvironmentVariables = new LinkedList<>();
         expectedMicoEnvironmentVariables.addAll(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS());
         expectedMicoEnvironmentVariables.addAll(kafkaConfig.getDefaultEnvironmentVariablesForKafka());
+        expectedMicoEnvironmentVariables.add(new MicoEnvironmentVariable()
+            .setName(MicoEnvironmentVariable.DefaultNames.KAFKA_GROUP_ID.name())
+            .setValue(actualServiceDeploymentInfo.getInstanceId()));
         List<MicoEnvironmentVariable> actualEnvironmentVariables = actualServiceDeploymentInfo.getEnvironmentVariables();
         assertEquals(3, actualEnvironmentVariables.size());
         assertThat(actualEnvironmentVariables.stream().map(MicoEnvironmentVariable::getName).collect(Collectors.toList()),

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
@@ -64,10 +64,9 @@ public class DefaultEnvironmentVariablesConfigurationTests {
     public void testKafkaConfigForEnvironmentVariables() {
         List<MicoEnvironmentVariable> expectedEnvironmentVariables = new LinkedList<>();
         expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_BOOTSTRAP_SERVERS.name()).setValue(kafkaConfig.getBootstrapServers()));
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(KAFKA_GROUP_ID.name()).setValue(kafkaConfig.getGroupId()));
 
         List<MicoEnvironmentVariable> actualEnvVars = kafkaConfig.getDefaultEnvironmentVariablesForKafka();
-        assertThat(actualEnvVars, hasSize(2));
+        assertThat(actualEnvVars, hasSize(1));
         assertThat(actualEnvVars, containsInAnyOrder(expectedEnvironmentVariables.toArray()));
     }
 


### PR DESCRIPTION
# Description

The group id has to be unique for every logical deployment unit.
The instanceId already has this property.

- [ ] this PR contains breaking changes!

# Resolves / is related to

Closes #847 

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [ ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
