### PR TITLE
Multiple instance deployment

### DIFF
--- a/mico-admin/src/app/api/api.service.ts
+++ b/mico-admin/src/app/api/api.service.ts
@@ -606,11 +606,12 @@ export class ApiService {
      *
      * @param serviceShortName shortName of the service
      * @param serviceVersion version of the service
+     * @param instanceId the instance id  of the service deployment information
      * @param interfaceShortName name of the serviceInterface
      */
-    getServiceInterfacePublicIp(serviceShortName: string, serviceVersion: string, interfaceShortName: string) {
+    getServiceInterfacePublicIp(serviceShortName: string, serviceVersion: string, instanceId: string, interfaceShortName: string) {
 
-        const resource = 'services/' + serviceShortName + '/' + serviceVersion + '/interfaces/' + interfaceShortName + '/publicIP';
+        const resource = 'services/' + serviceShortName + '/' + serviceVersion + '/interfaces/' + interfaceShortName + '/publicIP/' + instanceId;
         const stream = this.getStreamSource<ApiObject>(resource);
 
         this.rest.get<ApiObject>(resource).subscribe(val => {
@@ -1285,10 +1286,11 @@ export class ApiService {
      *
      * @param serviceShortName serviceShortName of the interface to be polled
      * @param serviceVersion serviceVersion of the interface to be polled
+     * @param instanceId the instance id  of the service deployment information
      * @param interfaceName interfaceName of the interface to be polled
      */
-    pollServiceInterfacePublicIp(serviceShortName: string, serviceVersion: string, interfaceName: string) {
-        const resource = 'poll/services/' + serviceShortName + '/' + serviceVersion + '/interfaces/' + interfaceName + '/publicIp';
+    pollServiceInterfacePublicIp(serviceShortName: string, serviceVersion: string, instanceId: string, interfaceName: string) {
+        const resource = 'poll/services/' + serviceShortName + '/' + serviceVersion + '/interfaces/' + interfaceName + '/publicIp/' + instanceId;
         const stream = this.getStreamSource<any>(resource);
 
         /**
@@ -1303,7 +1305,7 @@ export class ApiService {
 
         // poll status
         const subPolling = interval(5 * 1000).subscribe(() => {
-            this.getServiceInterfacePublicIp(serviceShortName, serviceVersion, interfaceName);
+            this.getServiceInterfacePublicIp(serviceShortName, serviceVersion, instanceId, interfaceName);
 
             // early exit
             if (subPublicIp.closed) {
@@ -1318,7 +1320,7 @@ export class ApiService {
             });
 
         // handle incomming publicIpDTOs
-        const subPublicIp = this.getServiceInterfacePublicIp(serviceShortName, serviceVersion, interfaceName)
+        const subPublicIp = this.getServiceInterfacePublicIp(serviceShortName, serviceVersion, instanceId, interfaceName)
             .subscribe(publicIpDTO => {
 
                 if (publicIpDTO.externalIpIsAvailable) {

--- a/mico-admin/src/app/api/api.service.ts
+++ b/mico-admin/src/app/api/api.service.ts
@@ -634,13 +634,18 @@ export class ApiService {
      */
     getServiceStatus(shortName: string, version: string) {
         const resource = 'services/' + shortName + '/' + version + '/status';
-        const stream = this.getStreamSource(resource);
+        const stream = this.getStreamSource<ApiObject[]>(resource);
 
         this.rest.get<ApiObject>(resource).subscribe(val => {
-            stream.next(freezeObject(val));
+            // return actual statusDTO list
+            if (val.hasOwnProperty('_embedded')) {
+                stream.next(freezeObject(val._embedded.micoServiceStatusResponseDTOList));
+            } else {
+                stream.next(freezeObject([]));
+            }
         });
 
-        return (stream.asObservable() as Observable<Readonly<ApiObject>>).pipe(
+        return (stream.asObservable() as Observable<Readonly<ApiObject[]>>).pipe(
             filter(data => data !== undefined)
         );
     }

--- a/mico-admin/src/app/service-detail-status/service-detail-status.component.html
+++ b/mico-admin/src/app/service-detail-status/service-detail-status.component.html
@@ -1,2 +1,2 @@
-<mico-data [modelUrl]="'remote/MicoServiceStatusResponseDTO'" [startData]="serviceStatus" [isBlacklist]="true"
+<mico-data *ngFor="let serviceStatus of serviceStatusList" [modelUrl]="'remote/MicoServiceStatusResponseDTO'" [startData]="serviceStatus" [isBlacklist]="true"
     [filter]="blackList"></mico-data>

--- a/mico-admin/src/app/service-detail-status/service-detail-status.component.ts
+++ b/mico-admin/src/app/service-detail-status/service-detail-status.component.ts
@@ -21,6 +21,7 @@ import { Component, OnChanges, Input, OnDestroy } from '@angular/core';
 import { ApiService } from '../api/api.service';
 import { Subscription } from 'rxjs';
 import { safeUnsubscribe } from '../util/utils';
+import { ApiObject } from '../api/apiobject';
 
 @Component({
     selector: 'mico-service-detail-status',
@@ -34,7 +35,7 @@ export class ServiceDetailStatusComponent implements OnChanges, OnDestroy {
 
     subServiceStatus: Subscription;
 
-    serviceStatus;
+    serviceStatusList: ApiObject[];
     blackList = ['shortName', 'version', 'name'];
 
     constructor(
@@ -48,7 +49,7 @@ export class ServiceDetailStatusComponent implements OnChanges, OnDestroy {
 
         // get and set serviceStatus
         this.apiService.getServiceStatus(this.shortName, this.version).subscribe(val => {
-            this.serviceStatus = JSON.parse(JSON.stringify(val));
+            this.serviceStatusList = JSON.parse(JSON.stringify(val));
         });
     }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/BackgroundJobBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/BackgroundJobBroker.java
@@ -139,7 +139,7 @@ public class BackgroundJobBroker {
     /**
      * Return a {@code MicoServiceBackgroundJob} for a given {@code instanceId} and {@code MicoServiceBackgroundJob.Type}.
      *
-     * @param instanceId instance id of a {@link MicoServiceDeploymentInfo}
+     * @param instanceId instance ID of a {@link MicoServiceDeploymentInfo}
      * @param type       the {@link MicoServiceBackgroundJob.Type}
      * @return the optional job. Is empty if no job exists for the given {@code instanceId}
      */
@@ -175,10 +175,10 @@ public class BackgroundJobBroker {
             MicoServiceBackgroundJob job = jobOptional.get();
             job.setFuture(future);
             saveJob(job);
-            log.debug("Saved new future of job '{}' with type '{}' for MicoService '{}' '{}' with instance id '{}'.",
+            log.debug("Saved new future of job '{}' with type '{}' for MicoService '{}' '{}' with instance ID '{}'.",
                 job.getId(), type, micoService.getShortName(), micoService.getVersion(), micoServiceInstanceId);
         } else {
-            log.warn("No job of type '{}' exists for '{}' '{}' with instance id '{}'.",
+            log.warn("No job of type '{}' exists for '{}' '{}' with instance ID '{}'.",
                 type, micoService.getShortName(), micoService.getVersion(), micoServiceInstanceId);
         }
     }
@@ -211,10 +211,10 @@ public class BackgroundJobBroker {
         if (jobOptional.isPresent()) {
             MicoServiceBackgroundJob job = jobOptional.get();
             if (!job.getStatus().equals(newStatus)) {
-                log.info("Job of '{}' '{}' with instance id '{}' with type '{}' changed its status: {} → {}.",
+                log.info("Job of '{}' '{}' with instance ID '{}' with type '{}' changed its status: {} → {}.",
                     micoService.getShortName(), micoService.getVersion(), micoServiceInstanceId, type, job.getStatus(), newStatus);
                 if (newStatus.equals(MicoServiceBackgroundJob.Status.ERROR) && !StringUtils.isEmpty(errorMessage)) {
-                    log.warn("Job of '{}' '{}' with instance id '{}' with type '{}' failed. Reason: {}",
+                    log.warn("Job of '{}' '{}' with instance ID '{}' with type '{}' failed. Reason: {}",
                         micoService.getShortName(), micoService.getVersion(), micoServiceInstanceId, type, errorMessage);
                 }
                 job.setStatus(newStatus);
@@ -222,7 +222,7 @@ public class BackgroundJobBroker {
                 saveJob(job);
             }
         } else {
-            log.warn("No job of type '{}' exists for '{}' '{}' with instance id '{}'.",
+            log.warn("No job of type '{}' exists for '{}' '{}' with instance ID '{}'.",
                 type, micoService.getShortName(), micoService.getVersion(), micoServiceInstanceId);
         }
     }

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/DeploymentBroker.java
@@ -201,7 +201,7 @@ public class DeploymentBroker {
 
         MicoService micoService = micoServiceDeploymentInfo.getService();
 
-        log.debug("Creating build job for service '{}' '{}' with instance id '{}'...",
+        log.debug("Creating build job for service '{}' '{}' with instance ID '{}'...",
             micoService.getShortName(), micoService.getVersion(), micoServiceDeploymentInfo.getInstanceId());
 
         // Check if a build for this MicoService is already running.
@@ -213,7 +213,7 @@ public class DeploymentBroker {
             if (jobOptional.get().getStatus() != MicoServiceBackgroundJob.Status.RUNNING) {
                 backgroundJobBroker.deleteJob(jobOptional.get().getId());
             } else {
-                log.info("Build job for service '{}' '{}' with instance id '{}' is already running.",
+                log.info("Build job for service '{}' '{}' with instance ID '{}' is already running.",
                     micoService.getShortName(), micoService.getVersion(), micoServiceDeploymentInfo.getInstanceId());
                 return;
             }
@@ -343,7 +343,7 @@ public class DeploymentBroker {
         if (!micoServiceInstanceIsDeployed) {
             log.info("MicoService '{}' '{}' in instance '{}' is not deployed yet. Create the required Kubernetes resources.",
                 micoService.getShortName(), micoService.getVersion(), instanceId);
-            deployment = micoKubernetesClient.createMicoService(serviceDeploymentInfo);
+            deployment = micoKubernetesClient.createMicoServiceInstance(serviceDeploymentInfo);
         } else {
             // MICO service was deployed by another MICO application.
             // Get information about the actual deployment to be able to perform the scaling.
@@ -379,7 +379,8 @@ public class DeploymentBroker {
         // Create / update the Kubernetes services that corresponds to the interfaces of the MICO services.
         List<io.fabric8.kubernetes.api.model.Service> createdServices = new ArrayList<>();
         for (MicoServiceInterface serviceInterface : micoService.getServiceInterfaces()) {
-            io.fabric8.kubernetes.api.model.Service createdService = micoKubernetesClient.createMicoServiceInterface(serviceInterface, micoService);
+            io.fabric8.kubernetes.api.model.Service createdService = micoKubernetesClient
+                .createMicoServiceInterface(serviceInterface, serviceDeploymentInfo);
             createdServices.add(createdService);
         }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/KafkaFaasConnectorDeploymentInfoBroker.java
@@ -94,7 +94,7 @@ public class KafkaFaasConnectorDeploymentInfoBroker {
         Optional<MicoServiceDeploymentInfo> micoServiceDeploymentInfoOptional = micoServiceDeploymentInfos.stream()
             .filter(sdi -> sdi.getInstanceId().equals(instanceId))
             .reduce((a, b) -> {
-                    throw new IllegalStateException("There are multiple KafkaFaasConnectors with the same instance id: " + a + ", " + b);
+                    throw new IllegalStateException("There are multiple KafkaFaasConnectors with the same instance ID: " + a + ", " + b);
                 }
             );
         if (micoServiceDeploymentInfoOptional.isPresent()) {

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -173,7 +173,7 @@ public class MicoApplicationBroker {
 
     /**
      * Adds a {@link MicoService} to a {@link MicoApplication}.
-     * If an instance id is provided, the existing {@link MicoServiceDeploymentInfo} will be reused.
+     * If an instance ID is provided, the existing {@link MicoServiceDeploymentInfo} will be reused.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}
      * @param applicationVersion   the version of the {@link MicoApplication}
@@ -232,7 +232,7 @@ public class MicoApplicationBroker {
             String instanceId;
             boolean setDefaultDeploymentInfos = false;
             if (instanceIdOptional.isPresent()) {
-                // Instance ID provided -> reuse the existing instance.
+                // instance ID provided -> reuse the existing instance.
                 instanceId = instanceIdOptional.get();
                 sdi = existingServiceDeploymentInfoOptional.get();
             } else {
@@ -369,7 +369,7 @@ public class MicoApplicationBroker {
      * @throws MicoApplicationNotFoundException            if the {@code MicoApplication} does not exist
      * @throws MicoApplicationIsNotUndeployedException     if the {@code MicoApplication} is not undeployed
      * @throws KafkaFaasConnectorVersionNotFoundException  if the version of the KafkaFaasConnector does not exist in MICO
-     * @throws KafkaFaasConnectorInstanceNotFoundException if there is no instance for the provided instance id
+     * @throws KafkaFaasConnectorInstanceNotFoundException if there is no instance for the provided instance ID
      */
     public MicoServiceDeploymentInfo updateKafkaFaasConnectorInstanceOfMicoApplicationByVersionAndInstanceId(
         String applicationShortName, String applicationVersion, String kfConnectorVersion, String instanceId)
@@ -393,7 +393,7 @@ public class MicoApplicationBroker {
             throw new KafkaFaasConnectorInstanceNotFoundException(instanceId);
         }
         if (kfConnectorsWithSameInstanceId.size() > 1) {
-            // Illegal state, an instance id must be unique
+            // Illegal state, an instance ID must be unique
             String errorMessage = "There are " + kfConnectorsWithSameInstanceId.size() +
                 " service deployment information stored for KafkaFaasConnector in version with the same instance ID '"
                 + instanceId + "' used by the application '" + micoApplication.getShortName() +
@@ -427,7 +427,7 @@ public class MicoApplicationBroker {
     }
 
     /**
-     * Removes a KafkaFaasConnector instance that has the requested instance id from the {@link MicoApplication}.
+     * Removes a KafkaFaasConnector instance that has the requested instance ID from the {@link MicoApplication}.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}
      * @param applicationVersion   the version of the {@link MicoApplication}
@@ -556,7 +556,7 @@ public class MicoApplicationBroker {
      *
      * @param serviceShortName the short name of the {@link MicoService}
      * @param serviceVersion   the version of the {@link MicoService}
-     * @param instanceId       the instance id of the {@link MicoServiceDeploymentInfo}
+     * @param instanceId       the instance ID of the {@link MicoServiceDeploymentInfo}
      * @return the {@link MicoServiceDeploymentInfo} corresponding to the provided {@code instanceId}
      * @throws MicoServiceInstanceNotFoundException if the instance does not exist or the instance does not match the provided MicoService {@code shortName} or {@code version}
      */
@@ -572,7 +572,7 @@ public class MicoApplicationBroker {
         MicoServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfoOptional.get();
         if (!serviceDeploymentInfo.getService().getShortName().equals(serviceShortName) ||
             !serviceDeploymentInfo.getService().getVersion().equals(serviceVersion)) {
-            // Provided instance id is used for a different MicoService or a different version of it
+            // Provided instance ID is used for a different MicoService or a different version of it
             throw new MicoServiceInstanceNotFoundException(serviceShortName, serviceVersion, instanceId);
         }
         return serviceDeploymentInfo;
@@ -628,7 +628,7 @@ public class MicoApplicationBroker {
 
     /**
      * Returns the {@link MicoApplication} for the provided short name and version if it exists
-     * and if it refers to the KafkaFaasConnector deployment with the provided instance id.
+     * and if it refers to the KafkaFaasConnector deployment with the provided instance ID.
      *
      * @param applicationShortName the short name of the {@link MicoApplication}
      * @param applicationVersion   the version of the {@link MicoApplication}

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -235,7 +235,7 @@ public class MicoServiceDeploymentInfoBroker {
      * the standard {@code save()} function of the service deployment information repository will not delete those
      * "tangling" (without relationships) labels (nodes), hence the manual clean up.
      */
-    void cleanUpTanglingNodes() {
+    public void cleanUpTanglingNodes() {
 
         micoLabelRepository.cleanUp();
         micoTopicRepository.cleanUp();

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/request/KFConnectorDeploymentInfoRequestDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/request/KFConnectorDeploymentInfoRequestDTO.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 public class KFConnectorDeploymentInfoRequestDTO {
 
     /**
-     * Instance ID.
+     * instance ID.
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceBackgroundJobResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceBackgroundJobResponseDTO.java
@@ -86,14 +86,14 @@ public class MicoServiceBackgroundJobResponseDTO {
     private String serviceVersion;
 
     /**
-     * The instance id of the corresponding {@link MicoServiceDeploymentInfo}.
+     * The instance ID of the corresponding {@link MicoServiceDeploymentInfo}.
      */
     @ApiModelProperty(extensions = {
         @Extension(name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION, properties = {
-            @ExtensionProperty(name = "title", value = "Instance ID"),
+            @ExtensionProperty(name = "title", value = "instance ID"),
             @ExtensionProperty(name = "x-order", value = "30"),
             @ExtensionProperty(name = "readOnly", value = "true"),
-            @ExtensionProperty(name = "description", value = "The instance id of the corresponding service deployment info.")
+            @ExtensionProperty(name = "description", value = "The instance ID of the corresponding service deployment info.")
         })
     })
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/MicoServiceDeploymentInfoResponseDTO.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 public class MicoServiceDeploymentInfoResponseDTO extends MicoServiceDeploymentInfoRequestDTO {
 
     /**
-     * Instance ID.
+     * instance ID.
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceStatusResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceStatusResponseDTO.java
@@ -141,18 +141,18 @@ public class MicoServiceStatusResponseDTO {
 
     /**
      * List of {@link MicoApplicationResponseDTO MicoApplicationResponseDTOs} representing all applications that share
-     * the MicoService.
+     * the MicoService instance ({@link MicoServiceDeploymentInfo}).
      */
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "Applications Using This Service"),
+            @ExtensionProperty(name = "title", value = "Other Applications Using This Service Instance"),
             @ExtensionProperty(name = "x-order", value = "70"),
             @ExtensionProperty(name = "description", value = "List of MicoApplicationDTOs " +
-                "representing all applications that share the MicoService.")
+                "representing all applications that share the MicoService instance.")
         }
     )})
-    private List<MicoApplicationResponseDTO> applicationsUsingThisService = new ArrayList<>();
+    private List<MicoApplicationResponseDTO> otherApplicationsUsingThisServiceInstance = new ArrayList<>();
 
     /**
      * List of all {@link Pod Pods} of all replicas of a deployment of the {@link MicoService}.

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceStatusResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceStatusResponseDTO.java
@@ -19,13 +19,11 @@
 
 package io.github.ust.mico.core.dto.response.status;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import io.fabric8.kubernetes.api.model.Pod;
 import io.github.ust.mico.core.configuration.extension.CustomOpenApiExtentionsPlugin;
 import io.github.ust.mico.core.dto.response.MicoApplicationResponseDTO;
 import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.Extension;
 import io.swagger.annotations.ExtensionProperty;
@@ -33,6 +31,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * DTO for the status information of a {@link MicoService} intended to use with responses only..
@@ -81,6 +82,19 @@ public class MicoServiceStatusResponseDTO {
         }
     )})
     private String name;
+
+    /**
+     * instance ID of the {@link MicoServiceDeploymentInfo}.
+     */
+    @ApiModelProperty(extensions = {@Extension(
+        name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
+        properties = {
+            @ExtensionProperty(name = "title", value = "instance ID"),
+            @ExtensionProperty(name = "x-order", value = "35"),
+            @ExtensionProperty(name = "description", value = "instance ID of the MicoServiceDeploymentInfo.")
+        }
+    )})
+    private String instanceId;
 
     /**
      * Counter for the number of replicas the corresponding that should be available.

--- a/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceInstanceDoesNotMatchShortNameAndVersionException.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/exception/MicoServiceInstanceDoesNotMatchShortNameAndVersionException.java
@@ -1,0 +1,13 @@
+package io.github.ust.mico.core.exception;
+
+public class MicoServiceInstanceDoesNotMatchShortNameAndVersionException extends Exception {
+
+    private static final long serialVersionUID = -7092745863409627653L;
+
+    public MicoServiceInstanceDoesNotMatchShortNameAndVersionException(String instanceId, String providedShortName, String providedVersion, String actualShortName, String actualVersion) {
+        super("The MICO service deployment with the instance ID '" + instanceId +
+            "' does not match the provided short name '" + providedShortName + "' and version '" + providedVersion + "'. " +
+            "Actual short name is '" + actualShortName + "' and version '" + actualVersion + "'.");
+    }
+
+}

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceBackgroundJob.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceBackgroundJob.java
@@ -65,7 +65,7 @@ public class MicoServiceBackgroundJob implements Serializable {
     private String serviceVersion;
 
     /**
-     * The instance id of the corresponding {@link MicoServiceDeploymentInfo}.
+     * The instance ID of the corresponding {@link MicoServiceDeploymentInfo}.
      */
     @Indexed
     private String instanceId;

--- a/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/model/MicoServiceDeploymentInfo.java
@@ -72,10 +72,10 @@ public class MicoServiceDeploymentInfo {
     private MicoService service;
 
     /**
-     * The instance id of this deployment.
+     * The instance ID of this deployment.
      * It must be generated immediately after the creation of this {@code MicoServiceDeploymentInfo}.
      * It should be handled as write once.
-     * The instance id is required to be able to have multiple independent deployments of the same MICO service.
+     * The instance ID is required to be able to have multiple independent deployments of the same MICO service.
      * Especially for KafkaFaasConnectors this is a must have.
      */
     private String instanceId;

--- a/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoApplicationRepository.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/persistence/MicoApplicationRepository.java
@@ -19,15 +19,16 @@
 
 package io.github.ust.mico.core.persistence;
 
-import java.util.List;
-import java.util.Optional;
-
 import io.github.ust.mico.core.model.MicoApplication;
 import io.github.ust.mico.core.model.MicoService;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import org.springframework.data.neo4j.annotation.Depth;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MicoApplicationRepository extends Neo4jRepository<MicoApplication, Long> {
 
@@ -52,9 +53,21 @@ public interface MicoApplicationRepository extends Neo4jRepository<MicoApplicati
      */
     @Query("MATCH (a:MicoApplication)-[i:INCLUDES]-(s:MicoService) "
         + "WHERE s.shortName = {shortName} AND s.version = {version} "
-        + "RETURN COLLECT((a)-[:INCLUDES|:PROVIDES]->()) AS applications")
+        + "RETURN COLLECT((a)-[:INCLUDES|:PROVIDES|:PROVIDES_KF_CONNECTOR]->()) AS applications")
     List<MicoApplication> findAllByUsedService(
         @Param("shortName") String shortName,
         @Param("version") String version);
+
+    /**
+     * Find all applications that are using the given service.
+     *
+     * @param instanceId the instance ID of the {@link MicoServiceDeploymentInfo}
+     * @return a list of {@link MicoApplication}
+     */
+    @Query("MATCH (a:MicoApplication)-[i:PROVIDES]-(sdi:MicoServiceDeploymentInfo) "
+        + "WHERE sdi.instanceId = {instanceId} "
+        + "RETURN COLLECT((a)-[:INCLUDES|:PROVIDES|:PROVIDES_KF_CONNECTOR]->()) AS applications")
+    List<MicoApplication> findAllByUsedServiceInstance(
+        @Param("instanceId") String instanceId);
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/KafkaFaasConnectorDeploymentInfoResource.java
@@ -73,12 +73,12 @@ public class KafkaFaasConnectorDeploymentInfoResource {
     public ResponseEntity<Resource<KFConnectorDeploymentInfoResponseDTO>> getKafkaFaasConnectorDeploymentInformationInstance(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
                                                                                                                              @PathVariable(PATH_VARIABLE_VERSION) String version,
                                                                                                                              @PathVariable(PATH_VARIABLE_KAFKA_FAAS_CONNECTOR_INSTANCE_ID) String instanceId) {
-        log.debug("Get the KafkaFaasConnector deployment information of the MicoApplication '{}' '{}' with the instance id '{}'.", shortName, version, instanceId);
+        log.debug("Get the KafkaFaasConnector deployment information of the MicoApplication '{}' '{}' with the instance ID '{}'.", shortName, version, instanceId);
         Optional<MicoServiceDeploymentInfo> micoServiceDeploymentInfoOptional;
         try {
             micoServiceDeploymentInfoOptional = kafkaFaasConnectorDeploymentInfoBroker.getKafkaFaasConnectorDeploymentInformation(shortName, version, instanceId);
             micoServiceDeploymentInfoOptional.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-                "There is no KafkaFaasConnector with the instance id '" + instanceId + "'!"));
+                "There is no KafkaFaasConnector with the instance ID '" + instanceId + "'!"));
         } catch (MicoApplicationNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceResource.java
@@ -153,10 +153,21 @@ public class ServiceResource {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}" + "/status")
+    public ResponseEntity<Resources<Resource<MicoServiceStatusResponseDTO>>> getStatusOfServiceInstance(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                        @PathVariable(PATH_VARIABLE_VERSION) String version) {
+        MicoService micoService = getServiceFromMicoServiceBroker(shortName, version);
+
+        List<MicoServiceStatusResponseDTO> micoServiceStatusList = micoStatusService.getServiceStatus(micoService);
+        List<Resource<MicoServiceStatusResponseDTO>> micoServiceStatusResourceList = getMicoServiceStatusResourceList(micoServiceStatusList, micoService);
+
+        return ResponseEntity.ok(new Resources<>(micoServiceStatusResourceList));
+    }
+
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}/{" + PATH_VARIABLE_INSTANCE_ID + "}" + "/status")
     public ResponseEntity<Resource<MicoServiceStatusResponseDTO>> getStatusOfServiceInstance(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
-                                                                                     @PathVariable(PATH_VARIABLE_VERSION) String version,
-                                                                                     @PathVariable(PATH_VARIABLE_INSTANCE_ID) String instanceId) {
+                                                                                             @PathVariable(PATH_VARIABLE_VERSION) String version,
+                                                                                             @PathVariable(PATH_VARIABLE_INSTANCE_ID) String instanceId) {
         MicoServiceDeploymentInfo micoServiceDeploymentInfo = getServiceInstanceFromMicoServiceBroker(shortName, version, instanceId);
 
         MicoServiceStatusResponseDTO serviceStatus = micoStatusService.getServiceInstanceStatus(micoServiceDeploymentInfo);
@@ -446,6 +457,10 @@ public class ServiceResource {
 
     private List<MicoService> getAllVersionsOfServiceFromMicoServiceBroker(String shortName) throws ResponseStatusException {
         return micoServiceBroker.getAllVersionsOfServiceFromDatabase(shortName);
+    }
+
+    private List<Resource<MicoServiceStatusResponseDTO>> getMicoServiceStatusResourceList(List<MicoServiceStatusResponseDTO> statusList, MicoService micoService) {
+        return statusList.stream().map(status -> new Resource<>(status, getServiceLinks(micoService))).collect(Collectors.toList());
     }
 
 }

--- a/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceResource.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/resource/ServiceResource.java
@@ -154,8 +154,8 @@ public class ServiceResource {
     }
 
     @GetMapping("/{" + PATH_VARIABLE_SHORT_NAME + "}/{" + PATH_VARIABLE_VERSION + "}" + "/status")
-    public ResponseEntity<Resources<Resource<MicoServiceStatusResponseDTO>>> getStatusOfServiceInstance(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
-                                                                                                        @PathVariable(PATH_VARIABLE_VERSION) String version) {
+    public ResponseEntity<Resources<Resource<MicoServiceStatusResponseDTO>>> getStatusListOfService(@PathVariable(PATH_VARIABLE_SHORT_NAME) String shortName,
+                                                                                                    @PathVariable(PATH_VARIABLE_VERSION) String version) {
         MicoService micoService = getServiceFromMicoServiceBroker(shortName, version);
 
         List<MicoServiceStatusResponseDTO> micoServiceStatusList = micoStatusService.getServiceStatus(micoService);

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoKubernetesClient.java
@@ -575,7 +575,7 @@ public class MicoKubernetesClient {
                 message = "The Kubernetes deployment information for MicoService '"
                     + micoService.getShortName() + "' '" + micoService.getVersion()
                     + "' with instance ID '" + micoServiceInstanceId + "' is not available.";
-                log.warn(message);
+                log.debug(message);
                 messages.add(MicoMessage.error(message));
                 applicationDeploymentStatus = Value.INCOMPLETE;
             } else {

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -97,7 +97,7 @@ public class MicoStatusService {
             requestedReplicasCount += micoServiceStatus.getRequestedReplicas();
             availableReplicasCount += micoServiceStatus.getAvailableReplicas();
             // Remove the current application's name to retrieve a list with only the names of other applications that are sharing a service
-            micoServiceStatus.getApplicationsUsingThisService().removeIf(a ->
+            micoServiceStatus.getOtherApplicationsUsingThisServiceInstance().removeIf(a ->
                 a.getShortName().equals(micoApplication.getShortName()) &&
                     a.getVersion().equals(micoApplication.getVersion()));
             applicationStatus.getServiceStatuses().add(micoServiceStatus);
@@ -189,7 +189,7 @@ public class MicoStatusService {
         for (MicoApplication application : usingApplications) {
             if (micoKubernetesClient.isApplicationDeployed(application)) {
                 MicoApplicationDeploymentStatus applicationDeploymentStatus = micoKubernetesClient.getApplicationDeploymentStatus(application);
-                serviceStatus.getApplicationsUsingThisService().add(new MicoApplicationResponseDTO(application, applicationDeploymentStatus));
+                serviceStatus.getOtherApplicationsUsingThisServiceInstance().add(new MicoApplicationResponseDTO(application, applicationDeploymentStatus));
             }
         }
 

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -29,12 +29,9 @@ import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
 import io.github.ust.mico.core.dto.response.status.*;
 import io.github.ust.mico.core.exception.KubernetesResourceException;
 import io.github.ust.mico.core.exception.PrometheusRequestFailedException;
-import io.github.ust.mico.core.model.MicoApplication;
-import io.github.ust.mico.core.model.MicoMessage;
-import io.github.ust.mico.core.model.MicoService;
-import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.model.*;
 import io.github.ust.mico.core.persistence.MicoApplicationRepository;
-import io.github.ust.mico.core.persistence.MicoServiceRepository;
+import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
 import io.github.ust.mico.core.util.CollectionUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,17 +60,17 @@ public class MicoStatusService {
     private final PrometheusConfig prometheusConfig;
     private final MicoKubernetesClient micoKubernetesClient;
     private final RestTemplate restTemplate;
-    private final MicoServiceRepository serviceRepository;
+    private final MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
     private final MicoApplicationRepository micoApplicationRepository;
 
     @Autowired
     public MicoStatusService(PrometheusConfig prometheusConfig, MicoKubernetesClient micoKubernetesClient,
-                             RestTemplate restTemplate, MicoServiceRepository serviceRepository,
+                             RestTemplate restTemplate, MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository,
                              MicoApplicationRepository micoApplicationRepository) {
         this.prometheusConfig = prometheusConfig;
         this.micoKubernetesClient = micoKubernetesClient;
         this.restTemplate = restTemplate;
-        this.serviceRepository = serviceRepository;
+        this.serviceDeploymentInfoRepository = serviceDeploymentInfoRepository;
         this.micoApplicationRepository = micoApplicationRepository;
     }
 
@@ -86,13 +83,16 @@ public class MicoStatusService {
      */
     public MicoApplicationStatusResponseDTO getApplicationStatus(MicoApplication micoApplication) {
         MicoApplicationStatusResponseDTO applicationStatus = new MicoApplicationStatusResponseDTO();
-        List<MicoService> micoServices = serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion());
+        List<MicoServiceDeploymentInfo> serviceDeploymentInfos = new ArrayList<>();
+        serviceDeploymentInfos.addAll(micoApplication.getServiceDeploymentInfos());
+        serviceDeploymentInfos.addAll(micoApplication.getKafkaFaasConnectorDeploymentInfos());
+
         int podCount = 0;
         int requestedReplicasCount = 0;
         int availableReplicasCount = 0;
 
-        for (MicoService micoService : micoServices) {
-            MicoServiceStatusResponseDTO micoServiceStatus = getServiceStatus(micoService);
+        for (MicoServiceDeploymentInfo serviceDeploymentInfo : serviceDeploymentInfos) {
+            MicoServiceStatusResponseDTO micoServiceStatus = getServiceInstanceStatus(serviceDeploymentInfo);
             podCount += micoServiceStatus.getPodsInformation().size();
             requestedReplicasCount += micoServiceStatus.getRequestedReplicas();
             availableReplicasCount += micoServiceStatus.getAvailableReplicas();
@@ -103,7 +103,7 @@ public class MicoStatusService {
             applicationStatus.getServiceStatuses().add(micoServiceStatus);
         }
         applicationStatus
-            .setTotalNumberOfMicoServices(micoServices.size())
+            .setTotalNumberOfMicoServices(micoApplication.getServiceDeploymentInfos().size())
             .setTotalNumberOfKafkaFaasConnectors(micoApplication.getKafkaFaasConnectorDeploymentInfos().size())
             .setTotalNumberOfPods(podCount)
             .setTotalNumberOfAvailableReplicas(availableReplicasCount)
@@ -112,42 +112,45 @@ public class MicoStatusService {
     }
 
     /**
-     * Get status information for a single {@link MicoService}: # available replicas, # requested replicas, pod metrics
+     * Get status information for a single {@link MicoServiceDeploymentInfo}: # available replicas, # requested replicas, pod metrics
      * (CPU load, memory usage).
      *
-     * @param micoService is a {@link MicoService}.
+     * @param serviceDeploymentInfo the {@link MicoServiceDeploymentInfo}.
      * @return {@link MicoServiceStatusResponseDTO} which contains status information for a specific {@link
      * MicoService}.
      */
-    public MicoServiceStatusResponseDTO getServiceStatus(MicoService micoService) {
+    public MicoServiceStatusResponseDTO getServiceInstanceStatus(MicoServiceDeploymentInfo serviceDeploymentInfo) {
+        MicoService micoService = serviceDeploymentInfo.getService();
+        String instanceId = serviceDeploymentInfo.getInstanceId();
         MicoServiceStatusResponseDTO serviceStatus = new MicoServiceStatusResponseDTO()
             .setShortName(micoService.getShortName())
             .setVersion(micoService.getVersion())
-            .setName(micoService.getName());
+            .setName(micoService.getName())
+            .setInstanceId(instanceId);
 
         String message;
-        List<Deployment> deployments = micoKubernetesClient.getDeploymentsOfMicoService(micoService);
-        if (deployments.size() > 1) {
-            throw new IllegalStateException("Currently MICO doesn't support multiple instance deployments.");
-        } else if (deployments.size() == 1) {
-            Deployment deployment = deployments.get(0);
+        Optional<Deployment> deploymentOptional = micoKubernetesClient.getDeploymentOfMicoServiceInstance(serviceDeploymentInfo);
+        if (deploymentOptional.isPresent()) {
+            Deployment deployment = deploymentOptional.get();
             serviceStatus.setRequestedReplicas(deployment.getSpec().getReplicas());
             // Check if there are no replicas available of the deployment of a MicoService.
             if (deployment.getStatus().getUnavailableReplicas() == null) {
-                log.info("The MicoService '{}' with version '{}' has '{}' available replicas.",
-                    micoService.getShortName(), micoService.getVersion(), deployment.getStatus().getAvailableReplicas());
+                log.info("The MicoService '{}' '{}' with instance ID '{}' has '{}' available replicas.",
+                    micoService.getShortName(), micoService.getVersion(), instanceId, deployment.getStatus().getAvailableReplicas());
                 serviceStatus.setAvailableReplicas(deployment.getStatus().getAvailableReplicas());
             } else if ((deployment.getStatus().getUnavailableReplicas() != null) &&
                 deployment.getStatus().getUnavailableReplicas() < deployment.getSpec().getReplicas()) {
-                log.info("The MicoService '{}' with version '{}' has '{}' available replicas.",
-                    micoService.getShortName(), micoService.getVersion(), deployment.getStatus().getAvailableReplicas());
+                log.info("The MicoService '{}' '{}' with instance ID '{}' has '{}' available replicas.",
+                    micoService.getShortName(), micoService.getVersion(), instanceId, deployment.getStatus().getAvailableReplicas());
                 serviceStatus.setAvailableReplicas(deployment.getStatus().getAvailableReplicas());
             } else {
-                log.info("The MicoService '{}' with version '{}' has no available replicas.", micoService.getShortName(), micoService.getVersion());
+                log.info("The MicoService '{}' '{}' with instance ID '{}' has no available replicas.",
+                    micoService.getShortName(), micoService.getVersion(), instanceId);
                 serviceStatus.setAvailableReplicas(0);
             }
         } else {
-            message = "No deployment of MicoService '" + micoService.getShortName() + "' '" + micoService.getVersion() + "' is available.";
+            message = "No deployment of MicoService '" + micoService.getShortName() + "' '" + micoService.getVersion() +
+                "' with instance ID '" + instanceId + "' is available.";
             log.warn(message);
             MicoMessage errorMessage = MicoMessage.error(message);
             return serviceStatus.setErrorMessages(CollectionUtils.listOf(new MicoMessageResponseDTO(errorMessage)));
@@ -156,14 +159,14 @@ public class MicoStatusService {
         // Get status information for the service interfaces of this service,
         // if there are any errors, add them to the service status
         List<MicoMessageResponseDTO> errorMessages = new ArrayList<>();
-        List<MicoServiceInterfaceStatusResponseDTO> interfacesInformation = getServiceInterfaceStatus(micoService, errorMessages);
+        List<MicoServiceInterfaceStatusResponseDTO> interfacesInformation = getServiceInterfaceStatus(serviceDeploymentInfo, errorMessages);
         serviceStatus.setInterfacesInformation(interfacesInformation);
         if (!errorMessages.isEmpty()) {
             serviceStatus.getErrorMessages().addAll(errorMessages);
         }
 
         // Return all applications that are using this service and are actually deployed
-        List<MicoApplication> usingApplications = micoApplicationRepository.findAllByUsedService(micoService.getShortName(), micoService.getVersion());
+        List<MicoApplication> usingApplications = micoApplicationRepository.findAllByUsedServiceInstance(instanceId);
         for (MicoApplication application : usingApplications) {
             if (micoKubernetesClient.isApplicationDeployed(application)) {
                 serviceStatus.getApplicationsUsingThisService().add(new MicoApplicationResponseDTO(application));
@@ -171,7 +174,7 @@ public class MicoStatusService {
         }
 
         // Get status information for all pods of a service
-        List<Pod> podList = micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(micoService);
+        List<Pod> podList = micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(serviceDeploymentInfo);
         List<KubernetesPodInformationResponseDTO> podInfos = new ArrayList<>();
         // Get all the nodes on which the pods of a deployment of a MicoService are running
         Map<String, List<Pod>> podsPerNode = new HashMap<>();
@@ -209,7 +212,7 @@ public class MicoStatusService {
                 averageMemoryUsage = sumMemoryUsageOnNode / sumRunningPods;
             } else {
                 message = "There are no Pods running on node '" + nodeName + "' for MICO service '"
-                    + micoService.getShortName() + "' '" + micoService.getVersion() + "'.";
+                    + micoService.getShortName() + "' '" + micoService.getVersion() + "' with instance ID '" + instanceId + "'.";
                 log.warn(message);
                 MicoMessage warning = MicoMessage.warning(message);
                 serviceStatus.getErrorMessages().add(new MicoMessageResponseDTO(warning));
@@ -229,18 +232,18 @@ public class MicoStatusService {
      * Get the status information for all {@link MicoServiceInterface MicoServiceInterfaces} of the {@link
      * MicoService}.
      *
-     * @param micoService   is the {@link MicoService} for which the status information of the MicoServiceInterfaces is
-     *                      requested.
-     * @param errorMessages is the list of error messages, which is empty if no error occurs.
+     * @param serviceDeploymentInfo is the {@link MicoServiceDeploymentInfo} that includes the service
+     *                              for which the status information of the MicoServiceInterfaces is requested.
+     * @param errorMessages         is the list of error messages, which is empty if no error occurs.
      * @return a list of {@link MicoServiceInterfaceStatusResponseDTO}, one DTO per MicoServiceInterface.
      */
-    public List<MicoServiceInterfaceStatusResponseDTO> getServiceInterfaceStatus(@NotNull MicoService micoService,
+    public List<MicoServiceInterfaceStatusResponseDTO> getServiceInterfaceStatus(@NotNull MicoServiceDeploymentInfo serviceDeploymentInfo,
                                                                                  @NotNull List<MicoMessageResponseDTO> errorMessages) {
         List<MicoServiceInterfaceStatusResponseDTO> interfacesInformation = new ArrayList<>();
-        for (MicoServiceInterface serviceInterface : micoService.getServiceInterfaces()) {
+        for (MicoServiceInterface serviceInterface : serviceDeploymentInfo.getService().getServiceInterfaces()) {
             String serviceInterfaceName = serviceInterface.getServiceInterfaceName();
             try {
-                MicoServiceInterfaceStatusResponseDTO interfaceStatusResponseDTO = getPublicIpOfKubernetesService(micoService, serviceInterface);
+                MicoServiceInterfaceStatusResponseDTO interfaceStatusResponseDTO = getPublicIpOfKubernetesService(serviceDeploymentInfo, serviceInterface);
                 interfacesInformation.add(interfaceStatusResponseDTO);
             } catch (KubernetesResourceException e) {
                 interfacesInformation.add(new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName));
@@ -253,16 +256,17 @@ public class MicoStatusService {
     /**
      * Get the public IP of a {@link MicoServiceInterface} by providing the corresponding Kubernetes {@link Service}.
      *
-     * @param micoService      is the {@link MicoService}, that has a {@link MicoServiceInterface}, which is
-     *                         deployed on Kubernetes
-     * @param serviceInterface the {@link MicoServiceInterface}, that is deployed as a Kubernetes service
+     * @param serviceDeploymentInfo is the {@link MicoServiceDeploymentInfo}, that has a {@link MicoServiceInterface}, which is
+     *                              deployed on Kubernetes
+     * @param serviceInterface      the {@link MicoServiceInterface}, that is deployed as a Kubernetes service
      * @return the  public IP of the provided Kubernetes Service
      * @throws KubernetesResourceException if it's not possible to get the Kubernetes service
      */
-    public MicoServiceInterfaceStatusResponseDTO getPublicIpOfKubernetesService(MicoService micoService, MicoServiceInterface serviceInterface) throws KubernetesResourceException {
+    public MicoServiceInterfaceStatusResponseDTO getPublicIpOfKubernetesService(MicoServiceDeploymentInfo serviceDeploymentInfo, MicoServiceInterface serviceInterface) throws KubernetesResourceException {
+        MicoService micoService = serviceDeploymentInfo.getService();
         String serviceInterfaceName = serviceInterface.getServiceInterfaceName();
 
-        Optional<Service> kubernetesServiceOptional = micoKubernetesClient.getInterfaceByNameOfMicoService(micoService, serviceInterfaceName);
+        Optional<Service> kubernetesServiceOptional = micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(serviceDeploymentInfo, serviceInterfaceName);
         if (!kubernetesServiceOptional.isPresent()) {
             log.warn("There is no Kubernetes service deployed for MicoServiceInterface with name '{}' of MicoService '{}' in version '{}'.",
                 serviceInterfaceName, micoService.getShortName(), micoService.getVersion());

--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -112,12 +112,31 @@ public class MicoStatusService {
     }
 
     /**
+     * Get status information for all instances of a {@link MicoService} and return them as a list:
+     * # available replicas, # requested replicas, pod metrics (CPU load, memory usage).
+     *
+     * @param micoService the {@link MicoService}.
+     * @return the list of {@link MicoServiceStatusResponseDTO MicoServiceStatusResponseDTOs}
+     * which contains status information for all instances of a {@link MicoService}.
+     */
+    public List<MicoServiceStatusResponseDTO> getServiceStatus(MicoService micoService) {
+        List<MicoServiceDeploymentInfo> serviceDeploymentInfos = serviceDeploymentInfoRepository.findAllByService(
+            micoService.getShortName(), micoService.getVersion());
+        List<MicoServiceStatusResponseDTO> responseDTOList = new ArrayList<>();
+        for (MicoServiceDeploymentInfo serviceDeploymentInfo : serviceDeploymentInfos) {
+            MicoServiceStatusResponseDTO serviceInstanceStatus = getServiceInstanceStatus(serviceDeploymentInfo);
+            responseDTOList.add(serviceInstanceStatus);
+        }
+        return responseDTOList;
+    }
+
+    /**
      * Get status information for a single {@link MicoServiceDeploymentInfo}: # available replicas, # requested replicas, pod metrics
      * (CPU load, memory usage).
      *
      * @param serviceDeploymentInfo the {@link MicoServiceDeploymentInfo}.
-     * @return {@link MicoServiceStatusResponseDTO} which contains status information for a specific {@link
-     * MicoService}.
+     * @return the {@link MicoServiceStatusResponseDTO} which contains status information
+     * for a specific instance of a {@link MicoService}.
      */
     public MicoServiceStatusResponseDTO getServiceInstanceStatus(MicoServiceDeploymentInfo serviceDeploymentInfo) {
         MicoService micoService = serviceDeploymentInfo.getService();

--- a/mico-core/src/main/resources/application-dev.properties
+++ b/mico-core/src/main/resources/application-dev.properties
@@ -36,7 +36,7 @@ kubernetes.build-bot.docker-image-repository-url=docker.io/ustmico
 kubernetes.build-bot.docker-registry-service-account-name=build-bot-dockerhub
 kubernetes.build-bot.kaniko-executor-image-url=gcr.io/kaniko-project/executor
 kubernetes.build-bot.build-timeout=600
-kubernetes.build-bot.build-clean-up-by-undeploy=true
+kubernetes.build-bot.build-clean-up-by-undeploy=false
 
 # Prometheus
 kubernetes.prometheus.uri=http://localhost:9090/api/v1/query

--- a/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ApplicationResourceIntegrationTests.java
@@ -835,7 +835,7 @@ public class ApplicationResourceIntegrationTests {
             .setVersion(SERVICE_VERSION)
             .setAvailableReplicas(availableReplicas)
             .setRequestedReplicas(replicas)
-            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+            .setOtherApplicationsUsingThisServiceInstance(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
             .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2))
             .setNodeMetrics(CollectionUtils.listOf(

--- a/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceIntegrationTests.java
@@ -23,13 +23,11 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.github.ust.mico.core.broker.MicoApplicationBroker;
 import io.github.ust.mico.core.broker.MicoServiceBroker;
+import io.github.ust.mico.core.broker.MicoServiceDeploymentInfoBroker;
 import io.github.ust.mico.core.configuration.KafkaFaasConnectorConfig;
 import io.github.ust.mico.core.configuration.MicoKubernetesBuildBotConfig;
 import io.github.ust.mico.core.model.*;
-import io.github.ust.mico.core.persistence.MicoApplicationRepository;
-import io.github.ust.mico.core.persistence.MicoBackgroundJobRepository;
-import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
-import io.github.ust.mico.core.persistence.MicoTopicRepository;
+import io.github.ust.mico.core.persistence.*;
 import io.github.ust.mico.core.service.imagebuilder.ImageBuilder;
 import io.github.ust.mico.core.util.CollectionUtils;
 import io.github.ust.mico.core.util.EmbeddedRedisServer;
@@ -91,10 +89,13 @@ public class DeploymentResourceIntegrationTests {
     private MicoApplicationRepository applicationRepository;
 
     @Autowired
-    private MicoTopicRepository micoTopicRepository;
+    private MicoServiceRepository serviceRepository;
 
     @Autowired
     private MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
+
+    @Autowired
+    private MicoTopicRepository micoTopicRepository;
 
     @Autowired
     private MicoBackgroundJobRepository jobRepository;
@@ -104,6 +105,9 @@ public class DeploymentResourceIntegrationTests {
 
     @Autowired
     private MicoServiceBroker serviceBroker;
+
+    @Autowired
+    private MicoServiceDeploymentInfoBroker serviceDeploymentInfoBroker;
 
     @Autowired
     KafkaFaasConnectorConfig kafkaFaasConnectorConfig;
@@ -146,6 +150,11 @@ public class DeploymentResourceIntegrationTests {
 
         // Delete all jobs in Redis.
         jobRepository.deleteAll();
+        // Delete all entities that were added during the test execution
+        serviceDeploymentInfoRepository.deleteAllByApplication(application.getShortName(), application.getVersion());
+        serviceDeploymentInfoBroker.cleanUpTanglingNodes();
+        serviceRepository.deleteServiceByShortNameAndVersion(service.getShortName(), service.getVersion());
+        applicationRepository.delete(application);
     }
 
     @Test

--- a/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/DeploymentResourceIntegrationTests.java
@@ -261,7 +261,7 @@ public class DeploymentResourceIntegrationTests {
 
     private CompletableFuture<Service> waitForServiceCreation() throws InterruptedException, ExecutionException, TimeoutException {
         CompletableFuture<Service> createdService = integrationTestsUtils.waitUntilServiceIsCreated(
-            service, 1, 1, 10);
+            serviceDeploymentInfo, 1, 1, 10);
         assertNotNull("Kubernetes Service was not created!", createdService.get());
         log.debug("Created Kubernetes Service: {}", createdService.get().toString());
         return createdService;

--- a/mico-core/src/test/java/io/github/ust/mico/core/IntegrationTestsUtils.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/IntegrationTestsUtils.java
@@ -247,7 +247,7 @@ public class IntegrationTestsUtils {
         CompletableFuture<Deployment> completionFuture = new CompletableFuture<>();
 
         MicoService micoService = serviceDeploymentInfo.getService();
-        log.info("Wait until deployment of MicoService '{}' '{}' with instance id '{}' is created",
+        log.info("Wait until deployment of MicoService '{}' '{}' with instance ID '{}' is created",
             micoService.getShortName(), micoService.getVersion(), serviceDeploymentInfo.getInstanceId());
         ScheduledFuture<?> scheduledFuture = executorService.scheduleAtFixedRate(() -> {
             Optional<Deployment> deployment = micoKubernetesClient.getDeploymentOfMicoServiceInstance(serviceDeploymentInfo);
@@ -264,7 +264,7 @@ public class IntegrationTestsUtils {
     /**
      * Create a future that polls the deployment until it is created.
      *
-     * @param micoService  the {@link MicoService}
+     * @param serviceDeploymentInfo  the {@link MicoServiceDeploymentInfo}
      * @param initialDelay the initial delay in seconds
      * @param period       the period in seconds
      * @param timeout      the timeout in seconds
@@ -273,12 +273,16 @@ public class IntegrationTestsUtils {
      * @throws TimeoutException     if the build does not finish or fail in the expected time
      * @throws ExecutionException   if the build process fails unexpectedly
      */
-    CompletableFuture<Service> waitUntilServiceIsCreated(MicoService micoService, int initialDelay, int period, int timeout) throws InterruptedException, ExecutionException, TimeoutException {
+    CompletableFuture<Service> waitUntilServiceIsCreated(MicoServiceDeploymentInfo serviceDeploymentInfo, int initialDelay, int period, int timeout) throws InterruptedException, ExecutionException, TimeoutException {
+        String instanceId = serviceDeploymentInfo.getInstanceId();
+        MicoService micoService = serviceDeploymentInfo.getService();
+
         CompletableFuture<Service> completionFuture = new CompletableFuture<>();
 
-        log.info("Wait until Kubernetes Service for MicoService '{}' '{}' is created", micoService.getShortName(), micoService.getVersion());
+        log.info("Wait until Kubernetes Service for MicoService '{}' '{}' with instanceId  '{}' is created.",
+            micoService.getShortName(), micoService.getVersion(), instanceId);
         ScheduledFuture<?> scheduledFuture = executorService.scheduleAtFixedRate(() -> {
-            List<Service> services = micoKubernetesClient.getInterfacesOfMicoService(micoService);
+            List<Service> services = micoKubernetesClient.getInterfacesOfMicoServiceInstance(serviceDeploymentInfo);
             if (!services.isEmpty()) {
                 completionFuture.complete(services.get(0));
             }

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoKubernetesClientTests.java
@@ -629,6 +629,7 @@ public class MicoKubernetesClientTests {
             .setServices(CollectionUtils.listOf(micoService))
             .setServiceDeploymentInfos(CollectionUtils.listOf(serviceDeploymentInfo3));
 
+        // Each MICO application uses a different instance of the same MICO service
         given(serviceDeploymentInfoRepository.findByApplicationAndService(
             micoApplication1.getShortName(), micoApplication1.getVersion(), micoService.getShortName(), micoService.getVersion()))
             .willReturn(CollectionUtils.listOf(serviceDeploymentInfo1));

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -260,12 +260,14 @@ public class MicoStatusServiceTest {
             .setTotalNumberOfKafkaFaasConnectors(1)
             .setServiceStatuses(CollectionUtils.listOf(
                 new MicoServiceStatusResponseDTO()
-                    .setName(NAME)
-                    .setShortName(SHORT_NAME)
-                    .setVersion(VERSION)
-                    .setAvailableReplicas(1)
-                    .setRequestedReplicas(1)
-                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+                    .setName(micoService.getName())
+                    .setShortName(micoService.getShortName())
+                    .setVersion(micoService.getVersion())
+                    .setInstanceId(micoServiceDeploymentInfo.getInstanceId())
+                    .setAvailableReplicas(micoServiceDeploymentInfo.getReplicas())
+                    .setRequestedReplicas(micoServiceDeploymentInfo.getReplicas())
+                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                        new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
                             .setNodeName(nodeName1)
@@ -513,12 +515,14 @@ public class MicoStatusServiceTest {
     public void getServiceStatus() throws Exception {
         MicoServiceStatusResponseDTO micoServiceStatus = new MicoServiceStatusResponseDTO();
         micoServiceStatus
-            .setName(NAME)
-            .setShortName(SHORT_NAME)
-            .setVersion(VERSION)
-            .setAvailableReplicas(1)
-            .setRequestedReplicas(1)
-            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+            .setName(micoService.getName())
+            .setShortName(micoService.getShortName())
+            .setVersion(micoService.getVersion())
+            .setInstanceId(micoServiceDeploymentInfo.getInstanceId())
+            .setAvailableReplicas(micoServiceDeploymentInfo.getReplicas())
+            .setRequestedReplicas(micoServiceDeploymentInfo.getReplicas())
+            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
             .setNodeMetrics(CollectionUtils.listOf(
                 new KubernetesNodeMetricsResponseDTO()
                     .setNodeName(nodeName1)

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -85,9 +85,8 @@ public class MicoStatusServiceTest {
     private MicoApplication micoApplication;
     private MicoApplication otherMicoApplication;
     private MicoService micoService;
-    private MicoService kfConnectorService;
+    private MicoServiceDeploymentInfo micoServiceDeploymentInfo;
     private MicoServiceInterface micoServiceInterface;
-    private Deployment deployment;
     private Service kubernetesService;
     private PodList podList;
     private PodList podListWithOnePod;
@@ -122,7 +121,15 @@ public class MicoStatusServiceTest {
     private String startTimePod4 = new Date().toString();
     private int restartsPod4 = 0;
 
-    private String kfConnectorName = "kafka-faas-connector";
+    // KafkaFaasConnector
+    private MicoService kfConnectorService;
+    private MicoServiceDeploymentInfo kfConnectorDeploymentInfo;
+    private PodList kfConnectorPodList;
+    private String podName5 = "pod5";
+    private String startTimePod5 = new Date().toString();
+    private int restartsPod5 = 0;
+    private int memoryUsagePod5 = 5;
+    private int cpuLoadPod5 = 5;
 
     @Before
     public void setupMicoApplication() {
@@ -147,30 +154,15 @@ public class MicoStatusServiceTest {
                 .setTargetPort(8080)
                 .setType(MicoPortType.TCP)));
         micoService.setServiceInterfaces(CollectionUtils.listOf(micoServiceInterface));
-        kfConnectorService = new MicoService()
-            .setName(kfConnectorName)
-            .setShortName(kfConnectorName)
-            .setVersion(VERSION);
         micoApplication.getServices().add(micoService);
-        micoApplication.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo()
+        micoServiceDeploymentInfo = new MicoServiceDeploymentInfo()
             .setService(micoService)
-            .setInstanceId(INSTANCE_ID));
-        micoApplication.getKafkaFaasConnectorDeploymentInfos().add(new MicoServiceDeploymentInfo()
-            .setService(kfConnectorService)
-            .setInstanceId(INSTANCE_ID_1));
+            .setInstanceId(INSTANCE_ID)
+            .setReplicas(4);
+        micoApplication.getServiceDeploymentInfos().add(micoServiceDeploymentInfo);
+
         otherMicoApplication.getServices().add(micoService);
-        otherMicoApplication.getServiceDeploymentInfos().add(new MicoServiceDeploymentInfo()
-            .setService(micoService)
-            .setInstanceId(INSTANCE_ID_2));
-
-        int availableReplicas = 1;
-        int replicas = 1;
-
-        String deploymentName = "deployment1";
-        deployment = new DeploymentBuilder()
-            .withNewMetadata().withName(deploymentName).endMetadata()
-            .withNewSpec().withReplicas(replicas).endSpec().withNewStatus().withAvailableReplicas(availableReplicas).endStatus()
-            .build();
+        otherMicoApplication.getServiceDeploymentInfos().add(micoServiceDeploymentInfo);
 
         kubernetesService = new ServiceBuilder()
             .withNewMetadata().withName(SERVICE_INTERFACE_NAME).withNamespace(testNamespace).endMetadata()
@@ -229,15 +221,41 @@ public class MicoStatusServiceTest {
             .withNewStatus().withStartTime(startTimePod1).addNewContainerStatus().withRestartCount(restartsPod1).endContainerStatus().withPhase(POD_PHASE_RUNNING).withHostIP(hostIp).endStatus()
             .endItem()
             .build();
+
+        String kfConnectorName = "kafka-faas-connector";
+        kfConnectorService = new MicoService()
+            .setName(kfConnectorName)
+            .setShortName(kfConnectorName)
+            .setVersion(VERSION);
+        kfConnectorDeploymentInfo = new MicoServiceDeploymentInfo()
+            .setService(kfConnectorService)
+            .setInstanceId(INSTANCE_ID_1)
+            .setReplicas(1);
+        kfConnectorPodList = new PodListBuilder()
+            .addNewItem()
+            .withNewMetadata().withName(podName5).endMetadata()
+            .withNewSpec().withNodeName(nodeName1).endSpec()
+            .withNewStatus().withStartTime(startTimePod5)
+            .addNewContainerStatus().withRestartCount(restartsPod5).endContainerStatus()
+            .withPhase(POD_PHASE_RUNNING)
+            .withHostIP(hostIp)
+            .endStatus()
+            .endItem()
+            .build();
+
     }
 
     @Test
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void getApplicationStatus() throws Exception {
+
+        // With KafkaFaasConnector
+        micoApplication.getKafkaFaasConnectorDeploymentInfos().add(kfConnectorDeploymentInfo);
+
         MicoApplicationStatusResponseDTO micoApplicationStatus = new MicoApplicationStatusResponseDTO()
-            .setTotalNumberOfRequestedReplicas(1)
-            .setTotalNumberOfAvailableReplicas(1)
-            .setTotalNumberOfPods(4)
+            .setTotalNumberOfRequestedReplicas(5)
+            .setTotalNumberOfAvailableReplicas(5)
+            .setTotalNumberOfPods(5)
             .setTotalNumberOfMicoServices(1)
             .setTotalNumberOfKafkaFaasConnectors(1)
             .setServiceStatuses(CollectionUtils.listOf(
@@ -245,8 +263,9 @@ public class MicoStatusServiceTest {
                     .setName(NAME)
                     .setShortName(SHORT_NAME)
                     .setVersion(VERSION)
-                    .setAvailableReplicas(1)
-                    .setRequestedReplicas(1)
+                    .setInstanceId(INSTANCE_ID)
+                    .setAvailableReplicas(4)
+                    .setRequestedReplicas(4)
                     .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
@@ -303,13 +322,53 @@ public class MicoStatusServiceTest {
                             .setName(SERVICE_INTERFACE_NAME)
                             .setExternalIpIsAvailable(true)
                             .setExternalIp("192.168.2.112")
-                            .setPort(8080)))));
-        given(micoKubernetesClient.getDeploymentsOfMicoService(any(MicoService.class))).willReturn(CollectionUtils.listOf(deployment));
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
-        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podList.getItems());
+                            .setPort(8080))),
+                new MicoServiceStatusResponseDTO()
+                    .setName(kfConnectorService.getName())
+                    .setShortName(kfConnectorService.getShortName())
+                    .setVersion(kfConnectorService.getVersion())
+                    .setInstanceId(kfConnectorDeploymentInfo.getInstanceId())
+                    .setAvailableReplicas(1)
+                    .setRequestedReplicas(1)
+                    .setApplicationsUsingThisService(new ArrayList<>())
+                    .setNodeMetrics(CollectionUtils.listOf(
+                        new KubernetesNodeMetricsResponseDTO()
+                            .setNodeName(nodeName1)
+                            .setAverageCpuLoad(5)
+                            .setAverageMemoryUsage(5)
+                    ))
+                    // Add four pods (on two different nodes)
+                    .setPodsInformation(Collections.singletonList(
+                        new KubernetesPodInformationResponseDTO()
+                            .setPodName(podName5)
+                            .setHostIp(hostIp)
+                            .setNodeName(nodeName1)
+                            .setPhase(POD_PHASE_RUNNING)
+                            .setStartTime(startTimePod5)
+                            .setRestarts(restartsPod5)
+                            .setMetrics(new KubernetesPodMetricsResponseDTO()
+                                .setMemoryUsage(memoryUsagePod5)
+                                .setCpuLoad(cpuLoadPod5))))
+                    .setErrorMessages(CollectionUtils.listOf())
+                    .setInterfacesInformation(new ArrayList<>())));
+        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(eq(micoServiceDeploymentInfo))).willReturn(podList.getItems());
+        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(eq(kfConnectorDeploymentInfo))).willReturn(kfConnectorPodList.getItems());
+        Deployment deployment = new DeploymentBuilder()
+            .withNewMetadata().withName("deployment1").endMetadata()
+            .withNewSpec().withReplicas(podList.getItems().size()).endSpec()
+            .withNewStatus().withAvailableReplicas(podList.getItems().size()).endStatus()
+            .build();
+        Deployment deploymentKfConnector = new DeploymentBuilder()
+            .withNewMetadata().withName("kf-connector-deployment").endMetadata()
+            .withNewSpec().withReplicas(kfConnectorPodList.getItems().size()).endSpec()
+            .withNewStatus().withAvailableReplicas(kfConnectorPodList.getItems().size()).endStatus()
+            .build();
+        given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(eq(micoServiceDeploymentInfo))).willReturn(Optional.of(deployment));
+        given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(eq(kfConnectorDeploymentInfo))).willReturn(Optional.of(deploymentKfConnector));
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(eq(micoServiceDeploymentInfo), anyString())).willReturn(Optional.ofNullable(kubernetesService));
         given(micoKubernetesClient.isApplicationDeployed(otherMicoApplication)).willReturn(true);
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
-        given(applicationRepository.findAllByUsedService(any(), any())).willReturn(CollectionUtils.listOf(otherMicoApplication, micoApplication));
+        given(applicationRepository.findAllByUsedServiceInstance(INSTANCE_ID)).willReturn(CollectionUtils.listOf(otherMicoApplication, micoApplication));
         given(serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion())).willReturn(CollectionUtils.listOf(micoService));
         given(prometheusConfig.getUri()).willReturn("http://localhost:9090/api/v1/query");
         given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.of(micoServiceInterface));
@@ -328,6 +387,8 @@ public class MicoStatusServiceTest {
         ResponseEntity responseEntityCpuLoadPod3 = getPrometheusResponseEntity(cpuLoadPod3);
         ResponseEntity responseEntityMemoryUsagePod4 = getPrometheusResponseEntity(memoryUsagePod4);
         ResponseEntity responseEntityCpuLoadPod4 = getPrometheusResponseEntity(cpuLoadPod4);
+        ResponseEntity responseEntityMemoryUsagePod5 = getPrometheusResponseEntity(memoryUsagePod5);
+        ResponseEntity responseEntityCpuLoadPod5 = getPrometheusResponseEntity(cpuLoadPod5);
         given(restTemplate.getForEntity(any(), eq(PrometheusResponseDTO.class))).
             willReturn(responseEntityMemoryUsagePod1)
             .willReturn(responseEntityCpuLoadPod1)
@@ -336,7 +397,9 @@ public class MicoStatusServiceTest {
             .willReturn(responseEntityMemoryUsagePod3)
             .willReturn(responseEntityCpuLoadPod3)
             .willReturn(responseEntityMemoryUsagePod4)
-            .willReturn(responseEntityCpuLoadPod4);
+            .willReturn(responseEntityCpuLoadPod4)
+            .willReturn(responseEntityMemoryUsagePod5)
+            .willReturn(responseEntityCpuLoadPod5);
         assertEquals(micoApplicationStatus, micoStatusService.getApplicationStatus(micoApplication));
     }
 
@@ -349,12 +412,13 @@ public class MicoStatusServiceTest {
             .setTotalNumberOfAvailableReplicas(1)
             .setTotalNumberOfPods(1)
             .setTotalNumberOfMicoServices(1)
-            .setTotalNumberOfKafkaFaasConnectors(1)
+            .setTotalNumberOfKafkaFaasConnectors(0)
             .setServiceStatuses(CollectionUtils.listOf(
                 new MicoServiceStatusResponseDTO()
                     .setName(NAME)
                     .setShortName(SHORT_NAME)
                     .setVersion(VERSION)
+                    .setInstanceId(INSTANCE_ID)
                     .setAvailableReplicas(1)
                     .setRequestedReplicas(1)
                     .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
@@ -381,13 +445,18 @@ public class MicoStatusServiceTest {
                     .setInterfacesInformation(CollectionUtils.listOf(
                         new MicoServiceInterfaceStatusResponseDTO()
                             .setName(SERVICE_INTERFACE_NAME))))); // No IPs
-        given(micoKubernetesClient.getDeploymentsOfMicoService(any(MicoService.class))).willReturn(CollectionUtils.listOf(deployment));
+        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(podListWithOnePod.getItems());
+        Deployment deployment = new DeploymentBuilder()
+            .withNewMetadata().withName("deployment1").endMetadata()
+            .withNewSpec().withReplicas(podListWithOnePod.getItems().size()).endSpec()
+            .withNewStatus().withAvailableReplicas(podListWithOnePod.getItems().size()).endStatus()
+            .build();
+        given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(Optional.of(deployment));
         given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.of(micoServiceInterface));
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.empty());
-        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podListWithOnePod.getItems());
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class), anyString())).willReturn(Optional.empty());
         given(micoKubernetesClient.isApplicationDeployed(otherMicoApplication)).willReturn(true);
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
-        given(applicationRepository.findAllByUsedService(any(), any())).willReturn(CollectionUtils.listOf(otherMicoApplication, micoApplication));
+        given(applicationRepository.findAllByUsedServiceInstance(INSTANCE_ID)).willReturn(CollectionUtils.listOf(otherMicoApplication, micoApplication));
         given(serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion())).willReturn(CollectionUtils.listOf(micoService));
         given(prometheusConfig.getUri()).willReturn("http://localhost:9090/api/v1/query");
         ResponseEntity responseEntityMemoryUsagePod1 = getPrometheusResponseEntity(memoryUsagePod1);
@@ -406,18 +475,20 @@ public class MicoStatusServiceTest {
             .setTotalNumberOfAvailableReplicas(0)
             .setTotalNumberOfPods(0)
             .setTotalNumberOfMicoServices(1)
-            .setTotalNumberOfKafkaFaasConnectors(1)
+            .setTotalNumberOfKafkaFaasConnectors(0)
             .setServiceStatuses(CollectionUtils.listOf(
                 new MicoServiceStatusResponseDTO()
                     .setShortName(micoApplication.getServices().get(0).getShortName())
                     .setVersion(micoApplication.getServices().get(0).getVersion())
                     .setName(micoApplication.getServices().get(0).getName())
+                    .setInstanceId(micoApplication.getServiceDeploymentInfos().get(0).getInstanceId())
                     .setErrorMessages(CollectionUtils
                         .listOf(new MicoMessageResponseDTO().setContent("No deployment of MicoService '" + micoService.getShortName()
-                            + "' '" + micoService.getVersion() + "' is available.").setType(Type.ERROR)))));
-        given(micoKubernetesClient.getDeploymentsOfMicoService(any(MicoService.class))).willReturn(new ArrayList<>());
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
-        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podList.getItems());
+                            + "' '" + micoService.getVersion() + "' with instance ID '" + micoServiceDeploymentInfo.getInstanceId()
+                            + "' is available.").setType(Type.ERROR)))));
+        given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(Optional.empty());
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
+        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(podListWithOnePod.getItems());
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
         given(serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion())).willReturn(CollectionUtils.listOf(micoService));
         assertEquals(micoApplicationStatus, micoStatusService.getApplicationStatus(micoApplication));
@@ -443,8 +514,9 @@ public class MicoStatusServiceTest {
             .setName(NAME)
             .setShortName(SHORT_NAME)
             .setVersion(VERSION)
-            .setAvailableReplicas(1)
-            .setRequestedReplicas(1)
+            .setInstanceId(INSTANCE_ID)
+            .setAvailableReplicas(4)
+            .setRequestedReplicas(4)
             .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
             .setNodeMetrics(CollectionUtils.listOf(
                 new KubernetesNodeMetricsResponseDTO()
@@ -502,12 +574,18 @@ public class MicoStatusServiceTest {
                 .setExternalIp("192.168.2.112")
                 .setPort(8080)));
 
-        given(micoKubernetesClient.getDeploymentsOfMicoService(any(MicoService.class))).willReturn(CollectionUtils.listOf(deployment));
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
-        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podList.getItems());
+        given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(podList.getItems());
+        Deployment deployment = new DeploymentBuilder()
+            .withNewMetadata().withName("deployment1").endMetadata()
+            .withNewSpec().withReplicas(podList.getItems().size()).endSpec()
+            .withNewStatus().withAvailableReplicas(podList.getItems().size()).endStatus()
+            .build();
+        given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(Optional.of(deployment));
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
         given(micoKubernetesClient.isApplicationDeployed(otherMicoApplication)).willReturn(true);
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
-        given(applicationRepository.findAllByUsedService(any(), any())).willReturn(CollectionUtils.listOf(otherMicoApplication));
+        given(applicationRepository.findAllByUsedServiceInstance(INSTANCE_ID)).willReturn(CollectionUtils.listOf(otherMicoApplication));
+
         given(prometheusConfig.getUri()).willReturn("http://localhost:9090/api/v1/query");
         given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.of(micoServiceInterface));
 
@@ -533,13 +611,13 @@ public class MicoStatusServiceTest {
             .willReturn(responseEntityCpuLoadPod3)
             .willReturn(responseEntityMemoryUsagePod4)
             .willReturn(responseEntityCpuLoadPod4);
-        assertEquals(micoServiceStatus, micoStatusService.getServiceStatus(micoService));
+        assertEquals(micoServiceStatus, micoStatusService.getServiceInstanceStatus(micoServiceDeploymentInfo));
     }
 
     @Test
     public void getServiceInterfaceStatus() throws Exception {
 
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(micoService, SERVICE_INTERFACE_NAME))
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(micoServiceDeploymentInfo, SERVICE_INTERFACE_NAME))
             .willReturn(Optional.ofNullable(kubernetesService));
 
         given(micoKubernetesClient.getPublicIpOfKubernetesService(kubernetesService.getMetadata().getName(),
@@ -556,7 +634,7 @@ public class MicoStatusServiceTest {
         expectedInterfaceStatusDTO.add(expectedServiceInterface);
         List<MicoMessageResponseDTO> errorMessages = new ArrayList<>();
 
-        List<MicoServiceInterfaceStatusResponseDTO> actualInterfaceStatusDTO = micoStatusService.getServiceInterfaceStatus(micoService, errorMessages);
+        List<MicoServiceInterfaceStatusResponseDTO> actualInterfaceStatusDTO = micoStatusService.getServiceInterfaceStatus(micoServiceDeploymentInfo, errorMessages);
 
         assertTrue("Expected there are no errors", errorMessages.isEmpty());
         assertEquals(expectedInterfaceStatusDTO, actualInterfaceStatusDTO);
@@ -566,7 +644,7 @@ public class MicoStatusServiceTest {
     public void getServiceInterfaceStatusWithErrors() {
 
         given(serviceInterfaceRepository.findByServiceAndName(micoService.getShortName(), micoService.getVersion(), SERVICE_INTERFACE_NAME)).willReturn(Optional.empty());
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(micoService, SERVICE_INTERFACE_NAME))
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(micoServiceDeploymentInfo, SERVICE_INTERFACE_NAME))
             .willReturn(Optional.empty());
 
         MicoServiceInterfaceStatusResponseDTO expectedServiceInterface = new MicoServiceInterfaceStatusResponseDTO()
@@ -576,7 +654,7 @@ public class MicoStatusServiceTest {
 
         List<MicoMessageResponseDTO> errorMessages = new ArrayList<>();
 
-        List<MicoServiceInterfaceStatusResponseDTO> actualInterfaceStatusDTO = micoStatusService.getServiceInterfaceStatus(micoService, errorMessages);
+        List<MicoServiceInterfaceStatusResponseDTO> actualInterfaceStatusDTO = micoStatusService.getServiceInterfaceStatus(micoServiceDeploymentInfo, errorMessages);
 
         assertEquals("Expected one error", 1, errorMessages.size());
         assertEquals(expectedInterfaceStatusDTO, actualInterfaceStatusDTO);

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -266,7 +266,7 @@ public class MicoStatusServiceTest {
                     .setInstanceId(micoServiceDeploymentInfo.getInstanceId())
                     .setAvailableReplicas(micoServiceDeploymentInfo.getReplicas())
                     .setRequestedReplicas(micoServiceDeploymentInfo.getReplicas())
-                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                    .setOtherApplicationsUsingThisServiceInstance(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
                         new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
@@ -331,7 +331,7 @@ public class MicoStatusServiceTest {
                     .setInstanceId(kfConnectorDeploymentInfo.getInstanceId())
                     .setAvailableReplicas(1)
                     .setRequestedReplicas(1)
-                    .setApplicationsUsingThisService(new ArrayList<>())
+                    .setOtherApplicationsUsingThisServiceInstance(new ArrayList<>())
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
                             .setNodeName(nodeName1)
@@ -423,7 +423,7 @@ public class MicoStatusServiceTest {
                     .setInstanceId(INSTANCE_ID)
                     .setAvailableReplicas(1)
                     .setRequestedReplicas(1)
-                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                    .setOtherApplicationsUsingThisServiceInstance(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
                         new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
@@ -521,7 +521,7 @@ public class MicoStatusServiceTest {
             .setInstanceId(micoServiceDeploymentInfo.getInstanceId())
             .setAvailableReplicas(micoServiceDeploymentInfo.getReplicas())
             .setRequestedReplicas(micoServiceDeploymentInfo.getReplicas())
-            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+            .setOtherApplicationsUsingThisServiceInstance(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
                 new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
             .setNodeMetrics(CollectionUtils.listOf(
                 new KubernetesNodeMetricsResponseDTO()

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceResourceIntegrationTests.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.github.ust.mico.core.dto.request.MicoServiceInterfaceRequestDTO;
 import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
 import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
 import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
@@ -96,6 +97,9 @@ public class ServiceInterfaceResourceIntegrationTests {
 
     @MockBean
     private MicoServiceInterfaceRepository serviceInterfaceRepository;
+
+    @MockBean
+    MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
 
     @MockBean
     private MicoKubernetesClient micoKubernetesClient;
@@ -206,20 +210,21 @@ public class ServiceInterfaceResourceIntegrationTests {
     @Test
     public void getInterfacePublicIpByName() throws Exception {
         String externalIP = "1.2.3.4";
+        String instanceId = INSTANCE_ID;
         MicoService micoService = new MicoService().setShortName(SHORT_NAME).setVersion(VERSION);
-        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setInstanceId(INSTANCE_ID).setService(micoService);
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setInstanceId(instanceId).setService(micoService);
         MicoServiceInterface micoServiceInterface = getTestServiceInterface();
         String serviceInterfaceName = micoServiceInterface.getServiceInterfaceName();
 
         Optional<Service> kubernetesService = Optional.of(getKubernetesService(micoServiceInterface.getServiceInterfaceName(), externalIP));
 
-        given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoService));
+        given(serviceDeploymentInfoRepository.findByInstanceId(instanceId)).willReturn(Optional.of(micoServiceDeploymentInfo));
         given(serviceInterfaceRepository.findByServiceAndName(SHORT_NAME, VERSION, serviceInterfaceName)).willReturn(Optional.of(micoServiceInterface));
         given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(eq(micoServiceDeploymentInfo), eq(serviceInterfaceName))).willReturn(kubernetesService);
         given(micoStatusService.getPublicIpOfKubernetesService(micoServiceDeploymentInfo, micoServiceInterface))
             .willReturn(new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName).setExternalIp(externalIP).setPort(INTERFACE_PORT));
 
-        mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP + "/" + instanceId).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.name", is(serviceInterfaceName)))
@@ -229,20 +234,21 @@ public class ServiceInterfaceResourceIntegrationTests {
 
     @Test
     public void getInterfacePublicIpByNameWithPendingIP() throws Exception {
+        String instanceId = INSTANCE_ID;
         MicoService micoService = new MicoService().setShortName(SHORT_NAME).setVersion(VERSION);
-        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setInstanceId(INSTANCE_ID).setService(micoService);
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setInstanceId(instanceId).setService(micoService);
         MicoServiceInterface micoServiceInterface = getTestServiceInterface();
         String serviceInterfaceName = micoServiceInterface.getServiceInterfaceName();
         MicoServiceInterfaceStatusResponseDTO interfaceStatusResponseDTO = new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName);
 
         Optional<Service> kubernetesService = Optional.of(getKubernetesService(micoServiceInterface.getServiceInterfaceName(), ""));
 
-        given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoService));
+        given(serviceDeploymentInfoRepository.findByInstanceId(instanceId)).willReturn(Optional.of(micoServiceDeploymentInfo));
         given(serviceInterfaceRepository.findByServiceAndName(SHORT_NAME, VERSION, serviceInterfaceName)).willReturn(Optional.of(micoServiceInterface));
         given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(eq(micoServiceDeploymentInfo), eq(serviceInterfaceName))).willReturn(kubernetesService);
         given(micoStatusService.getPublicIpOfKubernetesService(micoServiceDeploymentInfo, micoServiceInterface)).willReturn(interfaceStatusResponseDTO);
 
-        mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP).accept(MediaTypes.HAL_JSON_VALUE))
+        mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP + "/" + instanceId).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())
             .andExpect(status().is2xxSuccessful())
             .andExpect(jsonPath("$.name", is(serviceInterfaceName)))

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceInterfaceResourceIntegrationTests.java
@@ -25,10 +25,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.github.ust.mico.core.dto.request.MicoServiceInterfaceRequestDTO;
 import io.github.ust.mico.core.dto.response.status.MicoServiceInterfaceStatusResponseDTO;
-import io.github.ust.mico.core.model.MicoPortType;
-import io.github.ust.mico.core.model.MicoService;
-import io.github.ust.mico.core.model.MicoServiceInterface;
-import io.github.ust.mico.core.model.MicoServicePort;
+import io.github.ust.mico.core.model.*;
 import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
@@ -56,6 +53,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.github.ust.mico.core.JsonPathBuilder.*;
+import static io.github.ust.mico.core.TestConstants.IntegrationTest.INSTANCE_ID;
 import static io.github.ust.mico.core.TestConstants.SHORT_NAME;
 import static io.github.ust.mico.core.TestConstants.VERSION;
 import static org.hamcrest.CoreMatchers.*;
@@ -209,6 +207,7 @@ public class ServiceInterfaceResourceIntegrationTests {
     public void getInterfacePublicIpByName() throws Exception {
         String externalIP = "1.2.3.4";
         MicoService micoService = new MicoService().setShortName(SHORT_NAME).setVersion(VERSION);
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setInstanceId(INSTANCE_ID).setService(micoService);
         MicoServiceInterface micoServiceInterface = getTestServiceInterface();
         String serviceInterfaceName = micoServiceInterface.getServiceInterfaceName();
 
@@ -216,8 +215,8 @@ public class ServiceInterfaceResourceIntegrationTests {
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoService));
         given(serviceInterfaceRepository.findByServiceAndName(SHORT_NAME, VERSION, serviceInterfaceName)).willReturn(Optional.of(micoServiceInterface));
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(eq(micoService), eq(serviceInterfaceName))).willReturn(kubernetesService);
-        given(micoStatusService.getPublicIpOfKubernetesService(micoService, micoServiceInterface))
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(eq(micoServiceDeploymentInfo), eq(serviceInterfaceName))).willReturn(kubernetesService);
+        given(micoStatusService.getPublicIpOfKubernetesService(micoServiceDeploymentInfo, micoServiceInterface))
             .willReturn(new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName).setExternalIp(externalIP).setPort(INTERFACE_PORT));
 
         mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP).accept(MediaTypes.HAL_JSON_VALUE))
@@ -231,6 +230,7 @@ public class ServiceInterfaceResourceIntegrationTests {
     @Test
     public void getInterfacePublicIpByNameWithPendingIP() throws Exception {
         MicoService micoService = new MicoService().setShortName(SHORT_NAME).setVersion(VERSION);
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo().setInstanceId(INSTANCE_ID).setService(micoService);
         MicoServiceInterface micoServiceInterface = getTestServiceInterface();
         String serviceInterfaceName = micoServiceInterface.getServiceInterfaceName();
         MicoServiceInterfaceStatusResponseDTO interfaceStatusResponseDTO = new MicoServiceInterfaceStatusResponseDTO().setName(serviceInterfaceName);
@@ -239,8 +239,8 @@ public class ServiceInterfaceResourceIntegrationTests {
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoService));
         given(serviceInterfaceRepository.findByServiceAndName(SHORT_NAME, VERSION, serviceInterfaceName)).willReturn(Optional.of(micoServiceInterface));
-        given(micoKubernetesClient.getInterfaceByNameOfMicoService(eq(micoService), eq(serviceInterfaceName))).willReturn(kubernetesService);
-        given(micoStatusService.getPublicIpOfKubernetesService(micoService, micoServiceInterface)).willReturn(interfaceStatusResponseDTO);
+        given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(eq(micoServiceDeploymentInfo), eq(serviceInterfaceName))).willReturn(kubernetesService);
+        given(micoStatusService.getPublicIpOfKubernetesService(micoServiceDeploymentInfo, micoServiceInterface)).willReturn(interfaceStatusResponseDTO);
 
         mvc.perform(get(INTERFACES_URL + "/" + serviceInterfaceName + "/" + PATH_PART_PUBLIC_IP).accept(MediaTypes.HAL_JSON_VALUE))
             .andDo(print())

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
@@ -646,6 +646,7 @@ public class ServiceResourceIntegrationTests {
             .setName(NAME);
 
         given(serviceRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(existingService));
+        given(micoKubernetesClient.isMicoServiceDeployed(existingService)).willReturn(false);
 
         ResultActions resultDelete = mvc.perform(delete(SERVICES_PATH + "/" + SHORT_NAME + "/" + VERSION)
             .contentType(MediaTypes.HAL_JSON_UTF8_VALUE))

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
@@ -27,6 +27,7 @@ import io.github.ust.mico.core.dto.request.MicoServiceRequestDTO;
 import io.github.ust.mico.core.dto.request.MicoVersionRequestDTO;
 import io.github.ust.mico.core.dto.response.status.*;
 import io.github.ust.mico.core.model.*;
+import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.service.GitHubCrawler;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
@@ -101,7 +102,7 @@ public class ServiceResourceIntegrationTests {
     private MicoServiceRepository serviceRepository;
 
     @MockBean
-    private MicoServiceBroker micoServiceBroker;
+    private MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
 
     @MockBean
     private MicoCoreApplication micoCoreApplication;
@@ -182,7 +183,7 @@ public class ServiceResourceIntegrationTests {
             .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2));
 
         given(micoStatusService.getServiceInstanceStatus(any(MicoServiceDeploymentInfo.class))).willReturn(micoServiceStatus);
-        given(micoServiceBroker.getServiceInstanceFromDatabase(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).willReturn(micoServiceDeploymentInfo);
+        given(serviceDeploymentInfoRepository.findByInstanceId(INSTANCE_ID)).willReturn(Optional.of(micoServiceDeploymentInfo));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + INSTANCE_ID + "/status"))
             .andDo(print())

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceUnitTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceUnitTests.java
@@ -30,6 +30,7 @@ import io.github.ust.mico.core.exception.MicoServiceHasDependersException;
 import io.github.ust.mico.core.exception.MicoServiceIsDeployedException;
 import io.github.ust.mico.core.model.MicoService;
 import io.github.ust.mico.core.model.MicoServiceDependency;
+import io.github.ust.mico.core.model.MicoServiceDeploymentInfo;
 import io.github.ust.mico.core.model.MicoServiceInterface;
 import io.github.ust.mico.core.service.GitHubCrawler;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
@@ -125,6 +126,10 @@ public class ServiceResourceUnitTests {
             .setVersion(VERSION)
             .setDescription(DESCRIPTION_1);
 
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo = new MicoServiceDeploymentInfo()
+            .setService(micoService)
+            .setInstanceId(INSTANCE_ID);
+
         String nodeName = "testNode";
         String podPhase = "Running";
         String hostIp = "192.168.0.0";
@@ -172,10 +177,11 @@ public class ServiceResourceUnitTests {
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
             .setPodsInformation(Arrays.asList(kubernetesPodInfo1, kubernetesPodInfo2));
 
-        given(micoStatusService.getServiceStatus(any(MicoService.class))).willReturn(micoServiceStatus);
-        given(micoServiceBroker.getServiceFromDatabase(ArgumentMatchers.anyString(), ArgumentMatchers.any())).willReturn(micoService);
+        given(micoStatusService.getServiceInstanceStatus(any(MicoServiceDeploymentInfo.class))).willReturn(micoServiceStatus);
+        given(micoServiceBroker.getServiceInstanceFromDatabase(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString()))
+            .willReturn(micoServiceDeploymentInfo);
 
-        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/status"))
+        mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/" + INSTANCE_ID + "/status"))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath(SERVICE_DTO_SERVICE_NAME, is(NAME)))

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -105,6 +105,7 @@ class TestConstants {
      * All paths are build on the path for the status of this service.
      */
     static final String SERVICE_STATUS_PATH = buildPath(ROOT, "serviceStatuses[0]");
+    static final String SERVICE_STATUS_LIST_PATH = buildPath(ROOT, EMBEDDED, "micoServiceStatusResponseDTOList");
     static final String SERVICE_INFORMATION_NAME = buildPath(SERVICE_STATUS_PATH, "name");
     static final String REQUESTED_REPLICAS = buildPath(SERVICE_STATUS_PATH, "requestedReplicas");
     static final String AVAILABLE_REPLICAS = buildPath(SERVICE_STATUS_PATH, "availableReplicas");


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Every deployment is handled by an separate MicoService instance (`MicoServiceDeploymentInfo`). This is required to be able to have individual deployment configurations.
In future it could be further improved to have shared instances. That's not implemented in this PR. It will be covered by issue #864.

- [x] this PR contains breaking changes!

Changed API: 
- `getInterfacePublicIpByName`: `GET /services/:serviceShortName/:serviceVersion/interfaces/:serviceInterfaceName/publicIP`
→ `GET /services/:serviceShortName/:serviceVersion/interfaces/:serviceInterfaceName/publicIP/:instanceId`
- `getStatusOfService`: `GET /services/:serviceShortName/:serviceVersion/status` now responses with a list of status DTOs

New API:
- `getStatusOfServiceInstance`: `GET /services/:serviceShortName/:serviceVersion/:instanceId/status`


# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Relates to #729
Closes #743

# What is affected by this PR

- [x] Backend
    - [x] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [x] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
