### PR TITLE
Increase memory limits of ZooKeeper for Kafka

### DIFF
--- a/install/kubernetes/kafka/kafka/test/produce-consume.yml
+++ b/install/kubernetes/kafka/kafka/test/produce-consume.yml
@@ -120,7 +120,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 120Mi
+            memory: 200Mi
         volumeMounts:
         - name: config
           mountPath: /test

--- a/install/kubernetes/kafka/zookeeper/50pzoo.yml
+++ b/install/kubernetes/kafka/zookeeper/50pzoo.yml
@@ -57,7 +57,7 @@ spec:
             cpu: 10m
             memory: 100Mi
           limits:
-            memory: 120Mi
+            memory: 200Mi
         readinessProbe:
           exec:
             command:

--- a/install/kubernetes/kafka/zookeeper/51zoo.yml
+++ b/install/kubernetes/kafka/zookeeper/51zoo.yml
@@ -60,7 +60,7 @@ spec:
             cpu: 10m
             memory: 100Mi
           limits:
-            memory: 120Mi
+            memory: 200Mi
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Increases memory limits of ZooKeeper used by Kafka.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Closes #860

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation
- [x] Infrastructure

# Checklist

- [ ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
