### PR TITLE
Add two different config properties for OpenFaaS gateway URI

### DIFF
--- a/install/kubernetes/mico-core.yaml
+++ b/install/kubernetes/mico-core.yaml
@@ -12,7 +12,8 @@ data:
     spring.redis.host=redis.mico-system
     spring.redis.port=6379
     kafka.bootstrap-servers=bootstrap.kafka:9092
-    openfaas.gateway=http://gateway.openfaas:8080
+    openfaas.gateway-uri-used-for-kafka-faas-connectors=http://gateway.openfaas:8080
+    openfaas.gateway-uri-used-for-functions-endpoint=http://gateway.openfaas:8080
     openfaas.gateway-external-service-name=gateway-external
 ---
 apiVersion: v1

--- a/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/configuration/OpenFaaSConfig.java
@@ -41,17 +41,29 @@ import java.util.List;
 public class OpenFaaSConfig {
 
     /**
-     * The URL of the OpenFaaS gateway.
+     * The URL of the OpenFaaS gateway used as environment variable for KafkaFaasConnectors.
      */
     @NotBlank
-    private String gateway;
+    private String gatewayUriUsedForKafkaFaasConnectors;
 
+    /**
+     * The URL of the OpenFaaS gateway used for the endpoint `GET /functions`.
+     * It must be accessible by mico-core.
+     */
+    @NotBlank
+    private String gatewayUriUsedForFunctionsEndpoint;
+
+    /**
+     * The name of the Kubernetes service of the OpenFaaS gateway.
+     */
     @NotBlank
     private String gatewayExternalServiceName;
 
     public List<MicoEnvironmentVariable> getDefaultEnvironmentVariablesForOpenFaaS() {
         LinkedList<MicoEnvironmentVariable> micoEnvironmentVariables = new LinkedList<>();
-        micoEnvironmentVariables.add(new MicoEnvironmentVariable().setName(MicoEnvironmentVariable.DefaultNames.OPENFAAS_GATEWAY.name()).setValue(gateway));
+        micoEnvironmentVariables.add(new MicoEnvironmentVariable()
+            .setName(MicoEnvironmentVariable.DefaultNames.OPENFAAS_GATEWAY.name())
+            .setValue(gatewayUriUsedForKafkaFaasConnectors));
         return micoEnvironmentVariables;
     }
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/OpenFaasResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/OpenFaasResource.java
@@ -78,7 +78,7 @@ public class OpenFaasResource {
     @GetMapping(FUNCTIONS_PATH)
     public ResponseEntity<String> getOpenFaasFunctions() {
         try {
-            String openFaasFunctionListURI = openFaaSConfig.getGateway() + OPEN_FAAS_FUNCTION_LIST_PATH;
+            String openFaasFunctionListURI = openFaaSConfig.getGatewayUriUsedForFunctionsEndpoint() + OPEN_FAAS_FUNCTION_LIST_PATH;
             log.debug("OpenFaaS function list uri {}", openFaasFunctionListURI);
             return restTemplate.getForEntity(openFaasFunctionListURI, String.class);
         } catch (ResourceAccessException e) {

--- a/mico-core/src/main/resources/application-dev.properties
+++ b/mico-core/src/main/resources/application-dev.properties
@@ -49,7 +49,8 @@ spring.redis.host=localhost
 spring.redis.port=6379
 
 # OpenFaaS (if you want to deploy Kafka-enabled services, set it to `http://gateway.openfaas:8080`)
-openfaas.gateway=http://localhost:31112
+openfaas.gateway-uri-used-for-kafka-faas-connectors=http://gateway.openfaas:8080
+openfaas.gateway-uri-used-for-functions-endpoint=http://localhost:31112
 openfaas.gateway-external-service-name=gateway-external
 
 # Kafka (running inside the cluster, property will be used to set default values for Kafka-enabled services)

--- a/mico-core/src/main/resources/application-local.properties
+++ b/mico-core/src/main/resources/application-local.properties
@@ -31,7 +31,8 @@ spring.redis.host=localhost
 spring.redis.port=6379
 
 # OpenFaaS
-openfaas.gateway=http://localhost:8080
+openfaas.gateway-uri-used-for-kafka-faas-connectors=http://localhost:31112
+openfaas.gateway-uri-used-for-functions-endpoint=http://localhost:31112
 openfaas.gateway-external-service-name=gateway-external
 
 # Kafka

--- a/mico-core/src/main/resources/application-prod.properties
+++ b/mico-core/src/main/resources/application-prod.properties
@@ -48,7 +48,8 @@ spring.redis.host=
 spring.redis.port=
 
 # OpenFaaS (will be set by the Kubernetes ConfigMap)
-openfaas.gateway=
+openfaas.gateway-uri-used-for-kafka-faas-connectors=
+openfaas.gateway-uri-used-for-functions-endpoint=
 openfaas.gateway-external-service-name=
 
 # Kafka (will be set by the Kubernetes ConfigMap)

--- a/mico-core/src/main/resources/application-unit-testing.properties
+++ b/mico-core/src/main/resources/application-unit-testing.properties
@@ -32,7 +32,8 @@ spring.redis.host=localhost
 spring.redis.port=6379
 
 # OpenFaaS
-openfaas.gateway=http://localhost:8080
+openfaas.gateway-uri-used-for-kafka-faas-connectors=http://localhost:31112
+openfaas.gateway-uri-used-for-functions-endpoint=http://localhost:31112
 openfaas.gateway-external-service-name=gateway-external
 
 # Kafka

--- a/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DefaultEnvironmentVariablesConfigurationTests.java
@@ -54,7 +54,7 @@ public class DefaultEnvironmentVariablesConfigurationTests {
     @Test
     public void testOpenFaaSConfigForEnvironmentVariables() {
         List<MicoEnvironmentVariable> expectedEnvironmentVariables = new LinkedList<>();
-        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(OPENFAAS_GATEWAY.name()).setValue(openFaaSConfig.getGateway()));
+        expectedEnvironmentVariables.add(new MicoEnvironmentVariable().setName(OPENFAAS_GATEWAY.name()).setValue(openFaaSConfig.getGatewayUriUsedForKafkaFaasConnectors()));
 
         assertThat(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS(), hasSize(1));
         assertThat(openFaaSConfig.getDefaultEnvironmentVariablesForOpenFaaS(), containsInAnyOrder(expectedEnvironmentVariables.toArray()));

--- a/mico-core/src/test/java/io/github/ust/mico/core/OpenFaasResourceTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/OpenFaasResourceTests.java
@@ -86,8 +86,8 @@ public class OpenFaasResourceTests {
 
     @Test
     public void getFunctionsListNotReachable() throws Exception {
-        given(openFaaSConfig.getGateway()).willReturn("http://notReachableHost.test");
-        given(restTemplate.getForEntity(openFaaSConfig.getGateway() + OPEN_FAAS_FUNCTION_LIST_PATH, String.class)).willThrow(new ResourceAccessException(" I/O error"));
+        given(openFaaSConfig.getGatewayUriUsedForFunctionsEndpoint()).willReturn("http://notReachableHost.test");
+        given(restTemplate.getForEntity(openFaaSConfig.getGatewayUriUsedForFunctionsEndpoint() + OPEN_FAAS_FUNCTION_LIST_PATH, String.class)).willThrow(new ResourceAccessException(" I/O error"));
 
         mvc.perform(get(OPEN_FAAS_BASE_PATH + FUNCTIONS_PATH).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
@@ -97,10 +97,10 @@ public class OpenFaasResourceTests {
 
     @Test
     public void getFunctionsListReachable() throws Exception {
-        given(openFaaSConfig.getGateway()).willReturn("http://reachableHost.test");
+        given(openFaaSConfig.getGatewayUriUsedForFunctionsEndpoint()).willReturn("http://reachableHost.test");
         String testBody = "TestBody";
         ResponseEntity<String> responseEntity = new ResponseEntity<>("TestBody", HttpStatus.OK);
-        given(restTemplate.getForEntity(openFaaSConfig.getGateway() + OPEN_FAAS_FUNCTION_LIST_PATH, String.class)).willReturn(responseEntity);
+        given(restTemplate.getForEntity(openFaaSConfig.getGatewayUriUsedForFunctionsEndpoint() + OPEN_FAAS_FUNCTION_LIST_PATH, String.class)).willReturn(responseEntity);
         mvc.perform(get(OPEN_FAAS_BASE_PATH + FUNCTIONS_PATH).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Use two different configuration properties for OpenFaaS gateway URI, to be able to test `mico-core` and `kafka-faas-connector` locally.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Closes #786

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
