### PR TITLE
Fix deployment status of application within status service dto

### DIFF
--- a/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/service/MicoStatusService.java
@@ -29,10 +29,7 @@ import io.github.ust.mico.core.dto.response.internal.PrometheusResponseDTO;
 import io.github.ust.mico.core.dto.response.status.*;
 import io.github.ust.mico.core.exception.KubernetesResourceException;
 import io.github.ust.mico.core.exception.PrometheusRequestFailedException;
-import io.github.ust.mico.core.model.MicoApplication;
-import io.github.ust.mico.core.model.MicoMessage;
-import io.github.ust.mico.core.model.MicoService;
-import io.github.ust.mico.core.model.MicoServiceInterface;
+import io.github.ust.mico.core.model.*;
 import io.github.ust.mico.core.persistence.MicoApplicationRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.util.CollectionUtils;
@@ -166,7 +163,8 @@ public class MicoStatusService {
         List<MicoApplication> usingApplications = micoApplicationRepository.findAllByUsedService(micoService.getShortName(), micoService.getVersion());
         for (MicoApplication application : usingApplications) {
             if (micoKubernetesClient.isApplicationDeployed(application)) {
-                serviceStatus.getApplicationsUsingThisService().add(new MicoApplicationResponseDTO(application));
+                MicoApplicationDeploymentStatus applicationDeploymentStatus = micoKubernetesClient.getApplicationDeploymentStatus(application);
+                serviceStatus.getApplicationsUsingThisService().add(new MicoApplicationResponseDTO(application, applicationDeploymentStatus));
             }
         }
 

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -247,7 +247,8 @@ public class MicoStatusServiceTest {
                     .setVersion(VERSION)
                     .setAvailableReplicas(1)
                     .setRequestedReplicas(1)
-                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                        new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
                             .setNodeName(nodeName1)
@@ -308,6 +309,7 @@ public class MicoStatusServiceTest {
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podList.getItems());
         given(micoKubernetesClient.isApplicationDeployed(otherMicoApplication)).willReturn(true);
+        given(micoKubernetesClient.getApplicationDeploymentStatus(otherMicoApplication)).willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED));
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
         given(applicationRepository.findAllByUsedService(any(), any())).willReturn(CollectionUtils.listOf(otherMicoApplication, micoApplication));
         given(serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion())).willReturn(CollectionUtils.listOf(micoService));
@@ -357,7 +359,8 @@ public class MicoStatusServiceTest {
                     .setVersion(VERSION)
                     .setAvailableReplicas(1)
                     .setRequestedReplicas(1)
-                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+                    .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                        new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
                     .setNodeMetrics(CollectionUtils.listOf(
                         new KubernetesNodeMetricsResponseDTO()
                             .setNodeName(nodeName1)
@@ -386,6 +389,7 @@ public class MicoStatusServiceTest {
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.empty());
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podListWithOnePod.getItems());
         given(micoKubernetesClient.isApplicationDeployed(otherMicoApplication)).willReturn(true);
+        given(micoKubernetesClient.getApplicationDeploymentStatus(otherMicoApplication)).willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED));
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
         given(applicationRepository.findAllByUsedService(any(), any())).willReturn(CollectionUtils.listOf(otherMicoApplication, micoApplication));
         given(serviceRepository.findAllByApplication(micoApplication.getShortName(), micoApplication.getVersion())).willReturn(CollectionUtils.listOf(micoService));
@@ -445,7 +449,8 @@ public class MicoStatusServiceTest {
             .setVersion(VERSION)
             .setAvailableReplicas(1)
             .setRequestedReplicas(1)
-            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication)))
+            .setApplicationsUsingThisService(CollectionUtils.listOf(new MicoApplicationResponseDTO(otherMicoApplication,
+                new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED))))
             .setNodeMetrics(CollectionUtils.listOf(
                 new KubernetesNodeMetricsResponseDTO()
                     .setNodeName(nodeName1)
@@ -506,6 +511,7 @@ public class MicoStatusServiceTest {
         given(micoKubernetesClient.getInterfaceByNameOfMicoService(any(MicoService.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoService(any(MicoService.class))).willReturn(podList.getItems());
         given(micoKubernetesClient.isApplicationDeployed(otherMicoApplication)).willReturn(true);
+        given(micoKubernetesClient.getApplicationDeploymentStatus(otherMicoApplication)).willReturn(new MicoApplicationDeploymentStatus(MicoApplicationDeploymentStatus.Value.DEPLOYED));
         given(applicationRepository.findByShortNameAndVersion(SHORT_NAME, VERSION)).willReturn(Optional.of(micoApplication));
         given(applicationRepository.findAllByUsedService(any(), any())).willReturn(CollectionUtils.listOf(otherMicoApplication));
         given(prometheusConfig.getUri()).willReturn("http://localhost:9090/api/v1/query");


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Inside the status DTO of a service the deployment status of the using applications was not set.

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)

# Example data

```json
{
    "shortName": "test-message-generator",
    "version": "v1.1.0",
    "name": "UST-MICO/test_message_generator",
    "instanceId": "test-message-generator-yf6fyflj",
    "requestedReplicas": 1,
    "availableReplicas": 1,
    "interfacesInformation": [],
    "applicationsUsingThisService": [
        {
            "shortName": "kafka-faas-deployment",
            "version": "v0.0.1",
            "name": "kafka-faas-deployment-application",
            "description": "Real World application with a frontend and a backend",
            "contact": null,
            "owner": null,
            "deploymentStatus": {
                "value": "Deployed",
                "messages": [
                    {
                        "content": "The MicoApplication is currently deployed.",
                        "type": "Info"
                    }
                ]
            }
        }
    ],
    "podsInformation": [
        {
            "podName": "test-message-generator-yf6fyflj-578d5fcbfd-nlxxr",
            "phase": "Running",
            "hostIp": "10.240.0.6",
            "nodeName": "aks-nodepool1-88141437-2",
            "restarts": 0,
            "startTime": "2019-09-29T22:21:31Z",
            "metrics": {
                "memoryUsage": 15331328,
                "cpuLoad": 0
            }
        }
    ],
    "nodeMetrics": [
        {
            "nodeName": "aks-nodepool1-88141437-2",
            "averageCpuLoad": 0,
            "averageMemoryUsage": 15331328
        }
    ],
    "errorMessages": []
}
```