### PR TITLE
Bump Spring Boot to version 2.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.7.RELEASE</version>
+        <version>2.1.8.RELEASE</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Spring Boot version 2.1.7 → 2.1.8 ([release notes](https://github.com/spring-projects/spring-boot/releases/tag/v2.1.8.RELEASE))
Most relevant: Upgrade of Neo4j Ogm 3.1.13
