### PR TITLE
Fix missing OpenFaaS function name as EnvVar during deployment

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
@@ -170,7 +170,14 @@ public class MicoKubernetesClient {
         }
 
         ArrayList<MicoEnvironmentVariable> micoEnvironmentVariables = new ArrayList<>(serviceDeploymentInfo.getEnvironmentVariables());
+        // Add topics as environment variables
         micoEnvironmentVariables.addAll(serviceDeploymentInfo.getTopics().stream().map(this::createEnvVarBasedOnTopic).collect(Collectors.toList()));
+        // Add OpenFaas function name as environment variable if it is defined
+        if (serviceDeploymentInfo.getOpenFaaSFunction() != null && serviceDeploymentInfo.getOpenFaaSFunction().getName() != null) {
+            micoEnvironmentVariables.add(new MicoEnvironmentVariable()
+                .setName(MicoEnvironmentVariable.DefaultNames.OPENFAAS_FUNCTION_NAME.name())
+                .setValue(serviceDeploymentInfo.getOpenFaaSFunction().getName()));
+        }
 
         Deployment deployment = new DeploymentBuilder()
             .withNewMetadata()

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -159,6 +159,7 @@ public class MicoKubernetesClientTests {
         MicoLabel label = new MicoLabel().setKey("some-label-key").setValue("some-label-value");
         MicoEnvironmentVariable environmentVariable = new MicoEnvironmentVariable().setName("some-env-name").setValue("some-env-value");
         MicoTopicRole topicRole = new MicoTopicRole().setRole(MicoTopicRole.Role.INPUT).setTopic(new MicoTopic().setName("input-topic"));
+        OpenFaaSFunction openFaaSFunction = new OpenFaaSFunction().setName("open-faas-function");
         MicoInterfaceConnection interfaceConnection = new MicoInterfaceConnection()
             .setEnvironmentVariableName("ENV_VAR")
             .setMicoServiceInterfaceName("INTERFACE_NAME")
@@ -171,6 +172,7 @@ public class MicoKubernetesClientTests {
             .setLabels(CollectionUtils.listOf(label))
             .setEnvironmentVariables(CollectionUtils.listOf(environmentVariable))
             .setTopics(CollectionUtils.listOf(topicRole))
+            .setOpenFaaSFunction(openFaaSFunction)
             .setInterfaceConnections(CollectionUtils.listOf(interfaceConnection));
 
         micoKubernetesClient.createMicoService(serviceDeploymentInfo);
@@ -192,6 +194,9 @@ public class MicoKubernetesClientTests {
         assertTrue("Custom environment variable is not present", actualCustomEnvVar.isPresent());
         Optional<EnvVar> actualTopicEnvVar = actualEnvVarList.stream().filter(envVar -> envVar.getName().equals(MicoEnvironmentVariable.DefaultNames.KAFKA_TOPIC_INPUT.name()) && envVar.getValue().equals(topicRole.getTopic().getName())).findFirst();
         assertTrue("Topic environment variable is not present", actualTopicEnvVar.isPresent());
+        Optional<EnvVar> actualOpenFaasFunctionNameEnvVar = actualEnvVarList.stream().filter(envVar -> envVar.getName().equals(MicoEnvironmentVariable.DefaultNames.OPENFAAS_FUNCTION_NAME.name())).findFirst();
+        assertTrue("OpenFaaS function name environment variable is not present", actualOpenFaasFunctionNameEnvVar.isPresent());
+        assertEquals("OpenFaaS function name environment variable does not match expected", serviceDeploymentInfo.getOpenFaaSFunction().getName(), actualOpenFaasFunctionNameEnvVar.get().getValue());
     }
 
     @Test


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Add OpenFaaS function name as EnvVar to Kubernetes deployment.

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [x] Backend
    - [x] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
