### PR TITLE
Bump Neo4j to version 3.5.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   neo4j:
-    image: "neo4j:3.5.8"
+    image: "neo4j:3.5.11"
     container_name: neo4j
     ports:
      - "7474:7474"

--- a/install/kubernetes/neo4j.yaml
+++ b/install/kubernetes/neo4j.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: neo4j
-          image: 'neo4j:3.5.8'
+          image: 'neo4j:3.5.11'
           imagePullPolicy: 'IfNotPresent'
           env:
             - name: NEO4J_dbms_security_auth__enabled


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Neo4j version 3.5.8 → 3.5.11:
- [Release notes 3.5.11](https://neo4j.com/release-notes/neo4j-3-5-11/)
- [Release notes 3.5.9](https://neo4j.com/release-notes/neo4j-3-5-9/)