### PR TITLE
Add add kf connector button

### DIFF
--- a/mico-admin/src/app/app-detail-overview/app-detail-overview.component.html
+++ b/mico-admin/src/app/app-detail-overview/app-detail-overview.component.html
@@ -53,6 +53,20 @@
                         </div>
                         <mat-divider></mat-divider>
                     </div>
+
+                    <mat-divider></mat-divider>
+                    <div class="flex" (click)="addKafkaFaasConnector()">
+                        <div class="flex-grow-1">
+                            <mat-list-item>
+                                <span mat-line><b>Kafka FaaS Connector</b></span>
+                            </mat-list-item>
+                        </div>
+                        <div class="w-20">
+                            <mat-list-item>
+                                <mat-icon>add</mat-icon>
+                            </mat-list-item>
+                        </div>
+                    </div>
                 </mat-action-list>
             </mat-card-content>
 

--- a/mico-admin/src/app/app-detail-overview/app-detail-overview.component.ts
+++ b/mico-admin/src/app/app-detail-overview/app-detail-overview.component.ts
@@ -77,6 +77,12 @@ export class AppDetailOverviewComponent implements OnDestroy {
 
     }
 
+    addKafkaFaasConnector() {
+        const apiSub = this.apiService.postApplicationKafkaFaasConnector(this.application.shortName, this.application.version).subscribe(() => {
+            safeUnsubscribe(apiSub);
+        });
+    }
+
     deleteService(serviceShortName: string) {
 
         const dialogRef = this.dialog.open(YesNoDialogComponent, {


### PR DESCRIPTION
# Description

Add add kafka faas connector button to be able to add new connectors without dragging links from topics. This allows apps that only use topics and kafka faas connectors to be build in the UI.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

# What is affected by this PR

- [ ] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [x] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [ ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [ ] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
