### PR TITLE
Fix deleting tangling service deployment information

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoApplicationBroker.java
@@ -311,7 +311,9 @@ public class MicoApplicationBroker {
         serviceDeploymentInfoRepository.deleteByApplicationAndService(applicationShortName, applicationVersion, serviceShortName);
         // 2. Remove the service from the application
         micoApplication.getServices().removeIf(s -> s.getShortName().equals(serviceShortName));
-        return applicationRepository.save(micoApplication);
+        MicoApplication updatedApplication = applicationRepository.save(micoApplication);
+        serviceDeploymentInfoBroker.cleanUpTanglingNodes();
+        return updatedApplication;
 
         // TODO: Update Kubernetes deployment (see issue mico#627)
     }
@@ -624,6 +626,7 @@ public class MicoApplicationBroker {
             application.getKafkaFaasConnectorDeploymentInfos().remove(kafkaFaasConnectorSDI);
         }
         applicationRepository.save(application);
+        micoServiceDeploymentInfoBroker.cleanUpTanglingNodes();
     }
 
     /**

--- a/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/broker/MicoServiceDeploymentInfoBroker.java
@@ -222,19 +222,27 @@ public class MicoServiceDeploymentInfoBroker {
             MicoServiceDeploymentInfo sdiWithReusedTopics = createOrReuseTopicsInDatabase(sdiWithTopics);
             finalUpdatedServiceDeploymentInfo = serviceDeploymentInfoRepository.save(sdiWithReusedTopics);
         }
+        cleanUpTanglingNodes();
 
-        // In case addition properties (stored as separate node entity) such as labels, environment variables
-        // have been removed from this service deployment information,
-        // the standard save() function of the service deployment information repository will not delete those
-        // "tangling" (without relationships) labels (nodes), hence the manual clean up.
+        return finalUpdatedServiceDeploymentInfo;
+    }
+
+    /**
+     * Cleans up tangling nodes related to a {@link MicoServiceDeploymentInfo} in the database.
+     *
+     * In case addition properties (stored as separate node entity) such as labels, environment variables
+     * have been removed from a service deployment information,
+     * the standard {@code save()} function of the service deployment information repository will not delete those
+     * "tangling" (without relationships) labels (nodes), hence the manual clean up.
+     */
+    void cleanUpTanglingNodes() {
+
         micoLabelRepository.cleanUp();
         micoTopicRepository.cleanUp();
         micoEnvironmentVariableRepository.cleanUp();
         kubernetesDeploymentInfoRepository.cleanUp();
         micoInterfaceConnectionRepository.cleanUp();
         openFaaSFunctionRepository.cleanUp();
-
-        return finalUpdatedServiceDeploymentInfo;
     }
 
     /**


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Related nodes of a `MicoServiceDeploymentInformation` entity were not deleted if the entity itself was deleted. This PR removes all tangling nodes after a normal MicoService or a KafkaFaasConnector is removed from a application.

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
