### PR TITLE
mico-admin entrypoint: avoid truncating nginx.conf

### DIFF
--- a/mico-admin/docker-entrypoint.sh
+++ b/mico-admin/docker-entrypoint.sh
@@ -10,7 +10,8 @@ fi
 
 echo "Nameserver is:" $NAMESERVER
 
-envsubst '$NAMESERVER ${MICO_REST_API}' < /etc/nginx/nginx.conf > /etc/nginx/nginx.conf
+envsubst '$NAMESERVER ${MICO_REST_API}' < /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.new
+mv /etc/nginx/nginx.conf.new /etc/nginx/nginx.conf
 echo "done replacing"
 
 cat /etc/nginx/nginx.conf


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Rather than trying to operate on the nginx.conf file in place (see below on why this fails), this PR changes the docker entrypoint to create a temporary file and then replace nginx.conf with that one.

There are no breaking changes in this PR.

# Resolves / is related to

Currently, the mico-admin docker entrypoint reads and writes the nginx.conf in the same shell command. This is a race condition that often leads to erasing the contents of the nginx.conf, because
- the file is opened for reading (fine)
- the file is opened for writing *and truncated* so it's empty
- then envsubst tries to do its job, but ends up doing nothing because the file it's trying to read is empty

The shellcheck wiki has an article about this class of problems: https://github.com/koalaman/shellcheck/wiki/SC2094

# What is affected by this PR

- [x] **mico-admin Docker image requires a rebuild**
- [x] Backend
    - [ ] Kubernetes logic
    - [ ] Domain model
- [ ] API
    - [ ] discussed changes in the team / informed the team about changes
    - [ ] updated [`insertTestValues.sh`](https://github.com/UST-MICO/mico/blob/master/insertTestValues.sh) and [Postman Collections](https://github.com/UST-MICO/docs/tree/master/debugging-testing/postman) are updated
- [ ] Frontend
    - [ ] Ensure that it is compilable for production (`npm run build -- --prod`)
- [ ] Documentation

# Checklist

- (not applicable: no new files) ~~Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)~~
- (not applicable: just a bugfix, no changes necessary) ~~Ensure [JavaDoc is up to date](https://github.com/UST-MICO/mico/tree/master/docs#build-the-documentation-locally)~~
