### PR TITLE
Fix/mico#871 status endpoint

### DIFF
--- a/docs/mico-core/java/io/github/ust/mico/core/service/MicoStatusService.rst
+++ b/docs/mico-core/java/io/github/ust/mico/core/service/MicoStatusService.rst
@@ -90,7 +90,7 @@ getServiceInstanceStatus
 .. java:method:: public MicoServiceStatusResponseDTO getServiceInstanceStatus(MicoServiceDeploymentInfo serviceDeploymentInfo)
    :outertype: MicoStatusService
 
-   Get status information for a single \ :java:ref:`MicoServiceDeploymentInfo`\ : # available replicas, # requested replicas, pod metrics (CPU load, memory usage).
+   Get status information for a single \ :java:ref:`MicoServiceDeploymentInfo`\  if it is deployed: # available replicas, # requested replicas, pod metrics (CPU load, memory usage).
 
    :param serviceDeploymentInfo: the \ :java:ref:`MicoServiceDeploymentInfo`\ .
    :return: the \ :java:ref:`MicoServiceStatusResponseDTO`\  which contains status information for a specific instance of a \ :java:ref:`MicoService`\ .

--- a/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceStatusResponseDTO.java
+++ b/mico-core/src/main/java/io/github/ust/mico/core/dto/response/status/MicoServiceStatusResponseDTO.java
@@ -146,7 +146,7 @@ public class MicoServiceStatusResponseDTO {
     @ApiModelProperty(extensions = {@Extension(
         name = CustomOpenApiExtentionsPlugin.X_MICO_CUSTOM_EXTENSION,
         properties = {
-            @ExtensionProperty(name = "title", value = "Other Applications Using This Service Instance"),
+            @ExtensionProperty(name = "title", value = "Applications Using This Service Instance"),
             @ExtensionProperty(name = "x-order", value = "70"),
             @ExtensionProperty(name = "description", value = "List of MicoApplicationDTOs " +
                 "representing all applications that share the MicoService instance.")

--- a/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/MicoStatusServiceTest.java
@@ -32,6 +32,7 @@ import io.github.ust.mico.core.dto.response.status.*;
 import io.github.ust.mico.core.model.*;
 import io.github.ust.mico.core.model.MicoMessage.Type;
 import io.github.ust.mico.core.persistence.MicoApplicationRepository;
+import io.github.ust.mico.core.persistence.MicoServiceDeploymentInfoRepository;
 import io.github.ust.mico.core.persistence.MicoServiceInterfaceRepository;
 import io.github.ust.mico.core.persistence.MicoServiceRepository;
 import io.github.ust.mico.core.service.MicoKubernetesClient;
@@ -79,6 +80,8 @@ public class MicoStatusServiceTest {
     private MicoServiceRepository serviceRepository;
     @MockBean
     private MicoServiceInterfaceRepository serviceInterfaceRepository;
+    @MockBean
+    private MicoServiceDeploymentInfoRepository serviceDeploymentInfoRepository;
     @Autowired
     private MicoStatusService micoStatusService;
 
@@ -487,9 +490,9 @@ public class MicoStatusServiceTest {
                     .setName(micoApplication.getServices().get(0).getName())
                     .setInstanceId(micoApplication.getServiceDeploymentInfos().get(0).getInstanceId())
                     .setErrorMessages(CollectionUtils
-                        .listOf(new MicoMessageResponseDTO().setContent("No deployment of MicoService '" + micoService.getShortName()
+                        .listOf(new MicoMessageResponseDTO().setContent("MicoService '" + micoService.getShortName()
                             + "' '" + micoService.getVersion() + "' with instance ID '" + micoServiceDeploymentInfo.getInstanceId()
-                            + "' is available.").setType(Type.ERROR)))));
+                            + "' is not deployed.").setType(Type.INFO)))));
         given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(Optional.empty());
         given(micoKubernetesClient.getInterfaceByNameOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class), anyString())).willReturn(Optional.ofNullable(kubernetesService));
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(any(MicoServiceDeploymentInfo.class))).willReturn(podListWithOnePod.getItems());
@@ -513,8 +516,8 @@ public class MicoStatusServiceTest {
     @Test
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void getServiceStatus() throws Exception {
-        MicoServiceStatusResponseDTO micoServiceStatus = new MicoServiceStatusResponseDTO();
-        micoServiceStatus
+        List<MicoServiceStatusResponseDTO> micoServiceStatusList = new ArrayList<>();
+        MicoServiceStatusResponseDTO micoServiceStatusResponseDTO = new MicoServiceStatusResponseDTO()
             .setName(micoService.getName())
             .setShortName(micoService.getShortName())
             .setVersion(micoService.getVersion())
@@ -578,7 +581,10 @@ public class MicoStatusServiceTest {
                 .setExternalIpIsAvailable(true)
                 .setExternalIp("192.168.2.112")
                 .setPort(8080)));
+        micoServiceStatusList.add(micoServiceStatusResponseDTO);
 
+        given(serviceDeploymentInfoRepository.findAllByService(micoService.getShortName(), micoService.getVersion()))
+            .willReturn(CollectionUtils.listOf(micoServiceDeploymentInfo));
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(eq(micoServiceDeploymentInfo)))
             .willReturn(podList.getItems());
         Deployment deployment = new DeploymentBuilder()
@@ -626,31 +632,12 @@ public class MicoStatusServiceTest {
             .willReturn(responseEntityCpuLoadPod3)
             .willReturn(responseEntityMemoryUsagePod4)
             .willReturn(responseEntityCpuLoadPod4);
-        assertEquals(micoServiceStatus, micoStatusService.getServiceInstanceStatus(micoServiceDeploymentInfo));
+
+        assertEquals(micoServiceStatusList, micoStatusService.getServiceStatus(micoService));
     }
 
     @Test
-    public void getServiceStatusOfUndeployedInstance() throws Exception {
-        MicoServiceStatusResponseDTO micoServiceStatus = new MicoServiceStatusResponseDTO();
-        micoServiceStatus
-            .setName(micoService.getName())
-            .setShortName(micoService.getShortName())
-            .setVersion(micoService.getVersion())
-            .setInstanceId(micoServiceDeploymentInfo.getInstanceId())
-            .setAvailableReplicas(0)
-            .setRequestedReplicas(0)
-            .setOtherApplicationsUsingThisServiceInstance(CollectionUtils.listOf())
-            .setNodeMetrics(CollectionUtils.listOf())
-            // Add four pods (on two different nodes)
-            .setPodsInformation(CollectionUtils.listOf())
-            .setErrorMessages(CollectionUtils.listOf(
-                new MicoMessageResponseDTO()
-                    .setContent("No deployment of MicoService '" + micoService.getShortName() + "' '" + micoService.getVersion()
-                        + "' with instance ID '" + micoServiceDeploymentInfo.getInstanceId() + "' is available.")
-                    .setType(Type.ERROR)
-            ))
-            .setInterfacesInformation(CollectionUtils.listOf());
-
+    public void getServiceStatusWithInstanceThatIsNotDeployed() throws Exception {
         given(micoKubernetesClient.getPodsCreatedByDeploymentOfMicoServiceInstance(eq(micoServiceDeploymentInfo)))
             .willReturn(new ArrayList<>());
         given(micoKubernetesClient.getDeploymentOfMicoServiceInstance(eq(micoServiceDeploymentInfo)))
@@ -676,7 +663,7 @@ public class MicoStatusServiceTest {
         given(micoKubernetesClient.getPublicPortsOfKubernetesService(kubernetesService.getMetadata().getName(),
             kubernetesService.getMetadata().getNamespace())).willReturn(new ArrayList<>());
 
-        assertEquals(micoServiceStatus, micoStatusService.getServiceInstanceStatus(micoServiceDeploymentInfo));
+        assertEquals("Expected there is no instance included", 0, micoStatusService.getServiceStatus(micoService).size());
     }
 
     @Test

--- a/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/ServiceResourceIntegrationTests.java
@@ -222,6 +222,9 @@ public class ServiceResourceIntegrationTests {
         MicoServiceDeploymentInfo micoServiceDeploymentInfo2 = new MicoServiceDeploymentInfo()
             .setService(micoService)
             .setInstanceId(INSTANCE_ID_2);
+        MicoServiceDeploymentInfo micoServiceDeploymentInfo3 = new MicoServiceDeploymentInfo()
+            .setService(micoService)
+            .setInstanceId(INSTANCE_ID_3);
 
         String nodeName = "testNode";
         String podPhase = "Running";
@@ -254,7 +257,7 @@ public class ServiceResourceIntegrationTests {
                 .setCpuLoad(cpuLoadPod2)
                 .setMemoryUsage(memoryUsagePod2));
 
-        MicoServiceStatusResponseDTO micoServiceStatus1 = new MicoServiceStatusResponseDTO()
+        MicoServiceStatusResponseDTO micoServiceInstanceStatus1 = new MicoServiceStatusResponseDTO()
             .setVersion(micoService.getVersion())
             .setName(micoService.getName())
             .setShortName(micoService.getShortName())
@@ -269,7 +272,7 @@ public class ServiceResourceIntegrationTests {
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
             .setPodsInformation(Collections.singletonList(kubernetesPodInfo1));
 
-        MicoServiceStatusResponseDTO micoServiceStatus2 = new MicoServiceStatusResponseDTO()
+        MicoServiceStatusResponseDTO micoServiceInstanceStatus2 = new MicoServiceStatusResponseDTO()
             .setVersion(micoService.getVersion())
             .setName(micoService.getName())
             .setShortName(micoService.getShortName())
@@ -284,10 +287,13 @@ public class ServiceResourceIntegrationTests {
             .setInterfacesInformation(CollectionUtils.listOf(new MicoServiceInterfaceStatusResponseDTO().setName(SERVICE_INTERFACE_NAME)))
             .setPodsInformation(Collections.singletonList(kubernetesPodInfo2));
 
-        given(micoStatusService.getServiceStatus(micoService)).willReturn(CollectionUtils.listOf(micoServiceStatus1, micoServiceStatus2));
+        // MicoService instance 3 ist not deployed, therefore the status should not be part of the list.
+        given(micoStatusService.getServiceStatus(micoService))
+            .willReturn(CollectionUtils.listOf(micoServiceInstanceStatus1, micoServiceInstanceStatus2));
         given(serviceDeploymentInfoRepository.findAllByService(micoService.getShortName(), micoService.getVersion()))
-            .willReturn(CollectionUtils.listOf(micoServiceDeploymentInfo1, micoServiceDeploymentInfo2));
-        given(serviceRepository.findByShortNameAndVersion(micoService.getShortName(), micoService.getVersion())).willReturn(Optional.of(micoService));
+            .willReturn(CollectionUtils.listOf(micoServiceDeploymentInfo1, micoServiceDeploymentInfo2, micoServiceDeploymentInfo3));
+        given(serviceRepository.findByShortNameAndVersion(micoService.getShortName(), micoService.getVersion()))
+            .willReturn(Optional.of(micoService));
 
         mvc.perform(get(BASE_PATH + "/" + SHORT_NAME + "/" + VERSION + "/status"))
             .andDo(print())

--- a/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
+++ b/mico-core/src/test/java/io/github/ust/mico/core/TestConstants.java
@@ -91,6 +91,7 @@ class TestConstants {
     static final String INSTANCE_ID = "instance-id";
     static final String INSTANCE_ID_1 = "instance-id-1";
     static final String INSTANCE_ID_2 = "instance-id-2";
+    static final String INSTANCE_ID_3 = "instance-id-3";
 
     static final String INPUT_TOPIC = "input-topic";
     static final String INPUT_TOPIC_1 = "input-topic-1";


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

The status endpoint should only return the service instances, that are actually deployed (availableReplicas > 0) or at least should be deployed (requestedReplicas > 0).

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

Closes #871

# What is affected by this PR

- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [x] API
    - [x] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
- [x] Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)
